### PR TITLE
feat(p2): publish p2-cli from CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,6 +118,10 @@ jobs:
             "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org" | jq -r .value)
           echo "$token" | cut -d. -f2 | base64 -d 2>/dev/null | jq '{iss, sub, workflow, workflow_ref, job_workflow_ref, repository, ref}'
 
+      - name: Preflight npm trusted publishing checks
+        run: npx nx run-many -t npm-trust-check
+        shell: bash
+
       - name: Publish packages
         run: npx nx release publish
         shell: bash

--- a/nx.json
+++ b/nx.json
@@ -48,7 +48,10 @@
       "plugin": "./tools/nx-vitest/src/index.ts"
     },
     {
-      "plugin": "./tools/nx-npm-trust/src/index.ts"
+      "plugin": "./tools/nx-npm-trust/src/index.ts",
+      "options": {
+        "publishablePaths": ["packages/", "tools/"]
+      }
     },
     {
       "plugin": "@nx/vite/plugin",
@@ -71,7 +74,7 @@
     }
   ],
   "release": {
-    "projects": ["packages/*"],
+    "projects": ["packages/*", "tools/p2-cli"],
     "releaseTagPattern": "v{version}",
     "version": {
       "preVersionCommand": "npx nx run-many -t build",

--- a/tools/p2-cli/README.md
+++ b/tools/p2-cli/README.md
@@ -5,6 +5,16 @@ CLI for Eclipse P2 repositories - download, extract, and decompile plugins.
 ## Installation
 
 ```bash
+# npm
+npm install -g @abapify/p2-cli
+
+# or run without installing globally
+npx @abapify/p2-cli --help
+```
+
+## Development
+
+```bash
 # From monorepo root
 bun install
 npx nx build p2-cli
@@ -12,6 +22,20 @@ npx nx build p2-cli
 # Or run directly with tsx
 npx tsx tools/p2-cli/src/cli.ts
 ```
+
+## Publishing Bootstrap (maintainers)
+
+`p2-cli` is wired into workspace release publishing via `nx release`.
+
+```bash
+# Validate npm publish/trusted-publisher readiness
+bunx nx run p2-cli:npm-trust-check
+
+# One-time bootstrap for new npm package/trusted publishing
+bunx nx run p2-cli:npm-trust-check --prepare
+```
+
+Then publish from CI using the repository release workflow (which triggers `.github/workflows/publish.yml`).
 
 ## Commands
 

--- a/tools/p2-cli/package.json
+++ b/tools/p2-cli/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@abapify/p2-cli",
   "version": "0.1.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "CLI for Eclipse P2 repositories - download, extract, and decompile plugins",
   "license": "MIT",
   "type": "module",

--- a/tools/p2-cli/package.json
+++ b/tools/p2-cli/package.json
@@ -1,19 +1,39 @@
 {
   "name": "@abapify/p2-cli",
   "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/abapify/adt-cli.git",
+    "directory": "tools/p2-cli"
+  },
+  "homepage": "https://github.com/abapify/adt-cli/tree/main/tools/p2-cli#readme",
+  "bugs": {
+    "url": "https://github.com/abapify/adt-cli/issues"
+  },
   "publishConfig": {
     "access": "public"
   },
   "description": "CLI for Eclipse P2 repositories - download, extract, and decompile plugins",
   "license": "MIT",
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "bin": {
     "p2": "./dist/cli.mjs"
   },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "keywords": [
+    "sap",
+    "eclipse",
+    "p2",
+    "cli",
+    "decompiler"
+  ],
   "dependencies": {
     "commander": "*"
-  },
-  "files": [
-    "dist"
-  ]
+  }
 }

--- a/tools/p2-cli/src/cli.ts
+++ b/tools/p2-cli/src/cli.ts
@@ -9,18 +9,21 @@
  */
 
 import { Command } from 'commander';
+import { createRequire } from 'node:module';
 import { download } from './commands/download';
 import { extractJars } from './commands/extract';
 import { decompile } from './commands/decompile';
 
 const program = new Command();
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json') as { version?: string };
 
 program
   .name('p2')
   .description(
     'CLI for Eclipse P2 repositories - download, extract, and decompile plugins',
   )
-  .version('0.1.0');
+  .version(pkg.version ?? '0.0.0');
 
 // Download command
 program


### PR DESCRIPTION
## Summary\n- include tools/p2-cli in Nx release projects\n- mark @abapify/p2-cli as public npm package\n- run npm trust preflight in publish workflow\n- extend nx-npm-trust scope to include tools/\n\n## Why\nEnsure p2 is published by CI with trusted-publishing checks before release publish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added preflight validation checks to the npm publishing workflow to verify publishing readiness before releasing.
  * p2-cli is now included in the release automation and configured for public npm publishing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/abapify/adt-cli/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->