### PR TITLE
fix(adk): remove false from isEmpty in checkMetadataUnchanged

### DIFF
--- a/packages/adk/src/base/model.ts
+++ b/packages/adk/src/base/model.ts
@@ -850,13 +850,14 @@ export abstract class AdkObject<K extends AdkKind = AdkKind, D = any> {
 
       // Recursive subset match: checks that every field in `local`
       // has the same value in `sap`. Extra fields in `sap` are ignored.
-      // "Empty-like" values (null, undefined, "", false, [], {}) are treated
+      // "Empty-like" values (null, undefined, "", [], {}) are treated
       // as equivalent, since SAP normalizes defaults differently than
-      // abapGit serialization (e.g., style "" → "00", missing → false).
+      // abapGit serialization (e.g., style "" → "00", missing → undefined).
+      // Note: `false` is NOT empty-like — an explicit `false` must be
+      // compared against SAP's value to detect boolean flag toggles.
       const isEmpty = (v: unknown): boolean =>
         v == null ||
         v === '' ||
-        v === false ||
         (Array.isArray(v) && v.length === 0) ||
         (typeof v === 'object' && v !== null && Object.keys(v).length === 0);
 


### PR DESCRIPTION
`false` was treated as "empty-like", causing isSubsetMatch(false, true) to return true — silently skipping saves when boolean flags are toggled from true to false (e.g., lowercase, fixPointArithmetic, final).

Now only null, undefined, "", [], and {} are empty-like. An explicit `false` is compared against SAP's value as a real change.

Generated with [Devin](https://cli.devin.ai/docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata change detection for boolean values, ensuring proper identification when flag values change to or from false.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->