### PR TITLE
fix(docker): disable nx daemon/TUI and reduce parallelism to fix exit…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,12 @@ COPY samples/  ./samples/
 # Install all dependencies (including dev deps needed for the build)
 RUN bun install --frozen-lockfile
 
+# Disable the Nx daemon and TUI (not needed / unsupported in Docker builds)
+ENV NX_DAEMON=false
+ENV NX_TUI=false
+
 # Build every package (Nx respects the dependency graph, so output is correct)
-RUN npx nx run-many -t build --all --parallel=4
+RUN npx nx run-many -t build --parallel=2
 
 # ── Stage 2: runner ──────────────────────────────────────────────────────────
 # Lean image that ships only the built artifacts and their runtime deps.


### PR DESCRIPTION
… code 130

The Docker build was failing with exit code 130 (SIGINT) when running npx nx run-many -t build --all --parallel=4.

Fixes:
- Set NX_DAEMON=false: the nx background daemon is not supported in Docker
- Set NX_TUI=false: belt-and-suspenders alongside nx.json tui.enabled:false
- Remove deprecated --all flag (run-many targets all projects by default)
- Reduce --parallel from 4 to 2 to avoid memory pressure in the builder container

https://claude.ai/code/session_01C5crXYLZVnGhzjyc4HPWrt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build configuration by disabling build daemon and terminal UI modes to improve stability during containerized builds.
  * Adjusted build command parameters for enhanced consistency in Docker environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->