### PR TITLE
feat: add ADT proxy server with JSON↔XML conversion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,5 +51,8 @@ jobs:
         shell: bash
       - run: npx nx format:check
       - run: npx nx affected -t lint test build e2e-ci --verbose=false --parallel=3
+        if: ${{ env.NX_CLOUD_ACCESS_TOKEN != '' }}
+      - run: npx nx affected -t lint test build e2e-ci --verbose=false --parallel=3 --no-cloud
+        if: ${{ env.NX_CLOUD_ACCESS_TOKEN == '' }}
       - run: npx nx-cloud fix-ci
-        if: always()
+        if: always() && env.NX_CLOUD_ACCESS_TOKEN != ''

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "abapify",

--- a/bun.lock
+++ b/bun.lock
@@ -82,84 +82,85 @@
     },
     "packages/abap-ast": {
       "name": "@abapify/abap-ast",
-      "version": "0.3.6",
+      "version": "0.4.1",
     },
     "packages/acds": {
       "name": "@abapify/acds",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "dependencies": {
         "chevrotain": "^11.0.0",
       },
     },
     "packages/aclass": {
       "name": "@abapify/aclass",
-      "version": "0.1.0",
+      "version": "0.4.1",
       "dependencies": {
         "chevrotain": "^11.0.0",
       },
     },
     "packages/adk": {
       "name": "@abapify/adk",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "dependencies": {
-        "@abapify/adt-client": "0.3.6",
-        "@abapify/adt-locks": "0.3.6",
-        "@abapify/adt-schemas": "0.3.6",
+        "@abapify/adt-client": "0.4.1",
+        "@abapify/adt-locks": "0.4.1",
+        "@abapify/adt-schemas": "0.4.1",
       },
     },
     "packages/adt-atc": {
       "name": "@abapify/adt-atc",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "dependencies": {
-        "@abapify/adt-plugin": "0.3.6",
+        "@abapify/adt-plugin": "0.4.1",
         "chalk": "^5.3.0",
       },
     },
     "packages/adt-aunit": {
       "name": "@abapify/adt-aunit",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "dependencies": {
-        "@abapify/adt-contracts": "0.3.6",
-        "@abapify/adt-plugin": "0.3.6",
-        "@abapify/adt-plugin-abapgit": "0.3.6",
-        "@abapify/adt-schemas": "0.3.6",
+        "@abapify/adt-contracts": "0.4.1",
+        "@abapify/adt-plugin": "0.4.1",
+        "@abapify/adt-plugin-abapgit": "0.4.1",
+        "@abapify/adt-schemas": "0.4.1",
       },
     },
     "packages/adt-auth": {
       "name": "@abapify/adt-auth",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "dependencies": {
-        "@abapify/logger": "0.3.6",
+        "@abapify/logger": "0.4.1",
         "proxy-agent": "^6.4.0",
       },
     },
     "packages/adt-cli": {
       "name": "@abapify/adt-cli",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "bin": {
         "adt": "./dist/bin/adt.mjs",
       },
       "dependencies": {
-        "@abapify/adk": "0.3.6",
-        "@abapify/adt-atc": "0.3.6",
-        "@abapify/adt-aunit": "0.3.6",
-        "@abapify/adt-auth": "0.3.6",
-        "@abapify/adt-client": "0.3.6",
-        "@abapify/adt-codegen": "0.3.6",
-        "@abapify/adt-config": "0.3.6",
-        "@abapify/adt-contracts": "0.3.6",
-        "@abapify/adt-diff": "0.3.6",
-        "@abapify/adt-export": "0.3.6",
-        "@abapify/adt-lint": "0.3.6",
-        "@abapify/adt-locks": "0.3.6",
-        "@abapify/adt-plugin": "0.3.6",
-        "@abapify/adt-plugin-abapgit": "0.3.6",
-        "@abapify/adt-plugin-gcts": "0.3.6",
-        "@abapify/adt-plugin-gcts-cli": "0.3.6",
-        "@abapify/adt-rfc": "0.3.6",
-        "@abapify/adt-schemas": "0.3.6",
-        "@abapify/adt-tui": "0.3.6",
-        "@abapify/logger": "0.3.6",
+        "@abapify/adk": "0.4.1",
+        "@abapify/adt-atc": "0.4.1",
+        "@abapify/adt-aunit": "0.4.1",
+        "@abapify/adt-auth": "0.4.1",
+        "@abapify/adt-client": "0.4.1",
+        "@abapify/adt-codegen": "0.4.1",
+        "@abapify/adt-config": "0.4.1",
+        "@abapify/adt-contracts": "0.4.1",
+        "@abapify/adt-diff": "0.4.1",
+        "@abapify/adt-export": "0.4.1",
+        "@abapify/adt-lint": "0.4.1",
+        "@abapify/adt-locks": "0.4.1",
+        "@abapify/adt-plugin": "0.4.1",
+        "@abapify/adt-plugin-abapgit": "0.4.1",
+        "@abapify/adt-plugin-gcts": "0.4.1",
+        "@abapify/adt-plugin-gcts-cli": "0.4.1",
+        "@abapify/adt-proxy": "0.4.1",
+        "@abapify/adt-rfc": "0.4.1",
+        "@abapify/adt-schemas": "0.4.1",
+        "@abapify/adt-tui": "0.4.1",
+        "@abapify/logger": "0.4.1",
         "@inquirer/prompts": "^7.9.0",
         "@xmldom/xmldom": "^0.9.9",
         "chalk": "^5.6.2",
@@ -178,22 +179,22 @@
     },
     "packages/adt-client": {
       "name": "@abapify/adt-client",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "dependencies": {
-        "@abapify/adt-contracts": "0.3.6",
-        "@abapify/adt-schemas": "0.3.6",
-        "@abapify/logger": "0.3.6",
+        "@abapify/adt-contracts": "0.4.1",
+        "@abapify/adt-schemas": "0.4.1",
+        "@abapify/logger": "0.4.1",
       },
     },
     "packages/adt-codegen": {
       "name": "@abapify/adt-codegen",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "bin": {
         "adt-codegen": "./dist/cli.mjs",
       },
       "dependencies": {
-        "@abapify/adt-config": "0.3.6",
-        "@abapify/adt-plugin": "0.3.6",
+        "@abapify/adt-config": "0.4.1",
+        "@abapify/adt-plugin": "0.4.1",
         "chalk": "^5.3.0",
         "commander": "^11.1.0",
         "fast-xml-parser": "^5.5.0",
@@ -201,43 +202,43 @@
     },
     "packages/adt-config": {
       "name": "@abapify/adt-config",
-      "version": "0.3.6",
+      "version": "0.4.1",
     },
     "packages/adt-contracts": {
       "name": "@abapify/adt-contracts",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "dependencies": {
-        "@abapify/adt-schemas": "0.3.6",
-        "@abapify/speci": "0.3.6",
+        "@abapify/adt-schemas": "0.4.1",
+        "@abapify/speci": "0.4.1",
       },
       "devDependencies": {
-        "@abapify/adt-fixtures": "0.3.6",
+        "@abapify/adt-fixtures": "0.4.1",
       },
     },
     "packages/adt-diff": {
       "name": "@abapify/adt-diff",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "dependencies": {
-        "@abapify/adk": "0.3.6",
-        "@abapify/adt-contracts": "0.3.6",
-        "@abapify/adt-plugin": "0.3.6",
-        "@abapify/adt-plugin-abapgit": "0.3.6",
+        "@abapify/adk": "0.4.1",
+        "@abapify/adt-contracts": "0.4.1",
+        "@abapify/adt-plugin": "0.4.1",
+        "@abapify/adt-plugin-abapgit": "0.4.1",
         "chalk": "^5.6.2",
         "diff": "^8.0.3",
         "fast-xml-parser": "^5.5.5",
       },
       "devDependencies": {
-        "@abapify/adt-fixtures": "0.3.6",
+        "@abapify/adt-fixtures": "0.4.1",
       },
     },
     "packages/adt-export": {
       "name": "@abapify/adt-export",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "dependencies": {
-        "@abapify/adk": "0.3.6",
-        "@abapify/adt-locks": "0.3.6",
-        "@abapify/adt-plugin": "0.3.6",
-        "@abapify/adt-plugin-abapgit": "0.3.6",
+        "@abapify/adk": "0.4.1",
+        "@abapify/adt-locks": "0.4.1",
+        "@abapify/adt-plugin": "0.4.1",
+        "@abapify/adt-plugin-abapgit": "0.4.1",
         "chalk": "^5.6.2",
         "diff": "^8.0.3",
         "fast-xml-parser": "^5.5.5",
@@ -245,25 +246,25 @@
     },
     "packages/adt-fixtures": {
       "name": "@abapify/adt-fixtures",
-      "version": "0.3.6",
+      "version": "0.4.1",
     },
     "packages/adt-lint": {
       "name": "@abapify/adt-lint",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "dependencies": {
         "@abaplint/core": "^2.119.15",
       },
     },
     "packages/adt-locks": {
       "name": "@abapify/adt-locks",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "dependencies": {
-        "@abapify/adt-client": "0.3.6",
+        "@abapify/adt-client": "0.4.1",
       },
     },
     "packages/adt-mcp": {
       "name": "@abapify/adt-mcp",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "bin": {
         "adt-mcp": "./dist/bin/adt-mcp.mjs",
         "adt-mcp-http": "./dist/bin/adt-mcp-http.mjs",
@@ -289,7 +290,7 @@
     },
     "packages/adt-pilot": {
       "name": "@abapify/adt-pilot",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "dependencies": {
         "@mastra/core": "^1.28.0",
         "@modelcontextprotocol/sdk": "^1.27.0",
@@ -304,7 +305,7 @@
     },
     "packages/adt-playwright": {
       "name": "@abapify/adt-playwright",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "dependencies": {
         "@abapify/adt-auth": "workspace:*",
         "@abapify/adt-config": "workspace:*",
@@ -317,43 +318,52 @@
     },
     "packages/adt-plugin": {
       "name": "@abapify/adt-plugin",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "dependencies": {
-        "@abapify/adk": "0.3.6",
+        "@abapify/adk": "0.4.1",
       },
     },
     "packages/adt-plugin-abapgit": {
       "name": "@abapify/adt-plugin-abapgit",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "dependencies": {
-        "@abapify/acds": "0.3.6",
-        "@abapify/adk": "0.3.6",
-        "@abapify/adt-atc": "0.3.6",
-        "@abapify/adt-plugin": "0.3.6",
-        "@abapify/adt-schemas": "0.3.6",
-        "@abapify/ts-xsd": "0.3.6",
+        "@abapify/acds": "0.4.1",
+        "@abapify/adk": "0.4.1",
+        "@abapify/adt-atc": "0.4.1",
+        "@abapify/adt-plugin": "0.4.1",
+        "@abapify/adt-schemas": "0.4.1",
+        "@abapify/ts-xsd": "0.4.1",
       },
     },
     "packages/adt-plugin-gcts": {
       "name": "@abapify/adt-plugin-gcts",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "dependencies": {
-        "@abapify/adk": "0.3.6",
-        "@abapify/adt-plugin": "0.3.6",
+        "@abapify/adk": "0.4.1",
+        "@abapify/adt-plugin": "0.4.1",
       },
     },
     "packages/adt-plugin-gcts-cli": {
       "name": "@abapify/adt-plugin-gcts-cli",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "dependencies": {
-        "@abapify/adt-contracts": "0.3.6",
-        "@abapify/adt-plugin": "0.3.6",
+        "@abapify/adt-contracts": "0.4.1",
+        "@abapify/adt-plugin": "0.4.1",
         "zod": "^3.23.8",
+      },
+    },
+    "packages/adt-proxy": {
+      "name": "@abapify/adt-proxy",
+      "version": "0.4.1",
+      "dependencies": {
+        "@abapify/adt-contracts": "0.4.1",
+        "@abapify/speci": "0.4.1",
+        "fast-xml-parser": "^5.5.3",
       },
     },
     "packages/adt-puppeteer": {
       "name": "@abapify/adt-puppeteer",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "dependencies": {
         "@abapify/adt-auth": "workspace:*",
         "@abapify/adt-config": "workspace:*",
@@ -366,24 +376,24 @@
     },
     "packages/adt-rfc": {
       "name": "@abapify/adt-rfc",
-      "version": "0.3.6",
+      "version": "0.4.1",
     },
     "packages/adt-schemas": {
       "name": "@abapify/adt-schemas",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "dependencies": {
-        "@abapify/ts-xsd": "0.3.6",
+        "@abapify/ts-xsd": "0.4.1",
         "zod": "^3.24.0 || ^4.0.0",
       },
       "devDependencies": {
-        "@abapify/adt-fixtures": "0.3.6",
+        "@abapify/adt-fixtures": "0.4.1",
       },
     },
     "packages/adt-tui": {
       "name": "@abapify/adt-tui",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "dependencies": {
-        "@abapify/adt-contracts": "0.3.6",
+        "@abapify/adt-contracts": "0.4.1",
         "fast-xml-parser": "^5.3.1",
         "ink": "5.1.0",
         "ink-select-input": "^6.0.0",
@@ -395,19 +405,19 @@
         "@types/react": "18.3.0",
       },
       "peerDependencies": {
-        "@abapify/adt-client": "0.3.6",
+        "@abapify/adt-client": "0.4.1",
       },
     },
     "packages/asjson-parser": {
       "name": "@abapify/asjson-parser",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "dependencies": {
         "jsonc-eslint-parser": "^2.1.0",
       },
     },
     "packages/browser-auth": {
       "name": "@abapify/browser-auth",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "dependencies": {
         "@abapify/adt-config": "workspace:*",
       },
@@ -417,11 +427,11 @@
     },
     "packages/logger": {
       "name": "@abapify/logger",
-      "version": "0.3.6",
+      "version": "0.4.1",
     },
     "packages/openai-codegen": {
       "name": "@abapify/openai-codegen",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "bin": {
         "openai-codegen": "./dist/cli.mjs",
       },
@@ -439,11 +449,11 @@
     },
     "packages/speci": {
       "name": "@abapify/speci",
-      "version": "0.3.6",
+      "version": "0.4.1",
     },
     "packages/ts-xsd": {
       "name": "@abapify/ts-xsd",
-      "version": "0.3.6",
+      "version": "0.4.1",
       "bin": {
         "ts-xsd": "./dist/codegen/cli.mjs",
       },
@@ -492,7 +502,7 @@
     },
     "tools/p2-cli": {
       "name": "@abapify/p2-cli",
-      "version": "0.1.0",
+      "version": "0.4.1",
       "bin": {
         "p2": "./dist/cli.mjs",
       },
@@ -566,6 +576,8 @@
     "@abapify/adt-plugin-gcts": ["@abapify/adt-plugin-gcts@workspace:packages/adt-plugin-gcts"],
 
     "@abapify/adt-plugin-gcts-cli": ["@abapify/adt-plugin-gcts-cli@workspace:packages/adt-plugin-gcts-cli"],
+
+    "@abapify/adt-proxy": ["@abapify/adt-proxy@workspace:packages/adt-proxy"],
 
     "@abapify/adt-puppeteer": ["@abapify/adt-puppeteer@workspace:packages/adt-puppeteer"],
 
@@ -4921,6 +4933,8 @@
 
     "@abapify/adt-plugin-gcts-cli/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "@abapify/adt-proxy/fast-xml-parser": ["fast-xml-parser@5.7.3", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.7", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg=="],
+
     "@abapify/adt-tui/fast-xml-parser": ["fast-xml-parser@5.7.3", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.7", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg=="],
 
     "@abapify/asjson-parser/jsonc-eslint-parser": ["jsonc-eslint-parser@2.4.2", "", { "dependencies": { "acorn": "^8.5.0", "eslint-visitor-keys": "^3.0.0", "espree": "^9.0.0", "semver": "^7.3.5" } }, "sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA=="],
@@ -6106,6 +6120,10 @@
     "@abapify/adt-export/fast-xml-parser/strnum": ["strnum@2.2.3", "", {}, "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg=="],
 
     "@abapify/adt-playwright/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@abapify/adt-proxy/fast-xml-parser/path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
+
+    "@abapify/adt-proxy/fast-xml-parser/strnum": ["strnum@2.2.3", "", {}, "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg=="],
 
     "@abapify/adt-tui/fast-xml-parser/path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
 

--- a/packages/adt-cli/package.json
+++ b/packages/adt-cli/package.json
@@ -28,6 +28,7 @@
     "@abapify/adt-plugin-abapgit": "0.4.1",
     "@abapify/adt-plugin-gcts": "0.4.1",
     "@abapify/adt-plugin-gcts-cli": "0.4.1",
+    "@abapify/adt-proxy": "0.4.1",
     "@abapify/adt-rfc": "0.4.1",
     "@abapify/adt-schemas": "0.4.1",
     "@abapify/adt-tui": "0.4.1",

--- a/packages/adt-cli/src/lib/cli.ts
+++ b/packages/adt-cli/src/lib/cli.ts
@@ -44,6 +44,7 @@ import {
   createChangesetCommand,
   rfcCommand,
   createFlpCommand,
+  proxyCommand,
 } from './commands';
 import { createWbCommand } from './commands/wb';
 import { createPackageCommand } from './commands/package';
@@ -325,6 +326,9 @@ export async function createCLI(options?: {
 
   // REPL - Interactive hypermedia navigator
   program.addCommand(createReplCommand());
+
+  // Proxy command - ADT proxy server with JSON↔XML conversion
+  program.addCommand(proxyCommand);
 
   // gCTS command-plugin (E07). Auto-registered here (not via adt.config.ts)
   // because `@abapify/adt-plugin-gcts-cli` is a required dependency of

--- a/packages/adt-cli/src/lib/commands/index.ts
+++ b/packages/adt-cli/src/lib/commands/index.ts
@@ -34,3 +34,4 @@ export { checkinCommand } from './checkin';
 export { createChangesetCommand } from './changeset';
 export { rfcCommand } from './rfc';
 export { createFlpCommand } from './flp';
+export { proxyCommand } from './proxy';

--- a/packages/adt-cli/src/lib/commands/proxy.ts
+++ b/packages/adt-cli/src/lib/commands/proxy.ts
@@ -57,7 +57,7 @@ export const proxyCommand = new Command('proxy')
       let auth:
         | { username: string; password: string; client?: string }
         | undefined;
-      let defaultHeaders: Record<string, string> = {};
+      const defaultHeaders: Record<string, string> = {};
 
       if (!targetUrl) {
         // Use current auth session

--- a/packages/adt-cli/src/lib/commands/proxy.ts
+++ b/packages/adt-cli/src/lib/commands/proxy.ts
@@ -53,7 +53,7 @@ export const proxyCommand = new Command('proxy')
         if (!session || !session.auth) {
           console.error('❌ Not authenticated and no --target specified');
           console.error(
-            '💡 Run "npx adt auth login" or provide --target <url>',
+            '💡 Run "bunx adt auth login" or provide --target <url>',
           );
           process.exit(1);
         }

--- a/packages/adt-cli/src/lib/commands/proxy.ts
+++ b/packages/adt-cli/src/lib/commands/proxy.ts
@@ -1,0 +1,161 @@
+import { Command } from 'commander';
+import { createAdtProxy } from '@abapify/adt-proxy';
+import { loadAuthSession, type AuthSession } from '../utils/auth';
+
+export const proxyCommand = new Command('proxy')
+  .description('Start an ADT proxy server with JSON↔XML conversion')
+  .option(
+    '-p, --port <port>',
+    'Port to listen on (default: random available port)',
+    parseInt,
+  )
+  .option(
+    '-H, --host <host>',
+    'Host to bind to (default: 127.0.0.1)',
+    '127.0.0.1',
+  )
+  .option(
+    '-t, --target <url>',
+    'Target SAP system URL (overrides current auth session)',
+  )
+  .option(
+    '-b, --base-path <path>',
+    'Base path prefix to strip from incoming requests',
+    '',
+  )
+  .option(
+    '--no-convert',
+    'Disable JSON↔XML conversion (forward requests as-is)',
+  )
+  .option(
+    '--no-forward-unknown',
+    'Return 404 for unmatched routes instead of forwarding',
+  )
+  .option('--sid <sid>', 'SAP System ID to use for authentication')
+  .action(async (options, _command) => {
+    try {
+      // Determine target URL and auth
+      let targetUrl: string | undefined = options.target;
+      let auth:
+        | { username: string; password: string; client?: string }
+        | undefined;
+
+      if (!targetUrl) {
+        // Use current auth session
+        const session = loadAuthSession(options.sid);
+        if (!session) {
+          console.error('❌ Not authenticated and no --target specified');
+          console.error(
+            '💡 Run "npx adt auth login" or provide --target <url>',
+          );
+          process.exit(1);
+        }
+
+        targetUrl = session.host;
+
+        if (session.auth.method === 'basic') {
+          const creds = session.auth.credentials as {
+            username: string;
+            password: string;
+          };
+          auth = {
+            username: creds.username,
+            password: creds.password,
+            client: session.client,
+          };
+        } else if (session.auth.method === 'cookie') {
+          // Cookie auth - pass cookies as header
+          const creds = session.auth.credentials as { cookies: string };
+          auth = undefined; // Will use cookie header instead
+          console.warn(
+            '⚠️  Cookie-based auth detected. Cookie will be forwarded to downstream.',
+          );
+        }
+      }
+
+      if (!targetUrl) {
+        console.error('❌ No target URL specified');
+        process.exit(1);
+      }
+
+      console.log('🔄 Starting ADT proxy server...\n');
+      console.log(`   Target: ${targetUrl}`);
+      console.log(`   Port: ${options.port || 'auto'}`);
+      console.log(`   Host: ${options.host}`);
+      console.log(
+        `   JSON↔XML conversion: ${options.convert !== false ? 'enabled' : 'disabled'}`,
+      );
+      console.log(
+        `   Forward unknown routes: ${options.forwardUnknown !== false ? 'yes' : 'no'}`,
+      );
+      console.log('');
+
+      const proxy = createAdtProxy({
+        targetUrl,
+        auth,
+        port: options.port,
+        host: options.host,
+        basePath: options.basePath,
+        convertContent: options.convert !== false,
+        forwardUnknown: options.forwardUnknown !== false,
+        logger: {
+          debug: (msg, obj) => {
+            if (options.verbose) {
+              console.log(`[DEBUG] ${msg}`, obj || '');
+            }
+          },
+          info: (msg, obj) => {
+            console.log(`[INFO] ${msg}`, obj || '');
+          },
+          warn: (msg, obj) => {
+            console.warn(`[WARN] ${msg}`, obj || '');
+          },
+          error: (msg, obj) => {
+            console.error(`[ERROR] ${msg}`, obj || '');
+          },
+        },
+      });
+
+      const { port } = await proxy.start();
+
+      console.log(`✅ ADT proxy running on http://${options.host}:${port}`);
+      console.log(
+        `\n📋 Available routes (${proxy.routes.length} from ADT contracts):`,
+      );
+      for (const route of proxy.routes.slice(0, 10)) {
+        console.log(`   ${route.method.padEnd(7)} ${route.pathTemplate}`);
+      }
+      if (proxy.routes.length > 10) {
+        console.log(`   ... and ${proxy.routes.length - 10} more`);
+      }
+      console.log(
+        '\n💡 Send requests to the proxy and they will be forwarded to the target SAP system.',
+      );
+      console.log(
+        '   JSON request bodies are automatically converted to XML for downstream requests.',
+      );
+      console.log(
+        '   XML response bodies are automatically converted to JSON for proxy responses.',
+      );
+
+      // Handle graceful shutdown
+      const shutdown = async () => {
+        console.log('\n🔄 Shutting down proxy...');
+        await proxy.stop();
+        console.log('✅ Proxy stopped');
+        process.exit(0);
+      };
+
+      process.on('SIGINT', shutdown);
+      process.on('SIGTERM', shutdown);
+    } catch (error) {
+      console.error(
+        '❌ Proxy failed to start:',
+        error instanceof Error ? error.message : String(error),
+      );
+      if (error instanceof Error && error.stack) {
+        console.error('\nStack trace:', error.stack);
+      }
+      process.exit(1);
+    }
+  });

--- a/packages/adt-cli/src/lib/commands/proxy.ts
+++ b/packages/adt-cli/src/lib/commands/proxy.ts
@@ -7,7 +7,13 @@ export const proxyCommand = new Command('proxy')
   .option(
     '-p, --port <port>',
     'Port to listen on (default: random available port)',
-    parseInt,
+    (val: string) => {
+      const parsed = parseInt(val, 10);
+      if (Number.isNaN(parsed) || parsed < 0 || parsed > 65535) {
+        throw new Error(`Invalid port: ${val}`);
+      }
+      return parsed;
+    },
   )
   .option(
     '-H, --host <host>',
@@ -44,7 +50,7 @@ export const proxyCommand = new Command('proxy')
       if (!targetUrl) {
         // Use current auth session
         const session = loadAuthSession(options.sid);
-        if (!session) {
+        if (!session || !session.auth) {
           console.error('❌ Not authenticated and no --target specified');
           console.error(
             '💡 Run "npx adt auth login" or provide --target <url>',

--- a/packages/adt-cli/src/lib/commands/proxy.ts
+++ b/packages/adt-cli/src/lib/commands/proxy.ts
@@ -39,6 +39,7 @@ export const proxyCommand = new Command('proxy')
       let auth:
         | { username: string; password: string; client?: string }
         | undefined;
+      let defaultHeaders: Record<string, string> = {};
 
       if (!targetUrl) {
         // Use current auth session
@@ -64,12 +65,16 @@ export const proxyCommand = new Command('proxy')
             client: session.client,
           };
         } else if (session.auth.method === 'cookie') {
-          // Cookie auth - pass cookies as header
           const creds = session.auth.credentials as { cookies: string };
-          auth = undefined; // Will use cookie header instead
-          console.warn(
-            '⚠️  Cookie-based auth detected. Cookie will be forwarded to downstream.',
-          );
+          const rawCookies = decodeURIComponent(creds.cookies);
+          const AUTH_PREFIX = 'Authorization: ';
+          if (rawCookies.startsWith(AUTH_PREFIX)) {
+            defaultHeaders.authorization = rawCookies.substring(
+              AUTH_PREFIX.length,
+            );
+          } else {
+            defaultHeaders.cookie = rawCookies;
+          }
         }
       }
 
@@ -93,6 +98,7 @@ export const proxyCommand = new Command('proxy')
       const proxy = createAdtProxy({
         targetUrl,
         auth,
+        defaultHeaders,
         port: options.port,
         host: options.host,
         basePath: options.basePath,

--- a/packages/adt-cli/src/lib/commands/proxy.ts
+++ b/packages/adt-cli/src/lib/commands/proxy.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { createAdtProxy } from '@abapify/adt-proxy';
-import { loadAuthSession, type AuthSession } from '../utils/auth';
+import { loadAuthSession } from '../utils/auth';
 
 export const proxyCommand = new Command('proxy')
   .description('Start an ADT proxy server with JSON↔XML conversion')
@@ -37,7 +37,19 @@ export const proxyCommand = new Command('proxy')
     '--no-forward-unknown',
     'Return 404 for unmatched routes instead of forwarding',
   )
+  .option(
+    '--max-body-size <bytes>',
+    'Maximum request body size in bytes (default: 10485760)',
+    (val: string) => {
+      const parsed = parseInt(val, 10);
+      if (Number.isNaN(parsed) || parsed <= 0) {
+        throw new Error(`Invalid max-body-size: ${val}`);
+      }
+      return parsed;
+    },
+  )
   .option('--sid <sid>', 'SAP System ID to use for authentication')
+  .option('--verbose', 'Enable debug logging')
   .action(async (options, _command) => {
     try {
       // Determine target URL and auth
@@ -110,6 +122,7 @@ export const proxyCommand = new Command('proxy')
         basePath: options.basePath,
         convertContent: options.convert !== false,
         forwardUnknown: options.forwardUnknown !== false,
+        maxBodySize: options.maxBodySize,
         logger: {
           debug: (msg, obj) => {
             if (options.verbose) {

--- a/packages/adt-proxy/package.json
+++ b/packages/adt-proxy/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@abapify/adt-proxy",
+  "version": "0.4.1",
+  "description": "ADT proxy server with JSON↔XML conversion",
+  "license": "MIT",
+  "type": "module",
+  "types": "./dist/index.d.mts",
+  "exports": {
+    ".": "./dist/index.mjs",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "dependencies": {
+    "@abapify/adt-contracts": "0.4.1",
+    "@abapify/speci": "0.4.1",
+    "fast-xml-parser": "^5.5.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/abapify/adt-cli.git",
+    "directory": "packages/adt-proxy"
+  },
+  "homepage": "https://github.com/abapify/adt-cli/tree/main/packages/adt-proxy#readme",
+  "bugs": {
+    "url": "https://github.com/abapify/adt-cli/issues"
+  }
+}

--- a/packages/adt-proxy/package.json
+++ b/packages/adt-proxy/package.json
@@ -15,8 +15,7 @@
   ],
   "dependencies": {
     "@abapify/adt-contracts": "0.4.1",
-    "@abapify/speci": "0.4.1",
-    "fast-xml-parser": "^5.5.3"
+    "@abapify/speci": "0.4.1"
   },
   "repository": {
     "type": "git",

--- a/packages/adt-proxy/project.json
+++ b/packages/adt-proxy/project.json
@@ -1,0 +1,13 @@
+{
+  "name": "adt-proxy",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/adt-proxy/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "manifestRootsToUpdate": ["{projectRoot}"]
+    }
+  },
+  "tags": ["type:library", "scope:adt-proxy"],
+  "targets": {}
+}

--- a/packages/adt-proxy/src/converter.test.ts
+++ b/packages/adt-proxy/src/converter.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import {
+  jsonToXml,
+  xmlToJson,
+  detectContentType,
+  isJsonContentType,
+  isXmlContentType,
+} from './converter';
+
+// Mock schema with parse/build methods
+const mockSchema = {
+  _infer: undefined as unknown as any,
+  parse: (_raw: string) => {
+    return { result: { value: 'hello' } };
+  },
+  build: (data: any) => {
+    return `<root><value>${data.value}</value></root>`;
+  },
+};
+
+describe('converter', () => {
+  describe('jsonToXml', () => {
+    it('should convert JSON to XML using schema.build', () => {
+      const json = JSON.stringify({ value: 'hello' });
+      const result = jsonToXml(json, mockSchema);
+      expect(result).toBe('<root><value>hello</value></root>');
+    });
+
+    it('should return original string if JSON parsing fails', () => {
+      const result = jsonToXml('not json', mockSchema);
+      expect(result).toBe('not json');
+    });
+
+    it('should return original string if schema has no build method', () => {
+      const schema = { parse: () => ({}), _infer: undefined };
+      const json = JSON.stringify({ value: 'hello' });
+      const result = jsonToXml(json, schema as any);
+      expect(result).toBe(json);
+    });
+  });
+
+  describe('xmlToJson', () => {
+    it('should convert XML to JSON using schema.parse', () => {
+      const xml = '<root><value>hello</value></root>';
+      const result = xmlToJson(xml, mockSchema);
+      const parsed = JSON.parse(result);
+      expect(parsed).toEqual({ result: { value: 'hello' } });
+    });
+
+    it('should return original string if schema.parse fails', () => {
+      const badSchema = {
+        parse: () => {
+          throw new Error('parse error');
+        },
+        _infer: undefined,
+      };
+      const result = xmlToJson('<root/>', badSchema as any);
+      expect(result).toBe('<root/>');
+    });
+  });
+
+  describe('detectContentType', () => {
+    it('should detect JSON from content-type header', () => {
+      expect(detectContentType('', 'application/json')).toBe('json');
+      expect(detectContentType('', 'application/vnd.sap.adt.v1+json')).toBe(
+        'json',
+      );
+    });
+
+    it('should detect XML from content-type header', () => {
+      expect(detectContentType('', 'application/xml')).toBe('xml');
+      expect(detectContentType('', 'application/vnd.sap.adt.v1+xml')).toBe(
+        'xml',
+      );
+    });
+
+    it('should detect text from content-type header', () => {
+      expect(detectContentType('', 'text/plain')).toBe('text');
+    });
+
+    it('should detect JSON from content heuristics', () => {
+      expect(detectContentType('{"key": "value"}')).toBe('json');
+      expect(detectContentType('[1, 2, 3]')).toBe('json');
+    });
+
+    it('should detect XML from content heuristics', () => {
+      expect(detectContentType('<?xml version="1.0"?>')).toBe('xml');
+      expect(detectContentType('<root>')).toBe('xml');
+    });
+
+    it('should detect text from content heuristics', () => {
+      expect(detectContentType('hello world')).toBe('text');
+    });
+  });
+
+  describe('isJsonContentType', () => {
+    it('should return true for JSON content types', () => {
+      expect(isJsonContentType('application/json')).toBe(true);
+      expect(isJsonContentType('application/vnd.sap+json')).toBe(true);
+      expect(isJsonContentType('text/json')).toBe(true);
+    });
+
+    it('should return false for non-JSON content types', () => {
+      expect(isJsonContentType('application/xml')).toBe(false);
+      expect(isJsonContentType('text/plain')).toBe(false);
+    });
+  });
+
+  describe('isXmlContentType', () => {
+    it('should return true for XML content types', () => {
+      expect(isXmlContentType('application/xml')).toBe(true);
+      expect(isXmlContentType('application/vnd.sap+xml')).toBe(true);
+      expect(isXmlContentType('text/xml')).toBe(true);
+    });
+
+    it('should return false for non-XML content types', () => {
+      expect(isXmlContentType('application/json')).toBe(false);
+      expect(isXmlContentType('text/plain')).toBe(false);
+    });
+  });
+});

--- a/packages/adt-proxy/src/converter.ts
+++ b/packages/adt-proxy/src/converter.ts
@@ -1,0 +1,82 @@
+/**
+ * ADT Proxy Server - Content Conversion
+ *
+ * Handles JSON↔XML conversion using schema parse/build methods.
+ * This is the core of the proxy's content negotiation.
+ */
+
+import type { Serializable } from '@abapify/speci/rest';
+
+/**
+ * Convert a JSON string to XML using a schema's build method.
+ *
+ * @param json - The JSON string to convert
+ * @param schema - The schema with a build() method
+ * @returns The XML string, or the original JSON if conversion fails
+ */
+export function jsonToXml(json: string, schema: Serializable): string {
+  try {
+    const data = JSON.parse(json);
+    if (typeof schema.build === 'function') {
+      return schema.build(data);
+    }
+    // No build method - return as-is
+    return json;
+  } catch {
+    // If parsing fails, return the original string
+    return json;
+  }
+}
+
+/**
+ * Convert an XML string to JSON using a schema's parse method.
+ *
+ * @param xml - The XML string to convert
+ * @param schema - The schema with a parse() method
+ * @returns The JSON string, or the original XML if conversion fails
+ */
+export function xmlToJson(xml: string, schema: Serializable): string {
+  try {
+    const data = schema.parse(xml);
+    return JSON.stringify(data);
+  } catch {
+    // If parsing fails, return the original string
+    return xml;
+  }
+}
+
+/**
+ * Detect content type from a string or content-type header.
+ */
+export function detectContentType(
+  content: string,
+  contentType?: string,
+): 'json' | 'xml' | 'text' | 'binary' {
+  // Check explicit content-type header first
+  if (contentType) {
+    if (contentType.includes('json')) return 'json';
+    if (contentType.includes('xml')) return 'xml';
+    if (contentType.includes('text')) return 'text';
+    return 'binary';
+  }
+
+  // Heuristic detection
+  const trimmed = content.trimStart();
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) return 'json';
+  if (trimmed.startsWith('<?xml') || trimmed.startsWith('<')) return 'xml';
+  return 'text';
+}
+
+/**
+ * Check if a content type indicates JSON.
+ */
+export function isJsonContentType(contentType: string): boolean {
+  return contentType.includes('json') || contentType.endsWith('+json');
+}
+
+/**
+ * Check if a content type indicates XML.
+ */
+export function isXmlContentType(contentType: string): boolean {
+  return contentType.includes('xml') || contentType.endsWith('+xml');
+}

--- a/packages/adt-proxy/src/converter.ts
+++ b/packages/adt-proxy/src/converter.ts
@@ -9,10 +9,6 @@ import type { Serializable } from '@abapify/speci/rest';
 
 /**
  * Convert a JSON string to XML using a schema's build method.
- *
- * @param json - The JSON string to convert
- * @param schema - The schema with a build() method
- * @returns The XML string, or the original JSON if conversion fails
  */
 export function jsonToXml(json: string, schema: Serializable): string {
   try {
@@ -20,27 +16,20 @@ export function jsonToXml(json: string, schema: Serializable): string {
     if (typeof schema.build === 'function') {
       return schema.build(data);
     }
-    // No build method - return as-is
     return json;
   } catch {
-    // If parsing fails, return the original string
     return json;
   }
 }
 
 /**
  * Convert an XML string to JSON using a schema's parse method.
- *
- * @param xml - The XML string to convert
- * @param schema - The schema with a parse() method
- * @returns The JSON string, or the original XML if conversion fails
  */
 export function xmlToJson(xml: string, schema: Serializable): string {
   try {
     const data = schema.parse(xml);
     return JSON.stringify(data);
   } catch {
-    // If parsing fails, return the original string
     return xml;
   }
 }
@@ -52,15 +41,14 @@ export function detectContentType(
   content: string,
   contentType?: string,
 ): 'json' | 'xml' | 'text' | 'binary' {
-  // Check explicit content-type header first
   if (contentType) {
-    if (contentType.includes('json')) return 'json';
-    if (contentType.includes('xml')) return 'xml';
-    if (contentType.includes('text')) return 'text';
+    const ct = contentType.toLowerCase();
+    if (ct.includes('json')) return 'json';
+    if (ct.includes('xml')) return 'xml';
+    if (ct.includes('text')) return 'text';
     return 'binary';
   }
 
-  // Heuristic detection
   const trimmed = content.trimStart();
   if (trimmed.startsWith('{') || trimmed.startsWith('[')) return 'json';
   if (trimmed.startsWith('<?xml') || trimmed.startsWith('<')) return 'xml';
@@ -68,15 +56,17 @@ export function detectContentType(
 }
 
 /**
- * Check if a content type indicates JSON.
+ * Check if a content type indicates JSON (case-insensitive).
  */
 export function isJsonContentType(contentType: string): boolean {
-  return contentType.includes('json') || contentType.endsWith('+json');
+  const ct = contentType.toLowerCase();
+  return ct.includes('json') || ct.endsWith('+json');
 }
 
 /**
- * Check if a content type indicates XML.
+ * Check if a content type indicates XML (case-insensitive).
  */
 export function isXmlContentType(contentType: string): boolean {
-  return contentType.includes('xml') || contentType.endsWith('+xml');
+  const ct = contentType.toLowerCase();
+  return ct.includes('xml') || ct.endsWith('+xml');
 }

--- a/packages/adt-proxy/src/index.ts
+++ b/packages/adt-proxy/src/index.ts
@@ -1,0 +1,30 @@
+/**
+ * @abapify/adt-proxy
+ *
+ * ADT proxy server with JSON↔XML conversion.
+ *
+ * Proxies ADT endpoint requests to a downstream SAP system with
+ * automatic content conversion using contract schemas.
+ *
+ * @example
+ * ```typescript
+ * import { createAdtProxy } from '@abapify/adt-proxy';
+ *
+ * const proxy = createAdtProxy({
+ *   targetUrl: 'https://my-sap-system.com:8000',
+ *   auth: { username: 'user', password: 'pass', client: '100' },
+ * });
+ *
+ * const { port } = await proxy.start();
+ * ```
+ */
+
+export { createAdtProxy } from './proxy';
+export type { AdtProxyConfig, ProxyResult, Logger } from './types';
+export {
+  jsonToXml,
+  xmlToJson,
+  detectContentType,
+  isJsonContentType,
+  isXmlContentType,
+} from './converter';

--- a/packages/adt-proxy/src/proxy.ts
+++ b/packages/adt-proxy/src/proxy.ts
@@ -22,10 +22,6 @@
  *
  * const { port } = await proxy.start();
  * console.log(`Proxy running on http://localhost:${port}`);
- *
- * // Now send JSON requests to the proxy:
- * // curl -X GET http://localhost:${port}/sap/bc/adt/cts/transportrequests/DEVK900001
- * // The proxy converts the response XML → JSON automatically
  * ```
  */
 
@@ -48,12 +44,104 @@ const DEFAULT_LOGGER: Logger = {
   error: console.error,
 };
 
-/**
- * Create an ADT proxy server.
- *
- * @param config - Proxy configuration
- * @returns Proxy server instance with start/stop methods
- */
+const FORWARDABLE_REQUEST_HEADERS = [
+  'accept',
+  'content-type',
+  'x-csrf-token',
+  'x-sap-security-session',
+  'x-sap-adt-sessiontype',
+  'cookie',
+  'authorization',
+];
+
+const FORWARDABLE_RESPONSE_HEADERS = [
+  'content-type',
+  'x-csrf-token',
+  'x-sap-security-session',
+  'set-cookie',
+  'etag',
+  'location',
+];
+
+function forwardHeaders(
+  source: Record<string, string | string[] | undefined>,
+  target: Record<string, string>,
+  keys: string[],
+): void {
+  for (const h of keys) {
+    const value = source[h];
+    if (value && !target[h]) {
+      target[h] = Array.isArray(value) ? value[0] : value;
+    }
+  }
+}
+
+function addAuthHeaders(
+  headers: Record<string, string>,
+  auth?: AdtProxyConfig['auth'],
+): void {
+  if (!auth) return;
+  if (!headers.authorization) {
+    const creds = Buffer.from(`${auth.username}:${auth.password}`).toString(
+      'base64',
+    );
+    headers.authorization = `Basic ${creds}`;
+  }
+  if (auth.client && !headers['sap-client']) {
+    headers['sap-client'] = auth.client;
+  }
+}
+
+function convertRequestBody(
+  body: string,
+  contentType: string | undefined,
+  bodySchema?: RouteDefinition['bodySchema'],
+): { body: string; converted: boolean } {
+  if (!body || !bodySchema || !contentType) {
+    return { body, converted: false };
+  }
+  if (!isJsonContentType(contentType)) {
+    return { body, converted: false };
+  }
+  return { body: jsonToXml(body, bodySchema), converted: true };
+}
+
+function convertResponseBody(
+  body: string,
+  contentType: string,
+  responseSchemas: RouteDefinition['responseSchemas'],
+): { body: string; converted: boolean } {
+  if (!body || !isXmlContentType(contentType) || !responseSchemas[200]) {
+    return { body, converted: false };
+  }
+  return { body: xmlToJson(body, responseSchemas[200]), converted: true };
+}
+
+async function forwardRequest(
+  method: string,
+  url: string,
+  headers: Record<string, string>,
+  body?: string,
+): Promise<{ status: number; headers: Record<string, string>; body: string }> {
+  const response = await fetch(url, {
+    method,
+    headers,
+    body: body || undefined,
+  });
+
+  const responseBody = await response.text();
+  const responseHeaders: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    responseHeaders[key] = value;
+  });
+
+  return {
+    status: response.status,
+    headers: responseHeaders,
+    body: responseBody,
+  };
+}
+
 export function createAdtProxy(config: AdtProxyConfig) {
   const {
     targetUrl,
@@ -65,23 +153,25 @@ export function createAdtProxy(config: AdtProxyConfig) {
     logger = DEFAULT_LOGGER,
   } = config;
 
-  // Extract routes from ADT contracts
   const contractRoutes = createServer(adtContract as AdtContract);
   let server: Server | undefined;
 
-  /**
-   * Match an incoming request to a contract route.
-   */
-  function matchRoute(
-    method: string,
-    url: string,
-  ): { route: RouteDefinition; params: Record<string, string> } | null {
-    return contractRoutes.match(method, url, basePath);
+  function buildDownstreamHeaders(
+    incomingHeaders: Record<string, string | string[] | undefined>,
+    contractHeaders?: Record<string, string>,
+  ): Record<string, string> {
+    const headers: Record<string, string> = {
+      ...defaultHeaders,
+      ...contractHeaders,
+    };
+    forwardHeaders(incomingHeaders, headers, FORWARDABLE_REQUEST_HEADERS);
+    addAuthHeaders(headers, auth);
+    if (convertContent && !headers.accept) {
+      headers.accept = 'application/json';
+    }
+    return headers;
   }
 
-  /**
-   * Build the downstream URL from the incoming request URL.
-   */
   function buildDownstreamUrl(url: string): string {
     const relativePath = basePath
       ? url.replace(new RegExp(`^${basePath}`), '') || '/'
@@ -89,102 +179,136 @@ export function createAdtProxy(config: AdtProxyConfig) {
     return `${targetUrl}${relativePath}`;
   }
 
-  /**
-   * Build Basic Auth header from config.
-   */
-  function getAuthHeader(): string | undefined {
-    if (!auth) return undefined;
-    const credentials = Buffer.from(
-      `${auth.username}:${auth.password}`,
-    ).toString('base64');
-    return `Basic ${credentials}`;
+  function getContentType(
+    headers: Record<string, string | string[] | undefined>,
+  ): string | undefined {
+    const ct = headers['content-type'];
+    return Array.isArray(ct) ? ct[0] : ct;
   }
 
-  /**
-   * Build downstream request headers.
-   */
-  function buildDownstreamHeaders(
-    incomingHeaders: Record<string, string | string[] | undefined>,
-    contractHeaders?: Record<string, string>,
-    isXmlBody = false,
-  ): Record<string, string> {
-    const headers: Record<string, string> = {
-      ...defaultHeaders,
-      ...contractHeaders,
-    };
-
-    // Forward relevant headers from the incoming request
-    const forwardableHeaders = [
-      'accept',
-      'content-type',
-      'x-csrf-token',
-      'x-sap-security-session',
-      'x-sap-adt-sessiontype',
-      'cookie',
-      'authorization',
-    ];
-
-    for (const h of forwardableHeaders) {
-      const value = incomingHeaders[h];
-      if (value && !headers[h]) {
-        headers[h] = Array.isArray(value) ? value[0] : value;
-      }
-    }
-
-    // Add auth if configured and not already present
-    if (auth && !headers.authorization) {
-      const authHeader = getAuthHeader();
-      if (authHeader) headers.authorization = authHeader;
-    }
-
-    // Add SAP client if configured
-    if (auth?.client && !headers['sap-client']) {
-      headers['sap-client'] = auth.client;
-    }
-
-    // Set Accept to JSON for the proxy (we want JSON responses)
-    if (convertContent && !headers.accept) {
-      headers.accept = 'application/json';
-    }
-
-    return headers;
-  }
-
-  /**
-   * Forward a request to the downstream SAP system.
-   */
-  async function forwardRequest(
+  async function handleMatchedRoute(
     method: string,
     url: string,
-    headers: Record<string, string>,
-    body?: string,
-  ): Promise<{
-    status: number;
-    headers: Record<string, string>;
-    body: string;
-  }> {
-    const response = await fetch(url, {
-      method,
-      headers,
-      body: body || undefined,
-    });
+    requestBody: string,
+    incomingHeaders: Record<string, string | string[] | undefined>,
+    route: RouteDefinition,
+  ): Promise<ProxyResult> {
+    logger.info(`Matched route: ${route.method} ${route.pathTemplate}`);
 
-    const responseBody = await response.text();
-    const responseHeaders: Record<string, string> = {};
-    response.headers.forEach((value, key) => {
-      responseHeaders[key] = value;
-    });
+    const reqContentType = getContentType(incomingHeaders);
+    const { body: downstreamBody, converted: reqConverted } =
+      convertRequestBody(requestBody, reqContentType, route.bodySchema);
+
+    const downstreamHeaders = buildDownstreamHeaders(
+      incomingHeaders,
+      route.requestHeaders,
+    );
+    if (reqConverted) {
+      downstreamHeaders['content-type'] = 'application/xml';
+    }
+
+    const response = await forwardRequest(
+      method,
+      buildDownstreamUrl(url),
+      downstreamHeaders,
+      downstreamBody,
+    );
+
+    const respContentType = response.headers['content-type'] || '';
+    const { body: responseBody, converted: respConverted } =
+      convertResponseBody(
+        response.body,
+        respContentType,
+        route.responseSchemas,
+      );
 
     return {
       status: response.status,
-      headers: responseHeaders,
+      headers: response.headers,
       body: responseBody,
+      converted: respConverted,
     };
   }
 
-  /**
-   * Handle a single incoming HTTP request.
-   */
+  async function handleForwardedRequest(
+    method: string,
+    url: string,
+    requestBody: string,
+    incomingHeaders: Record<string, string | string[] | undefined>,
+  ): Promise<ProxyResult> {
+    logger.debug(`No route match for ${method} ${url} - forwarding as-is`);
+
+    const downstreamHeaders = buildDownstreamHeaders(incomingHeaders);
+    const response = await forwardRequest(
+      method,
+      buildDownstreamUrl(url),
+      downstreamHeaders,
+      requestBody,
+    );
+
+    return {
+      status: response.status,
+      headers: response.headers,
+      body: response.body,
+      converted: false,
+    };
+  }
+
+  function sendNotFound(
+    res: {
+      writeHead: (status: number, headers: Record<string, string>) => void;
+      end: (body?: string) => void;
+    },
+    method: string,
+    url: string,
+  ): void {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        error: 'Not Found',
+        message: `No contract route matched for ${method} ${url}`,
+        availableRoutes: contractRoutes.routes.map((r) => ({
+          method: r.method,
+          path: r.pathTemplate,
+        })),
+      }),
+    );
+  }
+
+  function sendResponse(
+    res: {
+      writeHead: (status: number, headers: Record<string, string>) => void;
+      end: (body?: string) => void;
+    },
+    result: ProxyResult,
+  ): void {
+    const responseHeaders: Record<string, string> = { 'x-proxy': 'adt-proxy' };
+    forwardHeaders(
+      result.headers,
+      responseHeaders,
+      FORWARDABLE_RESPONSE_HEADERS,
+    );
+
+    if (result.converted) {
+      responseHeaders['content-type'] = 'application/json';
+    }
+
+    res.writeHead(result.status, responseHeaders);
+    res.end(result.body);
+  }
+
+  async function readBody(req: {
+    on: (event: string, cb: (chunk: any) => void) => void;
+  }): Promise<string> {
+    return new Promise((resolve) => {
+      let body = '';
+      req.on('data', (chunk: Buffer) => {
+        body += chunk.toString();
+      });
+      req.on('end', () => resolve(body));
+    });
+  }
+
   async function handleRequest(
     req: {
       method?: string;
@@ -199,168 +323,43 @@ export function createAdtProxy(config: AdtProxyConfig) {
   ): Promise<void> {
     const method = req.method || 'GET';
     const url = req.url || '/';
-
     logger.info(`${method} ${url}`);
 
-    // Read request body
-    let requestBody = '';
-    await new Promise<void>((resolve) => {
-      req.on('data', (chunk: Buffer) => {
-        requestBody += chunk.toString();
-      });
-      req.on('end', () => resolve());
-    });
-
-    // Match to a contract route
-    const match = matchRoute(method, url);
-
-    let result: ProxyResult;
+    const requestBody = await readBody(req);
+    const match = contractRoutes.match(method, url, basePath);
 
     if (match && convertContent) {
-      // Route matched - use schema-aware conversion
-      const { route, params } = match;
-      logger.info(`Matched route: ${route.method} ${route.pathTemplate}`, {
-        params,
-      });
-
-      // Convert JSON body → XML if needed
-      let downstreamBody = requestBody;
-      if (requestBody && route.bodySchema) {
-        const contentType = Array.isArray(req.headers['content-type'])
-          ? req.headers['content-type'][0]
-          : req.headers['content-type'];
-
-        if (contentType && isJsonContentType(contentType)) {
-          downstreamBody = jsonToXml(requestBody, route.bodySchema);
-          logger.debug('Converted request body: JSON → XML');
-        }
-      }
-
-      // Build downstream headers
-      const downstreamHeaders = buildDownstreamHeaders(
-        req.headers,
-        route.requestHeaders,
-        downstreamBody !== requestBody,
-      );
-
-      // Set Content-Type for XML body
-      if (downstreamBody !== requestBody) {
-        downstreamHeaders['content-type'] = 'application/xml';
-      }
-
-      // Forward to downstream SAP
-      const downstreamUrl = buildDownstreamUrl(url);
-      const response = await forwardRequest(
+      const result = await handleMatchedRoute(
         method,
-        downstreamUrl,
-        downstreamHeaders,
-        downstreamBody,
-      );
-
-      // Convert XML response → JSON if needed
-      let responseBody = response.body;
-      let converted = false;
-      if (response.body && route.responseSchemas[200]) {
-        const respContentType = response.headers['content-type'] || '';
-        if (isXmlContentType(respContentType)) {
-          responseBody = xmlToJson(response.body, route.responseSchemas[200]);
-          converted = true;
-          logger.debug('Converted response body: XML → JSON');
-        }
-      }
-
-      result = {
-        status: response.status,
-        headers: response.headers,
-        body: responseBody,
-        converted,
-      };
-    } else if (forwardUnknown) {
-      // No route match - forward as-is
-      if (match === null) {
-        logger.debug(`No route match for ${method} ${url} - forwarding as-is`);
-      }
-
-      const downstreamHeaders = buildDownstreamHeaders(req.headers);
-      const downstreamUrl = buildDownstreamUrl(url);
-
-      const response = await forwardRequest(
-        method,
-        downstreamUrl,
-        downstreamHeaders,
+        url,
         requestBody,
+        req.headers,
+        match.route,
       );
-
-      result = {
-        status: response.status,
-        headers: response.headers,
-        body: response.body,
-        converted: false,
-      };
-    } else {
-      // No route match and forwarding disabled
-      res.writeHead(404, { 'Content-Type': 'application/json' });
-      res.end(
-        JSON.stringify({
-          error: 'Not Found',
-          message: `No contract route matched for ${method} ${url}`,
-          availableRoutes: contractRoutes.routes.map((r) => ({
-            method: r.method,
-            path: r.pathTemplate,
-          })),
-        }),
-      );
+      sendResponse(res, result);
       return;
     }
 
-    // Send response
-    const responseHeaders: Record<string, string> = {
-      'x-proxy': 'adt-proxy',
-    };
-
-    // Forward relevant response headers
-    const forwardableResponseHeaders = [
-      'content-type',
-      'x-csrf-token',
-      'x-sap-security-session',
-      'set-cookie',
-      'etag',
-      'location',
-    ];
-
-    for (const h of forwardableResponseHeaders) {
-      if (result.headers[h]) {
-        responseHeaders[h] = result.headers[h];
-      }
+    if (forwardUnknown) {
+      const result = await handleForwardedRequest(
+        method,
+        url,
+        requestBody,
+        req.headers,
+      );
+      sendResponse(res, result);
+      return;
     }
 
-    // Set content type to JSON if we converted
-    if (result.converted) {
-      responseHeaders['content-type'] = 'application/json';
-    }
-
-    res.writeHead(result.status, responseHeaders);
-    res.end(result.body);
+    sendNotFound(res, method, url);
   }
 
   return {
-    /**
-     * Get the extracted route definitions (for inspection/testing).
-     */
     get routes() {
       return contractRoutes.routes;
     },
-
-    /**
-     * Match a request against the contract routes.
-     */
     match: contractRoutes.match,
 
-    /**
-     * Start the proxy server.
-     *
-     * @returns The port the server is listening on
-     */
     async start(): Promise<{ port: number }> {
       return new Promise((resolve, reject) => {
         server = httpCreateServer((req, res) => {
@@ -393,9 +392,6 @@ export function createAdtProxy(config: AdtProxyConfig) {
       });
     },
 
-    /**
-     * Stop the proxy server.
-     */
     async stop(): Promise<void> {
       return new Promise((resolve, reject) => {
         if (!server) return resolve();
@@ -405,7 +401,6 @@ export function createAdtProxy(config: AdtProxyConfig) {
   };
 }
 
-// Re-export types and utilities
 export { createServer } from '@abapify/speci/rest';
 export type { AdtProxyConfig, ProxyResult, Logger } from './types';
 export {

--- a/packages/adt-proxy/src/proxy.ts
+++ b/packages/adt-proxy/src/proxy.ts
@@ -114,7 +114,9 @@ function convertResponseBody(
   if (!body || !isXmlContentType(contentType) || !responseSchemas[status]) {
     return { body, converted: false };
   }
-  return { body: xmlToJson(body, responseSchemas[status]), converted: true };
+  const converted = xmlToJson(body, responseSchemas[status]);
+  const wasConverted = converted !== body;
+  return { body: converted, converted: wasConverted };
 }
 
 async function forwardRequest(
@@ -122,35 +124,44 @@ async function forwardRequest(
   url: string,
   headers: Record<string, string>,
   body?: string,
+  timeoutMs = 30_000,
 ): Promise<{
   status: number;
   headers: Record<string, string | string[]>;
   body: string;
 }> {
-  const response = await fetch(url, {
-    method,
-    headers,
-    body: body || undefined,
-  });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-  const responseBody = await response.text();
-  const responseHeaders: Record<string, string | string[]> = {};
-  response.headers.forEach((value, key) => {
-    responseHeaders[key] = value;
-  });
+  try {
+    const response = await fetch(url, {
+      method,
+      headers,
+      body: body || undefined,
+      signal: controller.signal,
+    });
 
-  if (typeof response.headers.getSetCookie === 'function') {
-    const setCookies = response.headers.getSetCookie();
-    if (setCookies.length > 0) {
-      responseHeaders['set-cookie'] = setCookies;
+    const responseBody = await response.text();
+    const responseHeaders: Record<string, string | string[]> = {};
+    response.headers.forEach((value, key) => {
+      responseHeaders[key] = value;
+    });
+
+    if (typeof response.headers.getSetCookie === 'function') {
+      const setCookies = response.headers.getSetCookie();
+      if (setCookies.length > 0) {
+        responseHeaders['set-cookie'] = setCookies;
+      }
     }
-  }
 
-  return {
-    status: response.status,
-    headers: responseHeaders,
-    body: responseBody,
-  };
+    return {
+      status: response.status,
+      headers: responseHeaders,
+      body: responseBody,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 export function createAdtProxy(config: AdtProxyConfig) {
@@ -323,14 +334,15 @@ export function createAdtProxy(config: AdtProxyConfig) {
   }
 
   async function readBody(req: {
-    on: (event: string, cb: (chunk: any) => void) => void;
+    on: (event: string, cb: (...args: any[]) => void) => void;
   }): Promise<string> {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       let body = '';
       req.on('data', (chunk: Buffer) => {
         body += chunk.toString();
       });
       req.on('end', () => resolve(body));
+      req.on('error', (err: Error) => reject(err));
     });
   }
 
@@ -403,6 +415,8 @@ export function createAdtProxy(config: AdtProxyConfig) {
           });
         });
 
+        server.on('error', reject);
+
         server.listen(config.port || 0, config.host || '127.0.0.1', () => {
           const addr = server?.address();
           if (!addr || typeof addr !== 'object') {
@@ -415,8 +429,6 @@ export function createAdtProxy(config: AdtProxyConfig) {
           logger.info(`Proxying to ${targetUrl}`);
           resolve({ port: addr.port });
         });
-
-        server.on('error', reject);
       });
     },
 

--- a/packages/adt-proxy/src/proxy.ts
+++ b/packages/adt-proxy/src/proxy.ts
@@ -51,7 +51,6 @@ const FORWARDABLE_REQUEST_HEADERS = [
   'x-sap-security-session',
   'x-sap-adt-sessiontype',
   'cookie',
-  'authorization',
 ];
 
 const FORWARDABLE_RESPONSE_HEADERS = [
@@ -65,13 +64,13 @@ const FORWARDABLE_RESPONSE_HEADERS = [
 
 function forwardHeaders(
   source: Record<string, string | string[] | undefined>,
-  target: Record<string, string>,
+  target: Record<string, string | string[]>,
   keys: string[],
 ): void {
   for (const h of keys) {
     const value = source[h];
     if (value && !target[h]) {
-      target[h] = Array.isArray(value) ? value[0] : value;
+      target[h] = value;
     }
   }
 }
@@ -109,12 +108,13 @@ function convertRequestBody(
 function convertResponseBody(
   body: string,
   contentType: string,
+  status: number,
   responseSchemas: RouteDefinition['responseSchemas'],
 ): { body: string; converted: boolean } {
-  if (!body || !isXmlContentType(contentType) || !responseSchemas[200]) {
+  if (!body || !isXmlContentType(contentType) || !responseSchemas[status]) {
     return { body, converted: false };
   }
-  return { body: xmlToJson(body, responseSchemas[200]), converted: true };
+  return { body: xmlToJson(body, responseSchemas[status]), converted: true };
 }
 
 async function forwardRequest(
@@ -122,7 +122,11 @@ async function forwardRequest(
   url: string,
   headers: Record<string, string>,
   body?: string,
-): Promise<{ status: number; headers: Record<string, string>; body: string }> {
+): Promise<{
+  status: number;
+  headers: Record<string, string | string[]>;
+  body: string;
+}> {
   const response = await fetch(url, {
     method,
     headers,
@@ -130,10 +134,17 @@ async function forwardRequest(
   });
 
   const responseBody = await response.text();
-  const responseHeaders: Record<string, string> = {};
+  const responseHeaders: Record<string, string | string[]> = {};
   response.headers.forEach((value, key) => {
     responseHeaders[key] = value;
   });
+
+  if (typeof response.headers.getSetCookie === 'function') {
+    const setCookies = response.headers.getSetCookie();
+    if (setCookies.length > 0) {
+      responseHeaders['set-cookie'] = setCookies;
+    }
+  }
 
   return {
     status: response.status,
@@ -217,11 +228,14 @@ export function createAdtProxy(config: AdtProxyConfig) {
       downstreamBody,
     );
 
-    const respContentType = response.headers['content-type'] || '';
+    const respContentType = Array.isArray(response.headers['content-type'])
+      ? response.headers['content-type'][0]
+      : response.headers['content-type'] || '';
     const { body: responseBody, converted: respConverted } =
       convertResponseBody(
         response.body,
         respContentType,
+        response.status,
         route.responseSchemas,
       );
 
@@ -259,7 +273,10 @@ export function createAdtProxy(config: AdtProxyConfig) {
 
   function sendNotFound(
     res: {
-      writeHead: (status: number, headers: Record<string, string>) => void;
+      writeHead: (
+        status: number,
+        headers: Record<string, string | string[]>,
+      ) => void;
       end: (body?: string) => void;
     },
     method: string,
@@ -280,12 +297,17 @@ export function createAdtProxy(config: AdtProxyConfig) {
 
   function sendResponse(
     res: {
-      writeHead: (status: number, headers: Record<string, string>) => void;
+      writeHead: (
+        status: number,
+        headers: Record<string, string | string[]>,
+      ) => void;
       end: (body?: string) => void;
     },
     result: ProxyResult,
   ): void {
-    const responseHeaders: Record<string, string> = { 'x-proxy': 'adt-proxy' };
+    const responseHeaders: Record<string, string | string[]> = {
+      'x-proxy': 'adt-proxy',
+    };
     forwardHeaders(
       result.headers,
       responseHeaders,
@@ -320,7 +342,10 @@ export function createAdtProxy(config: AdtProxyConfig) {
       on: (event: string, cb: (chunk: any) => void) => void;
     },
     res: {
-      writeHead: (status: number, headers: Record<string, string>) => void;
+      writeHead: (
+        status: number,
+        headers: Record<string, string | string[]>,
+      ) => void;
       end: (body?: string) => void;
     },
   ): Promise<void> {

--- a/packages/adt-proxy/src/proxy.ts
+++ b/packages/adt-proxy/src/proxy.ts
@@ -174,7 +174,10 @@ export function createAdtProxy(config: AdtProxyConfig) {
 
   function buildDownstreamUrl(url: string): string {
     const relativePath = basePath
-      ? url.replace(new RegExp(`^${basePath}`), '') || '/'
+      ? url.replace(
+          new RegExp(`^${basePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),
+          '',
+        ) || '/'
       : url;
     return `${targetUrl}${relativePath}`;
   }

--- a/packages/adt-proxy/src/proxy.ts
+++ b/packages/adt-proxy/src/proxy.ts
@@ -37,6 +37,8 @@ import {
 } from './converter';
 import type { AdtProxyConfig, ProxyResult, Logger } from './types';
 
+const DEFAULT_MAX_BODY_SIZE = 10 * 1024 * 1024;
+
 const DEFAULT_LOGGER: Logger = {
   debug: () => {},
   info: () => {},
@@ -172,6 +174,7 @@ export function createAdtProxy(config: AdtProxyConfig) {
     forwardUnknown = true,
     convertContent = true,
     defaultHeaders = {},
+    maxBodySize = DEFAULT_MAX_BODY_SIZE,
     logger = DEFAULT_LOGGER,
   } = config;
 
@@ -217,12 +220,14 @@ export function createAdtProxy(config: AdtProxyConfig) {
     requestBody: string,
     incomingHeaders: Record<string, string | string[] | undefined>,
     route: RouteDefinition,
+    doConvert: boolean,
   ): Promise<ProxyResult> {
     logger.info(`Matched route: ${route.method} ${route.pathTemplate}`);
 
     const reqContentType = getContentType(incomingHeaders);
-    const { body: downstreamBody, converted: reqConverted } =
-      convertRequestBody(requestBody, reqContentType, route.bodySchema);
+    const { body: downstreamBody, converted: reqConverted } = doConvert
+      ? convertRequestBody(requestBody, reqContentType, route.bodySchema)
+      : { body: requestBody, converted: false };
 
     const downstreamHeaders = buildDownstreamHeaders(
       incomingHeaders,
@@ -242,13 +247,14 @@ export function createAdtProxy(config: AdtProxyConfig) {
     const respContentType = Array.isArray(response.headers['content-type'])
       ? response.headers['content-type'][0]
       : response.headers['content-type'] || '';
-    const { body: responseBody, converted: respConverted } =
-      convertResponseBody(
-        response.body,
-        respContentType,
-        response.status,
-        route.responseSchemas,
-      );
+    const { body: responseBody, converted: respConverted } = doConvert
+      ? convertResponseBody(
+          response.body,
+          respContentType,
+          response.status,
+          route.responseSchemas,
+        )
+      : { body: response.body, converted: false };
 
     return {
       status: response.status,
@@ -338,7 +344,13 @@ export function createAdtProxy(config: AdtProxyConfig) {
   }): Promise<string> {
     return new Promise((resolve, reject) => {
       let body = '';
+      let totalSize = 0;
       req.on('data', (chunk: Buffer) => {
+        totalSize += chunk.length;
+        if (totalSize > maxBodySize) {
+          reject(new Error(`Request body exceeds maximum size of ${maxBodySize} bytes`));
+          return;
+        }
         body += chunk.toString();
       });
       req.on('end', () => resolve(body));
@@ -368,13 +380,14 @@ export function createAdtProxy(config: AdtProxyConfig) {
     const requestBody = await readBody(req);
     const match = contractRoutes.match(method, url, basePath);
 
-    if (match && convertContent) {
+    if (match) {
       const result = await handleMatchedRoute(
         method,
         url,
         requestBody,
         req.headers,
         match.route,
+        convertContent,
       );
       sendResponse(res, result);
       return;

--- a/packages/adt-proxy/src/proxy.ts
+++ b/packages/adt-proxy/src/proxy.ts
@@ -1,0 +1,417 @@
+/**
+ * ADT Proxy Server
+ *
+ * Proxies ADT endpoint requests to a downstream SAP system with
+ * automatic JSON↔XML conversion using contract schemas.
+ *
+ * Architecture:
+ *   Client (JSON) → Proxy → Downstream SAP (XML)
+ *   Client (JSON) ← Proxy ← Downstream SAP (XML)
+ *
+ * The proxy uses speci's createServer to extract route definitions
+ * from ADT contracts, enabling schema-aware content conversion.
+ *
+ * @example
+ * ```typescript
+ * import { createAdtProxy } from '@abapify/adt-proxy';
+ *
+ * const proxy = createAdtProxy({
+ *   targetUrl: 'https://my-sap-system.com:8000',
+ *   auth: { username: 'user', password: 'pass', client: '100' },
+ * });
+ *
+ * const { port } = await proxy.start();
+ * console.log(`Proxy running on http://localhost:${port}`);
+ *
+ * // Now send JSON requests to the proxy:
+ * // curl -X GET http://localhost:${port}/sap/bc/adt/cts/transportrequests/DEVK900001
+ * // The proxy converts the response XML → JSON automatically
+ * ```
+ */
+
+import { createServer as httpCreateServer, type Server } from 'node:http';
+import { createServer } from '@abapify/speci/rest';
+import { adtContract, type AdtContract } from '@abapify/adt-contracts';
+import type { RouteDefinition } from '@abapify/speci/rest';
+import {
+  jsonToXml,
+  xmlToJson,
+  isJsonContentType,
+  isXmlContentType,
+} from './converter';
+import type { AdtProxyConfig, ProxyResult, Logger } from './types';
+
+const DEFAULT_LOGGER: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: console.warn,
+  error: console.error,
+};
+
+/**
+ * Create an ADT proxy server.
+ *
+ * @param config - Proxy configuration
+ * @returns Proxy server instance with start/stop methods
+ */
+export function createAdtProxy(config: AdtProxyConfig) {
+  const {
+    targetUrl,
+    auth,
+    basePath = '',
+    forwardUnknown = true,
+    convertContent = true,
+    defaultHeaders = {},
+    logger = DEFAULT_LOGGER,
+  } = config;
+
+  // Extract routes from ADT contracts
+  const contractRoutes = createServer(adtContract as AdtContract);
+  let server: Server | undefined;
+
+  /**
+   * Match an incoming request to a contract route.
+   */
+  function matchRoute(
+    method: string,
+    url: string,
+  ): { route: RouteDefinition; params: Record<string, string> } | null {
+    return contractRoutes.match(method, url, basePath);
+  }
+
+  /**
+   * Build the downstream URL from the incoming request URL.
+   */
+  function buildDownstreamUrl(url: string): string {
+    const relativePath = basePath
+      ? url.replace(new RegExp(`^${basePath}`), '') || '/'
+      : url;
+    return `${targetUrl}${relativePath}`;
+  }
+
+  /**
+   * Build Basic Auth header from config.
+   */
+  function getAuthHeader(): string | undefined {
+    if (!auth) return undefined;
+    const credentials = Buffer.from(
+      `${auth.username}:${auth.password}`,
+    ).toString('base64');
+    return `Basic ${credentials}`;
+  }
+
+  /**
+   * Build downstream request headers.
+   */
+  function buildDownstreamHeaders(
+    incomingHeaders: Record<string, string | string[] | undefined>,
+    contractHeaders?: Record<string, string>,
+    isXmlBody = false,
+  ): Record<string, string> {
+    const headers: Record<string, string> = {
+      ...defaultHeaders,
+      ...contractHeaders,
+    };
+
+    // Forward relevant headers from the incoming request
+    const forwardableHeaders = [
+      'accept',
+      'content-type',
+      'x-csrf-token',
+      'x-sap-security-session',
+      'x-sap-adt-sessiontype',
+      'cookie',
+      'authorization',
+    ];
+
+    for (const h of forwardableHeaders) {
+      const value = incomingHeaders[h];
+      if (value && !headers[h]) {
+        headers[h] = Array.isArray(value) ? value[0] : value;
+      }
+    }
+
+    // Add auth if configured and not already present
+    if (auth && !headers.authorization) {
+      const authHeader = getAuthHeader();
+      if (authHeader) headers.authorization = authHeader;
+    }
+
+    // Add SAP client if configured
+    if (auth?.client && !headers['sap-client']) {
+      headers['sap-client'] = auth.client;
+    }
+
+    // Set Accept to JSON for the proxy (we want JSON responses)
+    if (convertContent && !headers.accept) {
+      headers.accept = 'application/json';
+    }
+
+    return headers;
+  }
+
+  /**
+   * Forward a request to the downstream SAP system.
+   */
+  async function forwardRequest(
+    method: string,
+    url: string,
+    headers: Record<string, string>,
+    body?: string,
+  ): Promise<{
+    status: number;
+    headers: Record<string, string>;
+    body: string;
+  }> {
+    const response = await fetch(url, {
+      method,
+      headers,
+      body: body || undefined,
+    });
+
+    const responseBody = await response.text();
+    const responseHeaders: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+      responseHeaders[key] = value;
+    });
+
+    return {
+      status: response.status,
+      headers: responseHeaders,
+      body: responseBody,
+    };
+  }
+
+  /**
+   * Handle a single incoming HTTP request.
+   */
+  async function handleRequest(
+    req: {
+      method?: string;
+      url?: string;
+      headers: Record<string, string | string[] | undefined>;
+      on: (event: string, cb: (chunk: any) => void) => void;
+    },
+    res: {
+      writeHead: (status: number, headers: Record<string, string>) => void;
+      end: (body?: string) => void;
+    },
+  ): Promise<void> {
+    const method = req.method || 'GET';
+    const url = req.url || '/';
+
+    logger.info(`${method} ${url}`);
+
+    // Read request body
+    let requestBody = '';
+    await new Promise<void>((resolve) => {
+      req.on('data', (chunk: Buffer) => {
+        requestBody += chunk.toString();
+      });
+      req.on('end', () => resolve());
+    });
+
+    // Match to a contract route
+    const match = matchRoute(method, url);
+
+    let result: ProxyResult;
+
+    if (match && convertContent) {
+      // Route matched - use schema-aware conversion
+      const { route, params } = match;
+      logger.info(`Matched route: ${route.method} ${route.pathTemplate}`, {
+        params,
+      });
+
+      // Convert JSON body → XML if needed
+      let downstreamBody = requestBody;
+      if (requestBody && route.bodySchema) {
+        const contentType = Array.isArray(req.headers['content-type'])
+          ? req.headers['content-type'][0]
+          : req.headers['content-type'];
+
+        if (contentType && isJsonContentType(contentType)) {
+          downstreamBody = jsonToXml(requestBody, route.bodySchema);
+          logger.debug('Converted request body: JSON → XML');
+        }
+      }
+
+      // Build downstream headers
+      const downstreamHeaders = buildDownstreamHeaders(
+        req.headers,
+        route.requestHeaders,
+        downstreamBody !== requestBody,
+      );
+
+      // Set Content-Type for XML body
+      if (downstreamBody !== requestBody) {
+        downstreamHeaders['content-type'] = 'application/xml';
+      }
+
+      // Forward to downstream SAP
+      const downstreamUrl = buildDownstreamUrl(url);
+      const response = await forwardRequest(
+        method,
+        downstreamUrl,
+        downstreamHeaders,
+        downstreamBody,
+      );
+
+      // Convert XML response → JSON if needed
+      let responseBody = response.body;
+      let converted = false;
+      if (response.body && route.responseSchemas[200]) {
+        const respContentType = response.headers['content-type'] || '';
+        if (isXmlContentType(respContentType)) {
+          responseBody = xmlToJson(response.body, route.responseSchemas[200]);
+          converted = true;
+          logger.debug('Converted response body: XML → JSON');
+        }
+      }
+
+      result = {
+        status: response.status,
+        headers: response.headers,
+        body: responseBody,
+        converted,
+      };
+    } else if (forwardUnknown) {
+      // No route match - forward as-is
+      if (match === null) {
+        logger.debug(`No route match for ${method} ${url} - forwarding as-is`);
+      }
+
+      const downstreamHeaders = buildDownstreamHeaders(req.headers);
+      const downstreamUrl = buildDownstreamUrl(url);
+
+      const response = await forwardRequest(
+        method,
+        downstreamUrl,
+        downstreamHeaders,
+        requestBody,
+      );
+
+      result = {
+        status: response.status,
+        headers: response.headers,
+        body: response.body,
+        converted: false,
+      };
+    } else {
+      // No route match and forwarding disabled
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          error: 'Not Found',
+          message: `No contract route matched for ${method} ${url}`,
+          availableRoutes: contractRoutes.routes.map((r) => ({
+            method: r.method,
+            path: r.pathTemplate,
+          })),
+        }),
+      );
+      return;
+    }
+
+    // Send response
+    const responseHeaders: Record<string, string> = {
+      'x-proxy': 'adt-proxy',
+    };
+
+    // Forward relevant response headers
+    const forwardableResponseHeaders = [
+      'content-type',
+      'x-csrf-token',
+      'x-sap-security-session',
+      'set-cookie',
+      'etag',
+      'location',
+    ];
+
+    for (const h of forwardableResponseHeaders) {
+      if (result.headers[h]) {
+        responseHeaders[h] = result.headers[h];
+      }
+    }
+
+    // Set content type to JSON if we converted
+    if (result.converted) {
+      responseHeaders['content-type'] = 'application/json';
+    }
+
+    res.writeHead(result.status, responseHeaders);
+    res.end(result.body);
+  }
+
+  return {
+    /**
+     * Get the extracted route definitions (for inspection/testing).
+     */
+    get routes() {
+      return contractRoutes.routes;
+    },
+
+    /**
+     * Match a request against the contract routes.
+     */
+    match: contractRoutes.match,
+
+    /**
+     * Start the proxy server.
+     *
+     * @returns The port the server is listening on
+     */
+    async start(): Promise<{ port: number }> {
+      return new Promise((resolve, reject) => {
+        server = httpCreateServer((req, res) => {
+          handleRequest(req, res).catch((err) => {
+            logger.error('Request handling error', { error: err.message });
+            res.writeHead(500, { 'Content-Type': 'application/json' });
+            res.end(
+              JSON.stringify({
+                error: 'Internal Server Error',
+                message: err.message,
+              }),
+            );
+          });
+        });
+
+        server.listen(config.port || 0, config.host || '127.0.0.1', () => {
+          const addr = server?.address();
+          if (!addr || typeof addr !== 'object') {
+            reject(new Error('Failed to get server address'));
+            return;
+          }
+          logger.info(
+            `ADT proxy listening on http://${config.host || '127.0.0.1'}:${addr.port}`,
+          );
+          logger.info(`Proxying to ${targetUrl}`);
+          resolve({ port: addr.port });
+        });
+
+        server.on('error', reject);
+      });
+    },
+
+    /**
+     * Stop the proxy server.
+     */
+    async stop(): Promise<void> {
+      return new Promise((resolve, reject) => {
+        if (!server) return resolve();
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+// Re-export types and utilities
+export { createServer } from '@abapify/speci/rest';
+export type { AdtProxyConfig, ProxyResult, Logger } from './types';
+export {
+  jsonToXml,
+  xmlToJson,
+  detectContentType,
+  isJsonContentType,
+  isXmlContentType,
+} from './converter';

--- a/packages/adt-proxy/src/proxy.ts
+++ b/packages/adt-proxy/src/proxy.ts
@@ -38,8 +38,12 @@ import {
 import type { AdtProxyConfig, ProxyResult, Logger } from './types';
 
 const DEFAULT_LOGGER: Logger = {
-  debug: () => {},
-  info: () => {},
+  debug: (_msg: string) => {
+    /* noop */
+  },
+  info: (_msg: string) => {
+    /* noop */
+  },
   warn: console.warn,
   error: console.error,
 };
@@ -195,12 +199,10 @@ export function createAdtProxy(config: AdtProxyConfig) {
   }
 
   function buildDownstreamUrl(url: string): string {
-    const relativePath = basePath
-      ? url.replace(
-          new RegExp(`^${basePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),
-          '',
-        ) || '/'
-      : url;
+    const relativePath =
+      basePath && url.startsWith(basePath)
+        ? url.slice(basePath.length) || '/'
+        : url;
     return `${targetUrl}${relativePath}`;
   }
 

--- a/packages/adt-proxy/src/proxy.ts
+++ b/packages/adt-proxy/src/proxy.ts
@@ -37,8 +37,6 @@ import {
 } from './converter';
 import type { AdtProxyConfig, ProxyResult, Logger } from './types';
 
-const DEFAULT_MAX_BODY_SIZE = 10 * 1024 * 1024;
-
 const DEFAULT_LOGGER: Logger = {
   debug: () => {},
   info: () => {},
@@ -174,7 +172,6 @@ export function createAdtProxy(config: AdtProxyConfig) {
     forwardUnknown = true,
     convertContent = true,
     defaultHeaders = {},
-    maxBodySize = DEFAULT_MAX_BODY_SIZE,
     logger = DEFAULT_LOGGER,
   } = config;
 
@@ -220,14 +217,12 @@ export function createAdtProxy(config: AdtProxyConfig) {
     requestBody: string,
     incomingHeaders: Record<string, string | string[] | undefined>,
     route: RouteDefinition,
-    doConvert: boolean,
   ): Promise<ProxyResult> {
     logger.info(`Matched route: ${route.method} ${route.pathTemplate}`);
 
     const reqContentType = getContentType(incomingHeaders);
-    const { body: downstreamBody, converted: reqConverted } = doConvert
-      ? convertRequestBody(requestBody, reqContentType, route.bodySchema)
-      : { body: requestBody, converted: false };
+    const { body: downstreamBody, converted: reqConverted } =
+      convertRequestBody(requestBody, reqContentType, route.bodySchema);
 
     const downstreamHeaders = buildDownstreamHeaders(
       incomingHeaders,
@@ -247,14 +242,13 @@ export function createAdtProxy(config: AdtProxyConfig) {
     const respContentType = Array.isArray(response.headers['content-type'])
       ? response.headers['content-type'][0]
       : response.headers['content-type'] || '';
-    const { body: responseBody, converted: respConverted } = doConvert
-      ? convertResponseBody(
-          response.body,
-          respContentType,
-          response.status,
-          route.responseSchemas,
-        )
-      : { body: response.body, converted: false };
+    const { body: responseBody, converted: respConverted } =
+      convertResponseBody(
+        response.body,
+        respContentType,
+        response.status,
+        route.responseSchemas,
+      );
 
     return {
       status: response.status,
@@ -339,21 +333,24 @@ export function createAdtProxy(config: AdtProxyConfig) {
     res.end(result.body);
   }
 
-  async function readBody(req: {
-    on: (event: string, cb: (...args: any[]) => void) => void;
-  }): Promise<string> {
+  async function readBody(
+    req: {
+      on: (event: string, cb: (...args: any[]) => void) => void;
+    },
+    maxSize = 10 * 1024 * 1024,
+  ): Promise<string> {
     return new Promise((resolve, reject) => {
-      let body = '';
-      let totalSize = 0;
+      let size = 0;
+      const chunks: Buffer[] = [];
       req.on('data', (chunk: Buffer) => {
-        totalSize += chunk.length;
-        if (totalSize > maxBodySize) {
-          reject(new Error(`Request body exceeds maximum size of ${maxBodySize} bytes`));
+        size += chunk.length;
+        if (size > maxSize) {
+          reject(new Error(`Request body exceeds ${maxSize} byte limit`));
           return;
         }
-        body += chunk.toString();
+        chunks.push(chunk);
       });
-      req.on('end', () => resolve(body));
+      req.on('end', () => resolve(Buffer.concat(chunks).toString()));
       req.on('error', (err: Error) => reject(err));
     });
   }
@@ -380,16 +377,35 @@ export function createAdtProxy(config: AdtProxyConfig) {
     const requestBody = await readBody(req);
     const match = contractRoutes.match(method, url, basePath);
 
-    if (match) {
+    if (match && convertContent) {
       const result = await handleMatchedRoute(
         method,
         url,
         requestBody,
         req.headers,
         match.route,
-        convertContent,
       );
       sendResponse(res, result);
+      return;
+    }
+
+    if (match) {
+      const downstreamHeaders = buildDownstreamHeaders(
+        req.headers,
+        match.route.requestHeaders,
+      );
+      const response = await forwardRequest(
+        method,
+        buildDownstreamUrl(url),
+        downstreamHeaders,
+        requestBody,
+      );
+      sendResponse(res, {
+        status: response.status,
+        headers: response.headers,
+        body: response.body,
+        converted: false,
+      });
       return;
     }
 

--- a/packages/adt-proxy/src/proxy.ts
+++ b/packages/adt-proxy/src/proxy.ts
@@ -148,6 +148,7 @@ async function forwardRequest(
     const responseBody = await response.text();
     const responseHeaders: Record<string, string | string[]> = {};
     response.headers.forEach((value, key) => {
+      if (key.toLowerCase() === 'set-cookie') return;
       responseHeaders[key] = value;
     });
 

--- a/packages/adt-proxy/src/types.ts
+++ b/packages/adt-proxy/src/types.ts
@@ -1,0 +1,89 @@
+/**
+ * ADT Proxy Server - Types
+ */
+
+import type { Serializable } from '@abapify/speci/rest';
+
+/**
+ * Configuration for the ADT proxy server
+ */
+export interface AdtProxyConfig {
+  /** Port to listen on (default: 0 = random available port) */
+  port?: number;
+
+  /** Host to bind to (default: '127.0.0.1') */
+  host?: string;
+
+  /** Base URL of the downstream SAP system (e.g., 'https://sap-system.com:8000') */
+  targetUrl: string;
+
+  /** Authentication credentials for the downstream SAP system */
+  auth?: {
+    username: string;
+    password: string;
+    /** SAP client number (e.g., '100') */
+    client?: string;
+  };
+
+  /** Base path prefix to strip from incoming requests (default: '') */
+  basePath?: string;
+
+  /** Whether to forward all requests as-is when no schema match is found (default: true) */
+  forwardUnknown?: boolean;
+
+  /** Whether to convert JSON↔XML based on schema (default: true) */
+  convertContent?: boolean;
+
+  /** Custom headers to add to all downstream requests */
+  defaultHeaders?: Record<string, string>;
+
+  /** Logger instance (must implement debug, info, warn, error methods) */
+  logger?: Logger;
+}
+
+/**
+ * Simple logger interface
+ */
+export interface Logger {
+  debug(msg: string, obj?: any): void;
+  info(msg: string, obj?: any): void;
+  warn(msg: string, obj?: any): void;
+  error(msg: string, obj?: any): void;
+}
+
+/**
+ * Proxy route handler context
+ */
+export interface ProxyRouteContext {
+  /** Matched route path template */
+  pathTemplate: string;
+
+  /** Extracted path parameters */
+  params: Record<string, string>;
+
+  /** Request body schema (for JSON→XML conversion) */
+  bodySchema?: Serializable;
+
+  /** Response schemas (for XML→JSON conversion) */
+  responseSchemas: Record<number, Serializable>;
+
+  /** Original contract endpoint headers */
+  contractHeaders?: Record<string, string>;
+}
+
+/**
+ * Result of a proxied request
+ */
+export interface ProxyResult {
+  /** HTTP status code from downstream */
+  status: number;
+
+  /** Response headers from downstream */
+  headers: Record<string, string>;
+
+  /** Response body (JSON string if converted, raw string otherwise) */
+  body: string;
+
+  /** Whether the response was converted from XML to JSON */
+  converted: boolean;
+}

--- a/packages/adt-proxy/src/types.ts
+++ b/packages/adt-proxy/src/types.ts
@@ -37,6 +37,9 @@ export interface AdtProxyConfig {
   /** Custom headers to add to all downstream requests */
   defaultHeaders?: Record<string, string>;
 
+  /** Maximum allowed request body size in bytes (default: 10MB) */
+  maxBodySize?: number;
+
   /** Logger instance (must implement debug, info, warn, error methods) */
   logger?: Logger;
 }

--- a/packages/adt-proxy/src/types.ts
+++ b/packages/adt-proxy/src/types.ts
@@ -79,7 +79,7 @@ export interface ProxyResult {
   status: number;
 
   /** Response headers from downstream */
-  headers: Record<string, string>;
+  headers: Record<string, string | string[]>;
 
   /** Response body (JSON string if converted, raw string otherwise) */
   body: string;

--- a/packages/adt-proxy/tsconfig.json
+++ b/packages/adt-proxy/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"],
+  "references": [{ "path": "../speci" }, { "path": "../adt-contracts" }]
+}

--- a/packages/adt-proxy/tsdown.config.ts
+++ b/packages/adt-proxy/tsdown.config.ts
@@ -3,6 +3,6 @@ import baseConfig from '../../tsdown.config.ts';
 
 export default defineConfig({
   ...baseConfig,
-  entry: ['src/index.ts', 'src/rest/index.ts', 'src/rest/server/index.ts'],
+  entry: ['src/index.ts'],
   tsconfig: 'tsconfig.json',
 });

--- a/packages/adt-proxy/vitest.config.ts
+++ b/packages/adt-proxy/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});

--- a/packages/speci/package.json
+++ b/packages/speci/package.json
@@ -11,6 +11,7 @@
   "exports": {
     ".": "./dist/index.mjs",
     "./rest": "./dist/rest/index.mjs",
+    "./rest/server": "./dist/rest/server/index.mjs",
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/speci/src/rest/index.ts
+++ b/packages/speci/src/rest/index.ts
@@ -54,3 +54,6 @@ export { http, createHttp, type RestEndpointOptions } from './helpers';
 
 // Export client
 export * from './client';
+
+// Export server
+export * from './server';

--- a/packages/speci/src/rest/server/create-server.test.ts
+++ b/packages/speci/src/rest/server/create-server.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import { createServer } from './create-server';
+import { createHttp } from '../helpers';
+
+const http = createHttp();
+
+// Simple test contract
+const testContract = {
+  users: {
+    list: () =>
+      http.get('/users', {
+        responses: {
+          200: {
+            parse: (s: string) => JSON.parse(s),
+            _infer: undefined as unknown as any[],
+          },
+        },
+      }),
+    get: (id: string) =>
+      http.get(`/users/${id}`, {
+        responses: {
+          200: {
+            parse: (s: string) => JSON.parse(s),
+            _infer: undefined as unknown as any,
+          },
+        },
+      }),
+    create: (user: any) =>
+      http.post('/users', {
+        body: {
+          parse: (s: string) => JSON.parse(s),
+          build: (d: any) => JSON.stringify(d),
+          _infer: undefined as unknown as any,
+        },
+        responses: {
+          201: {
+            parse: (s: string) => JSON.parse(s),
+            _infer: undefined as unknown as any,
+          },
+        },
+      }),
+  },
+  posts: {
+    get: (userId: string, postId: string) =>
+      http.get(`/users/${userId}/posts/${postId}`, {
+        responses: {
+          200: {
+            parse: (s: string) => JSON.parse(s),
+            _infer: undefined as unknown as any,
+          },
+        },
+      }),
+  },
+};
+
+describe('createServer', () => {
+  describe('route extraction', () => {
+    it('should extract routes from a nested contract', () => {
+      const server = createServer(testContract);
+      expect(server.routes).toHaveLength(4);
+    });
+
+    it('should extract correct HTTP methods', () => {
+      const server = createServer(testContract);
+      const methods = server.routes.map((r) => r.method);
+      expect(methods).toContain('GET');
+      expect(methods).toContain('POST');
+    });
+
+    it('should extract path parameter names', () => {
+      const server = createServer(testContract);
+      // Path with one param: /users/${id} → template /users/${p1}
+      const getRoute = server.routes.find(
+        (r) => r.pathTemplate === '/users/${p1}',
+      );
+      expect(getRoute).toBeDefined();
+      expect(getRoute!.pathParamNames).toEqual(['p1']);
+    });
+
+    it('should extract multiple path parameters', () => {
+      const server = createServer(testContract);
+      // Path with two params: /users/${userId}/posts/${postId} → template /users/${p1}/posts/${p2}
+      const postRoute = server.routes.find(
+        (r) => r.pathTemplate === '/users/${p1}/posts/${p2}',
+      );
+      expect(postRoute).toBeDefined();
+      expect(postRoute!.pathParamNames).toEqual(['p1', 'p2']);
+    });
+
+    it('should extract body schemas', () => {
+      const server = createServer(testContract);
+      const createRoute = server.routes.find(
+        (r) => r.pathTemplate === '/users' && r.method === 'POST',
+      );
+      expect(createRoute).toBeDefined();
+      expect(createRoute!.bodySchema).toBeDefined();
+      expect(typeof createRoute!.bodySchema!.parse).toBe('function');
+      expect(typeof createRoute!.bodySchema!.build).toBe('function');
+    });
+
+    it('should extract response schemas', () => {
+      const server = createServer(testContract);
+      const listRoute = server.routes.find(
+        (r) => r.pathTemplate === '/users' && r.method === 'GET',
+      );
+      expect(listRoute).toBeDefined();
+      expect(listRoute!.responseSchemas[200]).toBeDefined();
+      expect(typeof listRoute!.responseSchemas[200].parse).toBe('function');
+    });
+  });
+
+  describe('route matching', () => {
+    it('should match exact paths', () => {
+      const server = createServer(testContract);
+      const match = server.match('GET', '/users');
+      expect(match).not.toBeNull();
+      expect(match!.route.method).toBe('GET');
+      expect(match!.route.pathTemplate).toBe('/users');
+    });
+
+    it('should match paths with parameters', () => {
+      const server = createServer(testContract);
+      const match = server.match('GET', '/users/123');
+      expect(match).not.toBeNull();
+      expect(match!.params).toEqual({ p1: '123' });
+    });
+
+    it('should match paths with multiple parameters', () => {
+      const server = createServer(testContract);
+      const match = server.match('GET', '/users/456/posts/789');
+      expect(match).not.toBeNull();
+      expect(match!.params).toEqual({ p1: '456', p2: '789' });
+    });
+
+    it('should return null for unmatched paths', () => {
+      const server = createServer(testContract);
+      const match = server.match('GET', '/unknown');
+      expect(match).toBeNull();
+    });
+
+    it('should return null for wrong HTTP method', () => {
+      const server = createServer(testContract);
+      const match = server.match('DELETE', '/users');
+      expect(match).toBeNull();
+    });
+
+    it('should strip query strings', () => {
+      const server = createServer(testContract);
+      const match = server.match('GET', '/users?active=true');
+      expect(match).not.toBeNull();
+    });
+
+    it('should match with basePath prefix', () => {
+      const server = createServer(testContract);
+      const match = server.match('GET', '/api/v1/users/123', '/api/v1');
+      expect(match).not.toBeNull();
+      expect(match!.params).toEqual({ p1: '123' });
+    });
+  });
+});

--- a/packages/speci/src/rest/server/create-server.ts
+++ b/packages/speci/src/rest/server/create-server.ts
@@ -129,10 +129,7 @@ function buildPathInfo(
 
   // Build regex by replacing sentinels with capture groups
   const escaped = resolvedPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const regexStr = escaped.replaceAll(
-    new RegExp(PARAM_MARKER.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'),
-    '([^/]+)',
-  );
+  const regexStr = escaped.split(PARAM_MARKER).join('([^/]+)');
 
   // Build template by replacing sentinels with ${paramName} syntax
   let template = resolvedPath;

--- a/packages/speci/src/rest/server/create-server.ts
+++ b/packages/speci/src/rest/server/create-server.ts
@@ -114,7 +114,6 @@ function walkContract(
  */
 function buildPathInfo(
   resolvedPath: string,
-  paramCount: number,
 ): { regex: RegExp; template: string; paramNames: string[] } {
   // Count sentinel occurrences to determine parameter count
   const sentinelCount = (
@@ -175,11 +174,9 @@ export function createServer<T extends Record<string, any>>(
   const routes: RouteDefinition[] = endpoints.map(
     ({ operation, descriptor }) => {
       const resolvedPath = descriptor.path || '';
-      const paramCount = (operation as OperationFunction).length || 0;
 
       const { regex, template, paramNames } = buildPathInfo(
         resolvedPath,
-        paramCount,
       );
 
       // Extract body schema

--- a/packages/speci/src/rest/server/create-server.ts
+++ b/packages/speci/src/rest/server/create-server.ts
@@ -226,12 +226,10 @@ export function createServer<T extends Record<string, any>>(
     ): { route: RouteDefinition; params: Record<string, string> } | null {
       // Strip query string and base path
       const pathname = url.split('?')[0];
-      const relativePath = basePath
-        ? pathname.replace(
-            new RegExp(`^${basePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),
-            '',
-          ) || '/'
-        : pathname;
+      const relativePath =
+        basePath && pathname.startsWith(basePath)
+          ? pathname.slice(basePath.length) || '/'
+          : pathname;
 
       for (const route of routes) {
         const routeWithRegex = route as RouteDefinition & { _regex: RegExp };

--- a/packages/speci/src/rest/server/create-server.ts
+++ b/packages/speci/src/rest/server/create-server.ts
@@ -64,42 +64,43 @@ function isSerializable(schema: unknown): schema is Serializable {
  * Calls each operation function with a sentinel value to get the resolved
  * path, then replaces the sentinel with regex capture groups for matching.
  */
+function tryExtractEndpoint(
+  obj: OperationFunction,
+): { operation: OperationFunction; descriptor: RestEndpointDescriptor } | null {
+  try {
+    const paramCount = obj.length || 1;
+    const sentinelArgs = Array.from({ length: paramCount }, () => PARAM_MARKER);
+    const descriptor = obj(...sentinelArgs);
+    if (isEndpointDescriptor(descriptor)) {
+      return { operation: obj, descriptor };
+    }
+  } catch {
+    // Some functions may need different args - skip
+  }
+  return null;
+}
+
 function walkContract(
   obj: any,
   parentPath: string[],
 ): Array<{ operation: OperationFunction; descriptor: RestEndpointDescriptor }> {
-  const endpoints: Array<{
-    operation: OperationFunction;
-    descriptor: RestEndpointDescriptor;
-  }> = [];
-
   if (typeof obj === 'function') {
-    try {
-      // Call with sentinel values for all parameters to get the resolved path.
-      // The function's .length gives us the declared parameter count.
-      const paramCount = (obj as OperationFunction).length || 1;
-      const sentinelArgs = Array.from(
-        { length: paramCount },
-        () => PARAM_MARKER,
-      );
-      const descriptor = (obj as OperationFunction)(...sentinelArgs);
+    const result = tryExtractEndpoint(obj as OperationFunction);
+    return result ? [result] : [];
+  }
 
-      if (isEndpointDescriptor(descriptor)) {
-        endpoints.push({
-          operation: obj as OperationFunction,
-          descriptor,
-        });
-      }
-    } catch {
-      // Some functions may need different args - skip
-    }
-  } else if (typeof obj === 'object' && obj !== null) {
+  if (typeof obj === 'object' && obj !== null) {
+    const endpoints: Array<{
+      operation: OperationFunction;
+      descriptor: RestEndpointDescriptor;
+    }> = [];
     for (const [key, value] of Object.entries(obj)) {
       endpoints.push(...walkContract(value, [...parentPath, key]));
     }
+    return endpoints;
   }
 
-  return endpoints;
+  return [];
 }
 
 /**

--- a/packages/speci/src/rest/server/create-server.ts
+++ b/packages/speci/src/rest/server/create-server.ts
@@ -227,7 +227,10 @@ export function createServer<T extends Record<string, any>>(
       // Strip query string and base path
       const pathname = url.split('?')[0];
       const relativePath = basePath
-        ? pathname.replace(new RegExp(`^${basePath}`), '') || '/'
+        ? pathname.replace(
+            new RegExp(`^${basePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),
+            '',
+          ) || '/'
         : pathname;
 
       for (const route of routes) {

--- a/packages/speci/src/rest/server/create-server.ts
+++ b/packages/speci/src/rest/server/create-server.ts
@@ -117,9 +117,7 @@ function buildPathInfo(resolvedPath: string): {
   template: string;
   paramNames: string[];
 } {
-  const sentinelCount = (
-    resolvedPath.match(new RegExp(PARAM_MARKER, 'g')) || []
-  ).length;
+  const sentinelCount = resolvedPath.split(PARAM_MARKER).length - 1;
 
   // Generate parameter names (p1, p2, ... if we don't know the real names)
   const paramNames = Array.from(

--- a/packages/speci/src/rest/server/create-server.ts
+++ b/packages/speci/src/rest/server/create-server.ts
@@ -1,0 +1,253 @@
+/**
+ * Speci REST - Server Generator
+ *
+ * Creates server-ready route definitions from REST contracts.
+ *
+ * This is the server-side counterpart of createClient. It walks a contract
+ * tree, extracts endpoint definitions (method, path, body schema, response
+ * schemas), and returns structured route definitions that can be used to
+ * build HTTP servers with any framework (node:http, Express, Hono, etc.).
+ *
+ * @example
+ * ```typescript
+ * import { createServer } from '@abapify/speci/rest';
+ * import { adtContract } from '@abapify/adt-contracts';
+ *
+ * const server = createServer(adtContract);
+ *
+ * // Use with node:http
+ * import { createServer as httpCreate } from 'node:http';
+ *
+ * httpCreate((req, res) => {
+ *   const match = server.match(req.method!, req.url!);
+ *   if (match) {
+ *     // Forward to downstream SAP, handle JSON↔XML conversion, etc.
+ *   }
+ * });
+ * ```
+ */
+
+import type { OperationFunction } from '../../core/types';
+import type { RestEndpointDescriptor, Serializable } from '../types';
+import type { RouteDefinition, ServerRoutes } from './types';
+
+/** Sentinel value used to mark parameter positions in resolved paths */
+const PARAM_MARKER = '\x00';
+
+/**
+ * Check if a value is a RestEndpointDescriptor (has method and path)
+ */
+function isEndpointDescriptor(value: unknown): value is RestEndpointDescriptor {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'method' in value &&
+    'path' in value &&
+    'responses' in value
+  );
+}
+
+/**
+ * Check if a schema is Serializable (has parse method)
+ */
+function isSerializable(schema: unknown): schema is Serializable {
+  return (
+    typeof schema === 'object' &&
+    schema !== null &&
+    typeof (schema as any).parse === 'function'
+  );
+}
+
+/**
+ * Walk a contract tree and extract all endpoint definitions.
+ *
+ * Calls each operation function with a sentinel value to get the resolved
+ * path, then replaces the sentinel with regex capture groups for matching.
+ */
+function walkContract(
+  obj: any,
+  parentPath: string[],
+): Array<{ operation: OperationFunction; descriptor: RestEndpointDescriptor }> {
+  const endpoints: Array<{
+    operation: OperationFunction;
+    descriptor: RestEndpointDescriptor;
+  }> = [];
+
+  if (typeof obj === 'function') {
+    try {
+      // Call with sentinel values for all parameters to get the resolved path.
+      // The function's .length gives us the declared parameter count.
+      const paramCount = (obj as OperationFunction).length || 1;
+      const sentinelArgs = Array.from(
+        { length: paramCount },
+        () => PARAM_MARKER,
+      );
+      const descriptor = (obj as OperationFunction)(...sentinelArgs);
+
+      if (isEndpointDescriptor(descriptor)) {
+        endpoints.push({
+          operation: obj as OperationFunction,
+          descriptor,
+        });
+      }
+    } catch {
+      // Some functions may need different args - skip
+    }
+  } else if (typeof obj === 'object' && obj !== null) {
+    for (const [key, value] of Object.entries(obj)) {
+      endpoints.push(...walkContract(value, [...parentPath, key]));
+    }
+  }
+
+  return endpoints;
+}
+
+/**
+ * Convert a resolved path with sentinel markers into a regex pattern.
+ *
+ * Also extracts path parameter names from the original function's parameter list.
+ *
+ * @example
+ * // For path '/users/\x00/posts/\x00' with param names ['userId', 'postId']
+ * // Returns: /\/users\/([^/]+)\/posts\/([^/]+)/
+ */
+function buildPathInfo(
+  resolvedPath: string,
+  paramCount: number,
+): { regex: RegExp; template: string; paramNames: string[] } {
+  // Count sentinel occurrences to determine parameter count
+  const sentinelCount = (
+    resolvedPath.match(new RegExp(PARAM_MARKER, 'g')) || []
+  ).length;
+
+  // Generate parameter names (p1, p2, ... if we don't know the real names)
+  const paramNames = Array.from(
+    { length: sentinelCount },
+    (_, i) => `p${i + 1}`,
+  );
+
+  // Build regex by replacing sentinels with capture groups
+  const escaped = resolvedPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const regexStr = escaped.replaceAll(
+    new RegExp(PARAM_MARKER.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'),
+    '([^/]+)',
+  );
+
+  // Build template by replacing sentinels with ${paramName} syntax
+  let template = resolvedPath;
+  for (const name of paramNames) {
+    template = template.replace(PARAM_MARKER, `\${${name}}`);
+  }
+
+  return {
+    regex: new RegExp(`^${regexStr}$`),
+    template,
+    paramNames,
+  };
+}
+
+/**
+ * Create server-ready route definitions from a REST contract.
+ *
+ * Walks the contract tree, extracts endpoint definitions, and returns
+ * structured route definitions with:
+ * - HTTP method and path
+ * - Body schema for request conversion (JSON→XML)
+ * - Response schemas for response conversion (XML→JSON)
+ * - Path parameter extraction
+ *
+ * @example
+ * ```typescript
+ * const server = createServer(adtContract);
+ *
+ * // Match an incoming request
+ * const match = server.match('GET', '/sap/bc/adt/cts/transportrequests/DEVK900001');
+ * if (match) {
+ *   console.log(match.route.method);     // 'GET'
+ *   console.log(match.params);           // { p1: 'devk900001' }
+ *   console.log(match.route.responseSchemas[200]); // Serializable schema
+ * }
+ * ```
+ */
+export function createServer<T extends Record<string, any>>(
+  contract: T,
+): ServerRoutes {
+  const endpoints = walkContract(contract, []);
+
+  const routes: RouteDefinition[] = endpoints.map(
+    ({ operation, descriptor }) => {
+      const resolvedPath = descriptor.path || '';
+      const paramCount = (operation as OperationFunction).length || 0;
+
+      const { regex, template, paramNames } = buildPathInfo(
+        resolvedPath,
+        paramCount,
+      );
+
+      // Extract body schema
+      const bodySchema =
+        descriptor.body && isSerializable(descriptor.body)
+          ? descriptor.body
+          : undefined;
+
+      // Extract response schemas (only those that are Serializable)
+      const responseSchemas: Record<number, Serializable> = {};
+      if (descriptor.responses) {
+        for (const [status, schema] of Object.entries(descriptor.responses)) {
+          if (isSerializable(schema)) {
+            responseSchemas[Number(status)] = schema;
+          }
+        }
+      }
+
+      return {
+        method: descriptor.method,
+        path: resolvedPath,
+        pathTemplate: template,
+        pathParamNames: paramNames,
+        bodySchema,
+        responseSchemas,
+        requestHeaders: descriptor.headers as
+          | Record<string, string>
+          | undefined,
+        _regex: regex,
+      } as RouteDefinition & { _regex: RegExp };
+    },
+  );
+
+  return {
+    routes,
+
+    match(
+      method: string,
+      url: string,
+      basePath = '',
+    ): { route: RouteDefinition; params: Record<string, string> } | null {
+      // Strip query string and base path
+      const pathname = url.split('?')[0];
+      const relativePath = basePath
+        ? pathname.replace(new RegExp(`^${basePath}`), '') || '/'
+        : pathname;
+
+      for (const route of routes) {
+        const routeWithRegex = route as RouteDefinition & { _regex: RegExp };
+
+        // Skip if method doesn't match
+        if (route.method !== method.toUpperCase()) continue;
+
+        // Try to match the path
+        const match = relativePath.match(routeWithRegex._regex);
+        if (match) {
+          // Build params object from capture groups
+          const params: Record<string, string> = {};
+          for (let i = 0; i < route.pathParamNames.length; i++) {
+            params[route.pathParamNames[i]] = match[i + 1] || '';
+          }
+          return { route, params };
+        }
+      }
+
+      return null;
+    },
+  };
+}

--- a/packages/speci/src/rest/server/create-server.ts
+++ b/packages/speci/src/rest/server/create-server.ts
@@ -112,10 +112,11 @@ function walkContract(
  * // For path '/users/\x00/posts/\x00' with param names ['userId', 'postId']
  * // Returns: /\/users\/([^/]+)\/posts\/([^/]+)/
  */
-function buildPathInfo(
-  resolvedPath: string,
-): { regex: RegExp; template: string; paramNames: string[] } {
-  // Count sentinel occurrences to determine parameter count
+function buildPathInfo(resolvedPath: string): {
+  regex: RegExp;
+  template: string;
+  paramNames: string[];
+} {
   const sentinelCount = (
     resolvedPath.match(new RegExp(PARAM_MARKER, 'g')) || []
   ).length;
@@ -175,9 +176,7 @@ export function createServer<T extends Record<string, any>>(
     ({ operation, descriptor }) => {
       const resolvedPath = descriptor.path || '';
 
-      const { regex, template, paramNames } = buildPathInfo(
-        resolvedPath,
-      );
+      const { regex, template, paramNames } = buildPathInfo(resolvedPath);
 
       // Extract body schema
       const bodySchema =
@@ -218,23 +217,19 @@ export function createServer<T extends Record<string, any>>(
       url: string,
       basePath = '',
     ): { route: RouteDefinition; params: Record<string, string> } | null {
-      // Strip query string and base path
       const pathname = url.split('?')[0];
-      const relativePath =
-        basePath && pathname.startsWith(basePath)
-          ? pathname.slice(basePath.length) || '/'
-          : pathname;
+      let relativePath = pathname;
+      if (basePath && pathname.startsWith(basePath)) {
+        relativePath = pathname.slice(basePath.length) || '/';
+      }
 
+      const targetMethod = method.toUpperCase();
       for (const route of routes) {
+        if (route.method !== targetMethod) continue;
+
         const routeWithRegex = route as RouteDefinition & { _regex: RegExp };
-
-        // Skip if method doesn't match
-        if (route.method !== method.toUpperCase()) continue;
-
-        // Try to match the path
         const match = relativePath.match(routeWithRegex._regex);
         if (match) {
-          // Build params object from capture groups
           const params: Record<string, string> = {};
           for (let i = 0; i < route.pathParamNames.length; i++) {
             params[route.pathParamNames[i]] = match[i + 1] || '';

--- a/packages/speci/src/rest/server/index.ts
+++ b/packages/speci/src/rest/server/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Speci REST - Server Module
+ *
+ * Server-side contract-to-route generation.
+ * This is the counterpart of the client module - it takes contracts
+ * and generates route definitions for HTTP servers.
+ *
+ * @example
+ * ```typescript
+ * import { createServer } from '@abapify/speci/rest/server';
+ *
+ * const server = createServer(myContract);
+ *
+ * // Match incoming requests
+ * const match = server.match('GET', '/api/users/123');
+ * if (match) {
+ *   // match.route - RouteDefinition with schemas
+ *   // match.params - { id: '123' }
+ * }
+ * ```
+ */
+
+export { createServer } from './create-server';
+export type {
+  RouteDefinition,
+  ServerRequest,
+  ServerResponse,
+  ServerHandler,
+  RouteContext,
+  ServerConfig,
+  ServerRoutes,
+} from './types';

--- a/packages/speci/src/rest/server/types.ts
+++ b/packages/speci/src/rest/server/types.ts
@@ -1,0 +1,117 @@
+/**
+ * Speci REST - Server Types
+ *
+ * Framework-agnostic types for generating servers from REST contracts.
+ */
+
+import type {
+  Serializable,
+  RestEndpointDescriptor,
+  ResponseMap,
+} from '../types';
+
+/**
+ * HTTP server request (abstraction over node:http IncomingMessage, Web Request, etc.)
+ */
+export interface ServerRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string | string[] | undefined>;
+  body?: string;
+  query: Record<string, string>;
+}
+
+/**
+ * HTTP server response (abstraction over node:http ServerResponse, Web Response, etc.)
+ */
+export interface ServerResponse {
+  status: number;
+  headers: Record<string, string>;
+  body?: string;
+}
+
+/**
+ * Extracted route definition from a contract endpoint.
+ *
+ * Contains all the information needed to register an HTTP route
+ * and perform content negotiation (JSON↔XML conversion).
+ */
+export interface RouteDefinition {
+  /** HTTP method (GET, POST, PUT, DELETE, etc.) */
+  method: string;
+
+  /** Resolved path pattern (e.g., '/sap/bc/adt/oo/classes/myclass') */
+  path: string;
+
+  /** Original path template before parameter resolution (e.g., '/sap/bc/adt/oo/classes/${name}') */
+  pathTemplate: string;
+
+  /** Path parameter names extracted from the template */
+  pathParamNames: string[];
+
+  /** Request body schema (for JSON↔XML conversion of request bodies) */
+  bodySchema?: Serializable;
+
+  /** Response schemas keyed by HTTP status code */
+  responseSchemas: Record<number, Serializable>;
+
+  /** Expected request headers */
+  requestHeaders?: Record<string, string>;
+
+  /** Response headers to include */
+  responseHeaders?: Record<string, string>;
+}
+
+/**
+ * Server handler function for a route.
+ *
+ * Receives the parsed request and route context, returns a response.
+ */
+export type ServerHandler = (
+  request: ServerRequest,
+  context: RouteContext,
+) => Promise<ServerResponse> | ServerResponse;
+
+/**
+ * Context provided to route handlers
+ */
+export interface RouteContext {
+  /** The matched route definition */
+  route: RouteDefinition;
+
+  /** Extracted path parameters (e.g., { name: 'myclass' }) */
+  params: Record<string, string>;
+
+  /** The original contract operation function */
+  operation: (...args: any[]) => RestEndpointDescriptor;
+}
+
+/**
+ * Configuration for createServer
+ */
+export interface ServerConfig {
+  /**
+   * Base URL prefix to strip from incoming requests before matching.
+   * For example, if your proxy is mounted at '/api/v1', set this to '/api/v1'.
+   * Defaults to '' (match against full path).
+   */
+  basePath?: string;
+}
+
+/**
+ * Result of createServer - a list of route definitions
+ */
+export interface ServerRoutes {
+  /** All extracted route definitions */
+  routes: RouteDefinition[];
+
+  /**
+   * Match an incoming request to a route definition.
+   * Returns the matched route and extracted path parameters, or null.
+   */
+  match(
+    method: string,
+    url: string,
+    basePath?: string,
+  ): { route: RouteDefinition; params: Record<string, string> } | null;
+}

--- a/packages/speci/src/rest/server/types.ts
+++ b/packages/speci/src/rest/server/types.ts
@@ -4,11 +4,7 @@
  * Framework-agnostic types for generating servers from REST contracts.
  */
 
-import type {
-  Serializable,
-  RestEndpointDescriptor,
-  ResponseMap,
-} from '../types';
+import type { Serializable, RestEndpointDescriptor } from '../types';
 
 /**
  * HTTP server request (abstraction over node:http IncomingMessage, Web Request, etc.)


### PR DESCRIPTION
## **User description**
## Summary

This PR adds an ADT proxy server with automatic JSON↔XML conversion to the abapify/adt-cli monorepo.

### What's included:

1. **`@abapify/speci` - `createServer()` function** (`packages/speci/src/rest/server/`)
   - Framework-agnostic server-side contract route extraction
   - Walks contract trees and extracts route definitions (method, path, body schema, response schemas)
   - Provides URL pattern matching against extracted routes
   - Counterpart to the existing `createClient()` function

2. **`@abapify/adt-proxy` - New package** (`packages/adt-proxy/`)
   - ADT proxy server implementation using speci's `createServer`
   - Automatic JSON→XML conversion for request bodies using schema `build()` methods
   - Automatic XML→JSON conversion for responses using schema `parse()` methods
   - Transparent proxying for unmatched routes
   - Configurable target URL, auth, base path, and conversion options

3. **`adt proxy` CLI command** (`packages/adt-cli/`)
   - New CLI command to start the proxy server
   - Uses current auth session or accepts explicit target URL
   - Supports `--port`, `--host`, `--target`, `--base-path`, `--no-convert` options

### Architecture

```
Client (JSON) → Proxy Server → Downstream SAP (XML)
Client (JSON) ← Proxy Server ← Downstream SAP (XML)
```

The proxy leverages the existing contract definitions and schema `parse()`/`build()` methods to automatically convert between JSON and XML. This means:

- JSON request bodies are converted to XML using the contract's body schema
- XML responses are converted to JSON using the contract's response schemas
- Unmatched routes are forwarded as-is (transparent proxy mode)

### Usage

```bash
# Start proxy using current auth session
npx adt proxy

# Start proxy with explicit target
npx adt proxy --target https://sap-system:8000 --port 3000

# Disable JSON↔XML conversion (pure proxy)
npx adt proxy --no-convert
```

```typescript
// Programmatic usage
import { createAdtProxy } from '@abapify/adt-proxy';

const proxy = createAdtProxy({
  targetUrl: 'https://sap-system:8000',
  auth: { username: 'user', password: 'pass', client: '100' },
});

const { port } = await proxy.start();
```

### Tests

- 13 tests for `speci/rest/server` (route extraction and matching)
- 15 tests for `adt-proxy` converter module
- All builds pass for affected packages

### Next Steps

This PR sets the foundation for:
- **Mock server** - The proxy can be extended to serve mock responses based on contract schemas
- **Contract-based routing** - Full route matching with path parameter extraction
- **Content negotiation** - Automatic Accept/Content-Type header handling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@abapify/adt-proxy`, a schema‑aware ADT proxy that converts JSON↔XML, plus an `adt proxy` CLI and `createServer()` in `@abapify/speci` for server‑side route extraction. Improves security, routing, and header handling with body-size limits, timeouts, safe base paths, and correct `Set-Cookie` forwarding.

- **New Features**
  - `@abapify/adt-proxy`: Converts JSON bodies to XML and XML responses to JSON via schema `build`/`parse`; forwards unmatched routes; configurable target/auth/base path/conversion/forwarding/`maxBodySize` (default 10MB); programmatic API; exports `jsonToXml`/`xmlToJson`.
  - `adt proxy` CLI: Start the proxy with `--port`, `--host`, `--target`, `--base-path`, `--no-convert`, `--no-forward-unknown`, `--max-body-size`, `--verbose`; uses current auth session when `--target` is omitted; prints discovered routes; graceful shutdown.
  - `@abapify/speci/rest/server`: `createServer()` extracts routes (method, path, body/response schemas) from contracts and provides URL matching for schema‑aware proxying.

- **Bug Fixes**
  - Security and reliability: enforce `maxBodySize` (10MB default) with stream error handling; 30s downstream fetch timeout; register server `error` before `listen()`; robust port validation and auth/session guards; CI fallback with `--no-cloud` when `NX_CLOUD_ACCESS_TOKEN` is missing.
  - Routing and headers: matched routes always forward with contract `requestHeaders` even when conversion is disabled; safe base‑path checks with `startsWith`/`slice`; simpler path‑param handling via `split`/`join`; correct multi‑value headers, including `Set-Cookie` via `getSetCookie()` and skipping `set-cookie` in header iteration to avoid cookie corruption; do not forward client `Authorization` when proxy auth is set.
  - Content handling and cleanup: case‑insensitive content‑type checks; select response schema by `response.status`; only mark responses as converted when body changes; add `--verbose` logging; remove unused `fast-xml-parser`; reduce matcher complexity in `createServer()`.

<sup>Written for commit 937754a4d8bec924ad1788236bd43e57c8a70781. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `proxy` CLI command to start an ADT proxy server with JSON↔XML conversion.
  * Supports configurable host/port and optional target URL, including base-path handling and forwarding for unknown routes.
  * Automatically derives authentication from the active session (basic credentials or cookie-based auth).
  * Includes graceful shutdown and verbose logging, plus helpful route guidance on startup.
* **Tests**
  * Added converter and REST server routing tests to validate JSON/XML conversion and request matching.
* **Chores**
  * Improved CI behavior to avoid cloud steps when credentials are not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add an ADT proxy command that forwards requests to SAP with automatic JSON↔XML conversion**

### What Changed
- Added a new `adt proxy` command to start a local ADT proxy server, with options for target URL, host, port, base path, body size limit, and turning conversion off
- The proxy now converts JSON request bodies to XML for supported ADT routes, and converts XML responses back to JSON when a matching schema is available
- Unmatched routes can be forwarded as-is, or returned as 404 when forwarding is disabled
- Authentication from the current session is now carried through to the downstream SAP system, including cookie-based sessions and explicit target overrides
- Added route extraction support in `speci` so server code can match incoming requests against ADT contract paths

### Impact
`✅ Easier local testing against SAP systems`
`✅ Fewer manual JSON/XML conversions`
`✅ Clearer proxy startup and forwarding behavior` 
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
