### PR TITLE
chore: remove internal references from source files and docs

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,7 @@
 # Guard: block committing bun.lock entries that contain the corporate JFrog URL.
 # This protects the public repo from accidental leakage of internal mirror URLs.
 if git diff --cached --name-only | grep -qx "bun.lock"; then
-  if git diff --cached bun.lock | grep -qE "jfrog"; then
+  if git show :bun.lock | grep -qE "jfrog"; then
     echo "refusing to commit: bun.lock contains corporate mirror URLs (jfrog)." >&2
     echo "unstage with: git restore --staged bun.lock" >&2
     exit 1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,8 +1,8 @@
 # Guard: block committing bun.lock entries that contain the corporate JFrog URL.
 # This protects the public repo from accidental leakage of internal mirror URLs.
 if git diff --cached --name-only | grep -qx "bun.lock"; then
-  if git diff --cached bun.lock | grep -qE "jfrog|booking\.com"; then
-    echo "refusing to commit: bun.lock contains corporate mirror URLs (jfrog/booking.com)." >&2
+  if git diff --cached bun.lock | grep -qE "jfrog"; then
+    echo "refusing to commit: bun.lock contains corporate mirror URLs (jfrog)." >&2
     echo "unstage with: git restore --staged bun.lock" >&2
     exit 1
   fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -523,7 +523,7 @@
 - decommission old transport commands, add cts tr commands, adt-tui package ([f84a58a](https://github.com/abapify/adt-cli/commit/f84a58a))
 - **adk:** enhance ADK package with class and interface support, update dependencies and build process ([75777b9](https://github.com/abapify/adt-cli/commit/75777b9))
 - **adk:** implement ADT XML parsing for ABAP objects ([c26a781](https://github.com/abapify/adt-cli/commit/c26a781))
-- **adk:** implement ADK architecture alignment with lazy loading [FSINN-1667] ([b3a52fa](https://github.com/abapify/adt-cli/commit/b3a52fa))
+- **adk:** implement ADK architecture alignment with lazy loading ([b3a52fa](https://github.com/abapify/adt-cli/commit/b3a52fa))
 - **adt-cli:** add ADT XML export option to get command ([9ec3e2b](https://github.com/abapify/adt-cli/commit/9ec3e2b))
 - **adt-cli:** add object structure option to get command ([a12dcd5](https://github.com/abapify/adt-cli/commit/a12dcd5))
 - **adt-cli:** enhance get command with object structure display for classes ([d318d1a](https://github.com/abapify/adt-cli/commit/d318d1a))

--- a/openspec/changes/add-exact-source-history/design.md
+++ b/openspec/changes/add-exact-source-history/design.md
@@ -42,7 +42,7 @@ ADT source history is link-driven. Object metadata describes one or more source 
 
 **Decision**: every manifest leaf represents one source component, not one repository object. A class can therefore produce definitions, implementations, macros, testclasses, and main leaves, each with independent provenance.
 
-**Rationale**: live D01 metadata proves those sections are independently versioned. Collapsing them to one object version would produce false before/after pairs.
+**Rationale**: live TRL metadata proves those sections are independently versioned. Collapsing them to one object version would produce false before/after pairs.
 
 ### 3a. Root requests expand to concrete task provenance
 
@@ -144,7 +144,7 @@ Names are illustrative; final exported schemas remain additive and versionable.
 3. ADK fixture tests for selection rules and composite components.
 4. CLI/MCP parity tests over the same fixtures.
 5. Targeted build, test, lint, and typecheck for affected projects with existing baseline failures reported separately.
-6. After credential rotation, one safe D01 smoke test that records only identities, counts, status codes, and hashes—not source.
+6. After credential rotation, one safe TRL smoke test that records only identities, counts, status codes, and hashes—not source.
 
 ## Open Questions
 

--- a/openspec/changes/add-exact-source-history/design.md
+++ b/openspec/changes/add-exact-source-history/design.md
@@ -9,7 +9,7 @@ ADT source history is link-driven. Object metadata describes one or more source 
 **Goals:**
 
 - Typed retrieval of an Atom source-version feed through the normal ADT adapter/session stack.
-- Normalized, immutable version records suitable for SDK, CLI, MCP, ARM, and CI consumers.
+- Normalized, immutable version records suitable for SDK, CLI, MCP, ADT, and CI consumers.
 - Per-component transport manifests that select the version immediately before the earliest in-scope change and the latest in-scope version.
 - Explicit exactness and failure states for new, deleted, renamed, unsupported, and non-contiguous histories.
 - Lazy historical source reads: manifest creation does not download every source body.
@@ -42,7 +42,7 @@ ADT source history is link-driven. Object metadata describes one or more source 
 
 **Decision**: every manifest leaf represents one source component, not one repository object. A class can therefore produce definitions, implementations, macros, testclasses, and main leaves, each with independent provenance.
 
-**Rationale**: live BHF metadata proves those sections are independently versioned. Collapsing them to one object version would produce false before/after pairs.
+**Rationale**: live D01 metadata proves those sections are independently versioned. Collapsing them to one object version would produce false before/after pairs.
 
 ### 3a. Root requests expand to concrete task provenance
 
@@ -144,7 +144,7 @@ Names are illustrative; final exported schemas remain additive and versionable.
 3. ADK fixture tests for selection rules and composite components.
 4. CLI/MCP parity tests over the same fixtures.
 5. Targeted build, test, lint, and typecheck for affected projects with existing baseline failures reported separately.
-6. After credential rotation, one safe BHF smoke test that records only identities, counts, status codes, and hashes—not source.
+6. After credential rotation, one safe D01 smoke test that records only identities, counts, status codes, and hashes—not source.
 
 ## Open Questions
 

--- a/openspec/changes/add-exact-source-history/proposal.md
+++ b/openspec/changes/add-exact-source-history/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-Transport review needs the exact source state introduced by a transport, not only the object's current active or inactive source. SAP ADT object metadata exposes per-source-component `relations/versions` links, and a read-only BHF probe confirmed that those links return Atom feeds whose entries reference immutable historical content and the responsible transport.
+Transport review needs the exact source state introduced by a transport, not only the object's current active or inactive source. SAP ADT object metadata exposes per-source-component `relations/versions` links, and a read-only D01 probe confirmed that those links return Atom feeds whose entries reference immutable historical content and the responsible transport.
 
 The repository currently has no typed way to list those entries, read an immutable historical source, or resolve a transport into a per-component before/after manifest. Callers therefore cannot prove a delta and are forced to compare against mutable current state.
 
@@ -34,8 +34,8 @@ The repository currently has no typed way to list those entries, read an immutab
 
 ## Preconditions and Evidence
 
-- Observed in BHF: a program version feed returned 29 immutable entries; historical content was verified by hash and length only.
-- Observed in BHF: a class exposes independently versioned definitions, implementations, macros, testclasses, and main components.
+- Observed in D01: a program version feed returned 29 immutable entries; historical content was verified by hash and length only.
+- Observed in D01: a class exposes independently versioned definitions, implementations, macros, testclasses, and main components.
 - Existing generated `atomFeed` schema is sufficient and MUST be reused rather than edited.
-- Live regression verification remains conditional on valid rotated BHF credentials. Fixture-based tests and package builds are mandatory regardless.
+- Live regression verification remains conditional on valid rotated D01 credentials. Fixture-based tests and package builds are mandatory regardless.
 - Baseline workspace typecheck/lint failures that predate this change are recorded separately; validation MUST distinguish new failures from baseline failures.

--- a/openspec/changes/add-exact-source-history/proposal.md
+++ b/openspec/changes/add-exact-source-history/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-Transport review needs the exact source state introduced by a transport, not only the object's current active or inactive source. SAP ADT object metadata exposes per-source-component `relations/versions` links, and a read-only D01 probe confirmed that those links return Atom feeds whose entries reference immutable historical content and the responsible transport.
+Transport review needs the exact source state introduced by a transport, not only the object's current active or inactive source. SAP ADT object metadata exposes per-source-component `relations/versions` links, and a read-only TRL probe confirmed that those links return Atom feeds whose entries reference immutable historical content and the responsible transport.
 
 The repository currently has no typed way to list those entries, read an immutable historical source, or resolve a transport into a per-component before/after manifest. Callers therefore cannot prove a delta and are forced to compare against mutable current state.
 
@@ -34,8 +34,8 @@ The repository currently has no typed way to list those entries, read an immutab
 
 ## Preconditions and Evidence
 
-- Observed in D01: a program version feed returned 29 immutable entries; historical content was verified by hash and length only.
-- Observed in D01: a class exposes independently versioned definitions, implementations, macros, testclasses, and main components.
+- Observed in TRL: a program version feed returned 29 immutable entries; historical content was verified by hash and length only.
+- Observed in TRL: a class exposes independently versioned definitions, implementations, macros, testclasses, and main components.
 - Existing generated `atomFeed` schema is sufficient and MUST be reused rather than edited.
-- Live regression verification remains conditional on valid rotated D01 credentials. Fixture-based tests and package builds are mandatory regardless.
+- Live regression verification remains conditional on valid rotated TRL credentials. Fixture-based tests and package builds are mandatory regardless.
 - Baseline workspace typecheck/lint failures that predate this change are recorded separately; validation MUST distinguish new failures from baseline failures.

--- a/openspec/changes/add-exact-source-history/tasks.md
+++ b/openspec/changes/add-exact-source-history/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Contract and fixture foundation
 
-- [ ] 1.1 Add sanitized Atom version-feed fixtures for a program and composite class; do not copy real source or credentials. Blocked until the exposed BHF ADT credential is rotated; repository rules require fixtures derived from real SAP responses rather than fabricated XML.
+- [ ] 1.1 Add sanitized Atom version-feed fixtures for a program and composite class; do not copy real source or credentials. Blocked until the exposed D01 ADT credential is rotated; repository rules require fixtures derived from real SAP responses rather than fabricated XML.
 - [x] 1.2 Add repository source-history contracts in `adt-contracts` for a link-provided versions URI and immutable source URI.
 - [x] 1.3 Reuse the generated `atomFeed` schema and add descriptor tests for path, Accept header, response schema, and URI validation.
 - [x] 1.4 Export the additive contract through the repository and root contract trees.
@@ -45,4 +45,4 @@
 - [ ] 6.3 Run targeted Nx builds for `adt-contracts`, `adt-client`, `adk`, `adt-cli`, and `adt-mcp` with `--skipSync` if workspace references are stale.
 - [ ] 6.4 Run targeted lint/typecheck and distinguish pre-existing baseline failures from regressions.
 - [ ] 6.5 Run `git diff --check` and inspect generated declarations/exports.
-- [ ] 6.6 After BHF credentials are rotated, run one read-only smoke test and record only counts, identifiers, statuses, and content hashes.
+- [ ] 6.6 After D01 credentials are rotated, run one read-only smoke test and record only counts, identifiers, statuses, and content hashes.

--- a/openspec/changes/add-exact-source-history/tasks.md
+++ b/openspec/changes/add-exact-source-history/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Contract and fixture foundation
 
-- [ ] 1.1 Add sanitized Atom version-feed fixtures for a program and composite class; do not copy real source or credentials. Blocked until the exposed D01 ADT credential is rotated; repository rules require fixtures derived from real SAP responses rather than fabricated XML.
+- [ ] 1.1 Add sanitized Atom version-feed fixtures for a program and composite class; do not copy real source or credentials. Blocked until the exposed TRL ADT credential is rotated; repository rules require fixtures derived from real SAP responses rather than fabricated XML.
 - [x] 1.2 Add repository source-history contracts in `adt-contracts` for a link-provided versions URI and immutable source URI.
 - [x] 1.3 Reuse the generated `atomFeed` schema and add descriptor tests for path, Accept header, response schema, and URI validation.
 - [x] 1.4 Export the additive contract through the repository and root contract trees.
@@ -45,4 +45,4 @@
 - [ ] 6.3 Run targeted Nx builds for `adt-contracts`, `adt-client`, `adk`, `adt-cli`, and `adt-mcp` with `--skipSync` if workspace references are stale.
 - [ ] 6.4 Run targeted lint/typecheck and distinguish pre-existing baseline failures from regressions.
 - [ ] 6.5 Run `git diff --check` and inspect generated declarations/exports.
-- [ ] 6.6 After D01 credentials are rotated, run one read-only smoke test and record only counts, identifiers, statuses, and content hashes.
+- [ ] 6.6 After TRL credentials are rotated, run one read-only smoke test and record only counts, identifiers, statuses, and content hashes.

--- a/openspec/specs/adt-cli/adt-response-logging.md
+++ b/openspec/specs/adt-cli/adt-response-logging.md
@@ -32,15 +32,15 @@ All logging flags use `--log-*` prefix for consistency:
 
 ```bash
 # Basic logging (console only)
-npx adt import transport D01K900103 --log-level=debug
+npx adt import transport TRLK900103 --log-level=debug
 
 # Save responses to files
-npx adt import transport D01K900103 \
+npx adt import transport TRLK900103 \
   --log-output=./tmp/logs \
   --log-response-files
 
 # Full debugging
-npx adt import transport D01K900103 \
+npx adt import transport TRLK900103 \
   --log-level=trace \
   --log-output=./tmp/logs \
   --log-response-files
@@ -179,7 +179,7 @@ Logged responses can be directly used as test fixtures:
 
 ```bash
 # Run with logging
-npx adt import transport D01K900103 \
+npx adt import transport TRLK900103 \
   --log-output=./tmp/logs \
   --log-response-files
 

--- a/openspec/specs/adt-cli/adt-response-logging.md
+++ b/openspec/specs/adt-cli/adt-response-logging.md
@@ -32,15 +32,15 @@ All logging flags use `--log-*` prefix for consistency:
 
 ```bash
 # Basic logging (console only)
-npx adt import transport BHFK900103 --log-level=debug
+npx adt import transport D01K900103 --log-level=debug
 
 # Save responses to files
-npx adt import transport BHFK900103 \
+npx adt import transport D01K900103 \
   --log-output=./tmp/logs \
   --log-response-files
 
 # Full debugging
-npx adt import transport BHFK900103 \
+npx adt import transport D01K900103 \
   --log-level=trace \
   --log-output=./tmp/logs \
   --log-response-files
@@ -179,7 +179,7 @@ Logged responses can be directly used as test fixtures:
 
 ```bash
 # Run with logging
-npx adt import transport BHFK900103 \
+npx adt import transport D01K900103 \
   --log-output=./tmp/logs \
   --log-response-files
 

--- a/packages/adk/src/base/global-context.ts
+++ b/packages/adk/src/base/global-context.ts
@@ -10,10 +10,10 @@
  *   initializeAdk(client);
  *
  *   // Then use ADK objects without passing context
- *   const transport = await AdkTransportRequest.get('S0DK900001');
+ *   const transport = await AdkTransportRequest.get('TRLK900001');
  *
  * For testing or multi-connection scenarios, you can still pass explicit context:
- *   const transport = await AdkTransportRequest.get('S0DK900001', customCtx);
+ *   const transport = await AdkTransportRequest.get('TRLK900001', customCtx);
  */
 
 import type { AdkContext } from './context';
@@ -49,7 +49,7 @@ let globalContext: AdkContext | null = null;
  * initializeAdk(client);
  *
  * // Now ADK objects work without context
- * const transport = await AdkTransportRequest.get('S0DK900001');
+ * const transport = await AdkTransportRequest.get('TRLK900001');
  * ```
  */
 export function initializeAdk(

--- a/packages/adk/src/base/model.ts
+++ b/packages/adk/src/base/model.ts
@@ -592,7 +592,7 @@ export abstract class AdkObject<K extends AdkKind = AdkKind, D = any> {
     try {
       // SAP can resolve a development task to its parent request during LOCK.
       // Subsequent PUTs must use that authoritative CORRNR rather than the
-      // caller's task number (D01 rejects the task even with a valid handle).
+      // caller's task number (TRL rejects the task even with a valid handle).
       const effectiveTransport =
         this._lockHandle?.correlationNumber || transport;
 

--- a/packages/adk/src/base/model.ts
+++ b/packages/adk/src/base/model.ts
@@ -592,7 +592,7 @@ export abstract class AdkObject<K extends AdkKind = AdkKind, D = any> {
     try {
       // SAP can resolve a development task to its parent request during LOCK.
       // Subsequent PUTs must use that authoritative CORRNR rather than the
-      // caller's task number (BHF rejects the task even with a valid handle).
+      // caller's task number (D01 rejects the task even with a valid handle).
       const effectiveTransport =
         this._lockHandle?.correlationNumber || transport;
 

--- a/packages/adk/src/objects/cts/transport/transport.ts
+++ b/packages/adk/src/objects/cts/transport/transport.ts
@@ -458,7 +458,7 @@ export class AdkTransportRequest extends AdkObject<
   /**
    * Get a transport request by number
    *
-   * @param number - Transport number (e.g., 'S0DK900001')
+   * @param number - Transport number (e.g., 'TRLK900001')
    * @param ctx - Optional ADK context (uses global context if not provided)
    */
   static async get(
@@ -631,7 +631,7 @@ export class AdkTransportTask extends AdkTransportRequest {
   /**
    * Get a transport task by number
    *
-   * @param number - Task number (e.g., 'S0DK900001')
+   * @param number - Task number (e.g., 'TRLK900001')
    * @param ctx - Optional ADK context (uses global context if not provided)
    */
   static override async get(

--- a/packages/adk/src/objects/cts/transport/transport.types.ts
+++ b/packages/adk/src/objects/cts/transport/transport.types.ts
@@ -15,8 +15,8 @@
  *     └── abap_object[] - objects in this task
  *
  * Key insight:
- * - Fetching REQUEST (S0DK942970): objects in response.request.task[].abap_object
- * - Fetching TASK (S0DK942971): objects in response.task[].abap_object
+ * - Fetching REQUEST (TRLK942970): objects in response.request.task[].abap_object
+ * - Fetching TASK (TRLK942971): objects in response.task[].abap_object
  */
 
 import type { TransportGetResponse } from '../../../base/adt';

--- a/packages/adk/tests/transport-source-manifest.test.ts
+++ b/packages/adk/tests/transport-source-manifest.test.ts
@@ -611,15 +611,15 @@ describe('buildTransportSourceManifest', () => {
       pgmid: 'LIMU',
       metadata: rootSourceMetadata(),
     });
-    mockResolution([object], ['BHFK900236'], ['BHFK900103', 'BHFK900236']);
-    const head = version('00002', 0, ['BHFK900236']);
-    const base = version('00001', 1, ['BHFK900100']);
+    mockResolution([object], ['D01K900236'], ['D01K900103', 'D01K900236']);
+    const head = version('00002', 0, ['D01K900236']);
+    const base = version('00001', 1, ['D01K900100']);
     const { ctx } = contextWithVersions(
       vi.fn().mockResolvedValue([head, base]),
     );
 
     const manifest = await buildTransportSourceManifest(
-      ['BHFK900103'],
+      ['D01K900103'],
       {},
       ctx,
     );
@@ -633,7 +633,7 @@ describe('buildTransportSourceManifest', () => {
           name: 'ZTEST_GCTS_PROGRAM',
           packageName: 'ZPACKAGE',
         },
-        sourceTransport: 'BHFK900236',
+        sourceTransport: 'D01K900236',
         changeKind: 'modified',
         exact: true,
         base,

--- a/packages/adk/tests/transport-source-manifest.test.ts
+++ b/packages/adk/tests/transport-source-manifest.test.ts
@@ -611,15 +611,15 @@ describe('buildTransportSourceManifest', () => {
       pgmid: 'LIMU',
       metadata: rootSourceMetadata(),
     });
-    mockResolution([object], ['D01K900236'], ['D01K900103', 'D01K900236']);
-    const head = version('00002', 0, ['D01K900236']);
-    const base = version('00001', 1, ['D01K900100']);
+    mockResolution([object], ['TRLK900236'], ['TRLK900103', 'TRLK900236']);
+    const head = version('00002', 0, ['TRLK900236']);
+    const base = version('00001', 1, ['TRLK900100']);
     const { ctx } = contextWithVersions(
       vi.fn().mockResolvedValue([head, base]),
     );
 
     const manifest = await buildTransportSourceManifest(
-      ['D01K900103'],
+      ['TRLK900103'],
       {},
       ctx,
     );
@@ -633,7 +633,7 @@ describe('buildTransportSourceManifest', () => {
           name: 'ZTEST_GCTS_PROGRAM',
           packageName: 'ZPACKAGE',
         },
-        sourceTransport: 'D01K900236',
+        sourceTransport: 'TRLK900236',
         changeKind: 'modified',
         exact: true,
         base,

--- a/packages/adt-atc/README.md
+++ b/packages/adt-atc/README.md
@@ -26,7 +26,7 @@ Then use the command:
 
 ```bash
 # Run ATC on a transport
-adt atc -t S0DK942970
+adt atc -t TRLK942970
 
 # Run ATC on a package
 adt atc -p ZMY_PACKAGE
@@ -35,10 +35,10 @@ adt atc -p ZMY_PACKAGE
 adt atc -o /sap/bc/adt/oo/classes/zcl_my_class
 
 # Output as SARIF (for GitHub Code Scanning)
-adt atc -t S0DK942970 --format sarif --output atc-results.sarif
+adt atc -t TRLK942970 --format sarif --output atc-results.sarif
 
 # Output as GitLab Code Quality
-adt atc -t S0DK942970 --format gitlab --output gl-code-quality.json
+adt atc -t TRLK942970 --format gitlab --output gl-code-quality.json
 ```
 
 ### Options

--- a/packages/adt-atc/src/commands/atc.ts
+++ b/packages/adt-atc/src/commands/atc.ts
@@ -207,7 +207,7 @@ export const atcCommand: CliCommandPlugin = {
     },
     {
       flags: '-t, --transport <transport>',
-      description: 'Run ATC on transport request (e.g., S0DK942970)',
+      description: 'Run ATC on transport request (e.g., TRLK942970)',
     },
     {
       flags: '-f, --from-file <file>',

--- a/packages/adt-auth/README.md
+++ b/packages/adt-auth/README.md
@@ -39,13 +39,13 @@ const session = await authManager.login(
     password: 'pass',
     client: '100',
   },
-  'BHF',
+  'D01',
 );
 
 console.log('✅ Logged in!', session.sid);
 
 // Later: get credentials
-const credentials = authManager.getCredentials('BHF');
+const credentials = authManager.getCredentials('D01');
 ```
 
 ### SAP Secure Login Client (SLC)
@@ -67,7 +67,7 @@ const session = await authManager.login(
     },
     client: '200',
   },
-  'BHF',
+  'D01',
 );
 
 console.log('✅ Logged in via SLC!');
@@ -77,7 +77,7 @@ console.log('✅ Logged in via SLC!');
 
 ```typescript
 // Login to multiple systems
-await authManager.login(config1, 'BHF');
+await authManager.login(config1, 'D01');
 await authManager.login(config2, 'S0D');
 await authManager.login(config3, 'PRD');
 
@@ -86,7 +86,7 @@ const sids = authManager.listSids();
 console.log('Available systems:', sids);
 
 // Set default
-authManager.setDefaultSid('BHF');
+authManager.setDefaultSid('D01');
 
 // Get default system credentials
 const creds = authManager.getCredentials(); // Uses default SID
@@ -163,7 +163,7 @@ Sessions are stored in `~/.adt/sessions/` with file permissions `0600` (owner re
 ```
 ~/.adt/
 └── sessions/
-    ├── BHF.json
+    ├── D01.json
     ├── S0D.json
     └── PRD.json
 ```
@@ -172,7 +172,7 @@ Sessions are stored in `~/.adt/sessions/` with file permissions `0600` (owner re
 
 ```json
 {
-  "sid": "BHF",
+  "sid": "D01",
   "credentials": {
     "method": "basic",
     "baseUrl": "https://sap.example.com",
@@ -194,7 +194,7 @@ import { AuthManager, BasicAuthMethod } from '@abapify/adt-auth';
 // Get credentials
 const authManager = new AuthManager();
 authManager.registerMethod(new BasicAuthMethod());
-const credentials = authManager.getCredentials('BHF');
+const credentials = authManager.getCredentials('D01');
 
 if (!credentials) {
   throw new Error('Not authenticated. Run: adt login');

--- a/packages/adt-auth/README.md
+++ b/packages/adt-auth/README.md
@@ -78,7 +78,7 @@ console.log('✅ Logged in via SLC!');
 ```typescript
 // Login to multiple systems
 await authManager.login(config1, 'TRL');
-await authManager.login(config2, 'TRL');
+await authManager.login(config2, 'QAS');
 await authManager.login(config3, 'PRD');
 
 // List all systems
@@ -164,7 +164,7 @@ Sessions are stored in `~/.adt/sessions/` with file permissions `0600` (owner re
 ~/.adt/
 └── sessions/
     ├── TRL.json
-    ├── TRL.json
+    ├── QAS.json
     └── PRD.json
 ```
 

--- a/packages/adt-auth/README.md
+++ b/packages/adt-auth/README.md
@@ -39,13 +39,13 @@ const session = await authManager.login(
     password: 'pass',
     client: '100',
   },
-  'D01',
+  'TRL',
 );
 
 console.log('✅ Logged in!', session.sid);
 
 // Later: get credentials
-const credentials = authManager.getCredentials('D01');
+const credentials = authManager.getCredentials('TRL');
 ```
 
 ### SAP Secure Login Client (SLC)
@@ -67,7 +67,7 @@ const session = await authManager.login(
     },
     client: '200',
   },
-  'D01',
+  'TRL',
 );
 
 console.log('✅ Logged in via SLC!');
@@ -77,8 +77,8 @@ console.log('✅ Logged in via SLC!');
 
 ```typescript
 // Login to multiple systems
-await authManager.login(config1, 'D01');
-await authManager.login(config2, 'S0D');
+await authManager.login(config1, 'TRL');
+await authManager.login(config2, 'TRL');
 await authManager.login(config3, 'PRD');
 
 // List all systems
@@ -86,7 +86,7 @@ const sids = authManager.listSids();
 console.log('Available systems:', sids);
 
 // Set default
-authManager.setDefaultSid('D01');
+authManager.setDefaultSid('TRL');
 
 // Get default system credentials
 const creds = authManager.getCredentials(); // Uses default SID
@@ -163,8 +163,8 @@ Sessions are stored in `~/.adt/sessions/` with file permissions `0600` (owner re
 ```
 ~/.adt/
 └── sessions/
-    ├── D01.json
-    ├── S0D.json
+    ├── TRL.json
+    ├── TRL.json
     └── PRD.json
 ```
 
@@ -172,7 +172,7 @@ Sessions are stored in `~/.adt/sessions/` with file permissions `0600` (owner re
 
 ```json
 {
-  "sid": "D01",
+  "sid": "TRL",
   "credentials": {
     "method": "basic",
     "baseUrl": "https://sap.example.com",
@@ -194,7 +194,7 @@ import { AuthManager, BasicAuthMethod } from '@abapify/adt-auth';
 // Get credentials
 const authManager = new AuthManager();
 authManager.registerMethod(new BasicAuthMethod());
-const credentials = authManager.getCredentials('D01');
+const credentials = authManager.getCredentials('TRL');
 
 if (!credentials) {
   throw new Error('Not authenticated. Run: adt login');

--- a/packages/adt-auth/package.json
+++ b/packages/adt-auth/package.json
@@ -32,7 +32,7 @@
     "slc",
     "oauth"
   ],
-  "author": "Booking.com",
+  "author": "abapify",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/adt-auth/src/auth-manager.ts
+++ b/packages/adt-auth/src/auth-manager.ts
@@ -42,7 +42,7 @@ export class AuthManager {
    *
    * Dynamically loads the plugin specified in destination.type and authenticates.
    *
-   * @param sid - System ID (e.g., 'D01', 'S0D')
+   * @param sid - System ID (e.g., 'TRL')
    * @param destination - Destination config with plugin type and options
    */
   async login(sid: string, destination: Destination): Promise<AuthSession> {

--- a/packages/adt-auth/src/auth-manager.ts
+++ b/packages/adt-auth/src/auth-manager.ts
@@ -42,7 +42,7 @@ export class AuthManager {
    *
    * Dynamically loads the plugin specified in destination.type and authenticates.
    *
-   * @param sid - System ID (e.g., 'BHF', 'S0D')
+   * @param sid - System ID (e.g., 'D01', 'S0D')
    * @param destination - Destination config with plugin type and options
    */
   async login(sid: string, destination: Destination): Promise<AuthSession> {

--- a/packages/adt-cli/src/lib/cli.ts
+++ b/packages/adt-cli/src/lib/cli.ts
@@ -152,7 +152,7 @@ export async function createCLI(options?: {
     .version('1.0.0')
     .option(
       '--sid <sid>',
-      'SAP System ID (e.g., D01, S0D) - overrides default system',
+      'SAP System ID (e.g., TRL) - overrides default system',
     )
     .option(
       '-v, --verbose [components]',

--- a/packages/adt-cli/src/lib/cli.ts
+++ b/packages/adt-cli/src/lib/cli.ts
@@ -152,7 +152,7 @@ export async function createCLI(options?: {
     .version('1.0.0')
     .option(
       '--sid <sid>',
-      'SAP System ID (e.g., BHF, S0D) - overrides default system',
+      'SAP System ID (e.g., D01, S0D) - overrides default system',
     )
     .option(
       '-v, --verbose [components]',

--- a/packages/adt-cli/src/lib/commands/auth/login.ts
+++ b/packages/adt-cli/src/lib/commands/auth/login.ts
@@ -274,11 +274,11 @@ export const loginCommand = new Command('login')
 
 async function promptForSid(): Promise<string> {
   const sid = await input({
-    message: 'System ID (e.g., D01, S0D)',
+    message: 'System ID (e.g., TRL)',
     validate: (value) => {
       if (!value) return 'SID is required';
       if (!/^[A-Z0-9]{3}$/.test(value.toUpperCase())) {
-        return 'SID must be 3 alphanumeric characters (e.g., D01, S0D)';
+        return 'SID must be 3 alphanumeric characters (e.g., TRL)';
       }
       return true;
     },

--- a/packages/adt-cli/src/lib/commands/auth/login.ts
+++ b/packages/adt-cli/src/lib/commands/auth/login.ts
@@ -274,11 +274,11 @@ export const loginCommand = new Command('login')
 
 async function promptForSid(): Promise<string> {
   const sid = await input({
-    message: 'System ID (e.g., BHF, S0D)',
+    message: 'System ID (e.g., D01, S0D)',
     validate: (value) => {
       if (!value) return 'SID is required';
       if (!/^[A-Z0-9]{3}$/.test(value.toUpperCase())) {
-        return 'SID must be 3 alphanumeric characters (e.g., BHF, S0D)';
+        return 'SID must be 3 alphanumeric characters (e.g., D01, S0D)';
       }
       return true;
     },

--- a/packages/adt-cli/src/lib/commands/auth/set-default.ts
+++ b/packages/adt-cli/src/lib/commands/auth/set-default.ts
@@ -3,7 +3,7 @@ import { setDefaultSid, listAvailableSids } from '../../utils/auth';
 
 export const setDefaultCommand = new Command('set-default')
   .description('Set the default SAP system')
-  .argument('<sid>', 'System ID to set as default (e.g., BHF, S0D)')
+  .argument('<sid>', 'System ID to set as default (e.g., D01, S0D)')
   .action(async (sid: string) => {
     try {
       // Validate SID exists

--- a/packages/adt-cli/src/lib/commands/auth/set-default.ts
+++ b/packages/adt-cli/src/lib/commands/auth/set-default.ts
@@ -3,7 +3,7 @@ import { setDefaultSid, listAvailableSids } from '../../utils/auth';
 
 export const setDefaultCommand = new Command('set-default')
   .description('Set the default SAP system')
-  .argument('<sid>', 'System ID to set as default (e.g., D01, S0D)')
+  .argument('<sid>', 'System ID to set as default (e.g., TRL)')
   .action(async (sid: string) => {
     try {
       // Validate SID exists

--- a/packages/adt-cli/src/lib/commands/cts/tr/delete.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/delete.ts
@@ -7,7 +7,7 @@
  * - Requires typing transport number to confirm
  *
  * Usage:
- *   adt cts tr delete S0DK900123
+ *   adt cts tr delete TRLK900123
  */
 
 import { Command } from 'commander';
@@ -18,7 +18,7 @@ import { createCliLogger } from '../../../utils/logger-config';
 
 export const ctsDeleteCommand = new Command('delete')
   .description('Delete transport request (with mandatory confirmation)')
-  .argument('<transport>', 'Transport number (e.g., D01K900123)')
+  .argument('<transport>', 'Transport number (e.g., TRLK900123)')
   .option('-y, --yes', 'Skip interactive confirmation (non-interactive)')
   .option('--json', 'Output result as JSON')
   .action(async function (this: Command, transport: string, options) {

--- a/packages/adt-cli/src/lib/commands/cts/tr/delete.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/delete.ts
@@ -18,7 +18,7 @@ import { createCliLogger } from '../../../utils/logger-config';
 
 export const ctsDeleteCommand = new Command('delete')
   .description('Delete transport request (with mandatory confirmation)')
-  .argument('<transport>', 'Transport number (e.g., BHFK900123)')
+  .argument('<transport>', 'Transport number (e.g., D01K900123)')
   .option('-y, --yes', 'Skip interactive confirmation (non-interactive)')
   .option('--json', 'Output result as JSON')
   .action(async function (this: Command, transport: string, options) {

--- a/packages/adt-cli/src/lib/commands/cts/tr/get.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/get.ts
@@ -15,7 +15,7 @@ import '../../../ui/pages/transport';
 
 export const ctsGetCommand = new Command('get')
   .description('Get transport request details')
-  .argument('<transport>', 'Transport number (e.g., S0DK942971)')
+  .argument('<transport>', 'Transport number (e.g., TRLK942971)')
   .option('--json', 'Output as JSON')
   .option('--objects', 'Show list of objects in transport')
   .action(async function (this: Command, transport: string, options) {

--- a/packages/adt-cli/src/lib/commands/cts/tr/reassign.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/reassign.ts
@@ -6,9 +6,9 @@
  * when the --recursive flag is used.
  *
  * Usage:
- *   adt cts tr reassign S0DK900123 NEWUSER
- *   adt cts tr reassign S0DK900123 NEWUSER --recursive
- *   adt cts tr reassign S0DK900123 NEWUSER --json
+ *   adt cts tr reassign TRLK900123 NEWUSER
+ *   adt cts tr reassign TRLK900123 NEWUSER --recursive
+ *   adt cts tr reassign TRLK900123 NEWUSER --json
  */
 
 import { Command } from 'commander';
@@ -19,7 +19,7 @@ import { AdkTransportRequest } from '@abapify/adk';
 
 export const ctsReassignCommand = new Command('reassign')
   .description('Change the owner of a transport request')
-  .argument('<transport>', 'Transport number (e.g., D01K900123)')
+  .argument('<transport>', 'Transport number (e.g., TRLK900123)')
   .argument('<new-owner>', 'SAP username of the new owner')
   .option(
     '-r, --recursive',

--- a/packages/adt-cli/src/lib/commands/cts/tr/reassign.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/reassign.ts
@@ -19,7 +19,7 @@ import { AdkTransportRequest } from '@abapify/adk';
 
 export const ctsReassignCommand = new Command('reassign')
   .description('Change the owner of a transport request')
-  .argument('<transport>', 'Transport number (e.g., BHFK900123)')
+  .argument('<transport>', 'Transport number (e.g., D01K900123)')
   .argument('<new-owner>', 'SAP username of the new owner')
   .option(
     '-r, --recursive',

--- a/packages/adt-cli/src/lib/commands/cts/tr/release.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/release.ts
@@ -19,7 +19,7 @@ import { AdkTransportRequest } from '@abapify/adk';
 
 export const ctsReleaseCommand = new Command('release')
   .description('Release transport request')
-  .argument('<transport>', 'Transport number (e.g., BHFK900123)')
+  .argument('<transport>', 'Transport number (e.g., D01K900123)')
   .option('--skip-check', 'Skip pre-release validation')
   .option('--release-all', 'Release all tasks first, then the transport')
   .option('-y, --yes', 'Skip confirmation prompt')

--- a/packages/adt-cli/src/lib/commands/cts/tr/release.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/release.ts
@@ -5,9 +5,9 @@
  * Optionally runs pre-release checks (ATC).
  *
  * Usage:
- *   adt cts tr release S0DK900123
- *   adt cts tr release S0DK900123 --skip-check
- *   adt cts tr release S0DK900123 --json
+ *   adt cts tr release TRLK900123
+ *   adt cts tr release TRLK900123 --skip-check
+ *   adt cts tr release TRLK900123 --json
  */
 
 import { Command } from 'commander';
@@ -19,7 +19,7 @@ import { AdkTransportRequest } from '@abapify/adk';
 
 export const ctsReleaseCommand = new Command('release')
   .description('Release transport request')
-  .argument('<transport>', 'Transport number (e.g., D01K900123)')
+  .argument('<transport>', 'Transport number (e.g., TRLK900123)')
   .option('--skip-check', 'Skip pre-release validation')
   .option('--release-all', 'Release all tasks first, then the transport')
   .option('-y, --yes', 'Skip confirmation prompt')

--- a/packages/adt-cli/src/lib/commands/cts/tr/set.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/set.ts
@@ -5,9 +5,9 @@
  * For interactive editing, use `adt cts tr change` (TUI).
  *
  * Usage:
- *   adt cts tr set S0DK900123 --description "New description"
- *   adt cts tr set S0DK900123 --target "QAS"
- *   adt cts tr set S0DK900123 --from-json payload.json
+ *   adt cts tr set TRLK900123 --description "New description"
+ *   adt cts tr set TRLK900123 --target "QAS"
+ *   adt cts tr set TRLK900123 --from-json payload.json
  */
 
 import { Command } from 'commander';
@@ -19,7 +19,7 @@ import { AdkTransportRequest } from '@abapify/adk';
 
 export const ctsSetCommand = new Command('set')
   .description('Update transport request (non-interactive, for scripting)')
-  .argument('<transport>', 'Transport number (e.g., D01K900123)')
+  .argument('<transport>', 'Transport number (e.g., TRLK900123)')
   .option('-d, --description <desc>', 'New transport description')
   .option('--target <target>', 'New target system')
   .option('--from-json <file>', 'Load full payload from JSON file')

--- a/packages/adt-cli/src/lib/commands/cts/tr/set.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/set.ts
@@ -19,7 +19,7 @@ import { AdkTransportRequest } from '@abapify/adk';
 
 export const ctsSetCommand = new Command('set')
   .description('Update transport request (non-interactive, for scripting)')
-  .argument('<transport>', 'Transport number (e.g., BHFK900123)')
+  .argument('<transport>', 'Transport number (e.g., D01K900123)')
   .option('-d, --description <desc>', 'New transport description')
   .option('--target <target>', 'New target system')
   .option('--from-json <file>', 'Load full payload from JSON file')

--- a/packages/adt-cli/src/lib/ui/pages/transport.ts
+++ b/packages/adt-cli/src/lib/ui/pages/transport.ts
@@ -28,7 +28,7 @@ import { definePage } from '../router';
  * Transport page navigation parameters
  */
 export interface TransportParams extends NavParams {
-  /** Transport number (e.g., S0DK942971) */
+  /** Transport number (e.g., TRLK942971) */
   name?: string;
   /** Show objects in transport */
   showObjects?: boolean;
@@ -245,7 +245,7 @@ function renderTransportPage(
  * Usage:
  * ```ts
  * const page = await router.navTo(client, 'RQRQ', {
- *   name: 'S0DK942971',
+ *   name: 'TRLK942971',
  *   showObjects: true
  * });
  * page.print();

--- a/packages/adt-cli/src/lib/utils/adt-client-v2.ts
+++ b/packages/adt-cli/src/lib/utils/adt-client-v2.ts
@@ -146,7 +146,7 @@ export interface AdtClientV2Options {
   logOutput?: string;
   /** Write metadata alongside response files (default: false) */
   writeMetadata?: boolean;
-  /** SAP System ID (SID) - e.g., 'D01', 'S0D' (default: from CLI --sid flag) */
+  /** SAP System ID (SID) - e.g., 'TRL' (default: from CLI --sid flag) */
   sid?: string;
   /** Enable capture plugin to capture raw XML and parsed JSON (default: false) */
   capture?: boolean;
@@ -352,7 +352,7 @@ export async function getAdtClientV2(
     reportNoSessionAndExit(effectiveOptions.sid);
   }
 
-  // Set system name for ADT hyperlinks (e.g., adt://S0D/sap/bc/adt/...)
+  // Set system name for ADT hyperlinks (e.g., adt://TRL/sap/bc/adt/...)
   setAdtSystem(session.sid);
 
   // Extract credentials based on auth method

--- a/packages/adt-cli/src/lib/utils/adt-client-v2.ts
+++ b/packages/adt-cli/src/lib/utils/adt-client-v2.ts
@@ -146,7 +146,7 @@ export interface AdtClientV2Options {
   logOutput?: string;
   /** Write metadata alongside response files (default: false) */
   writeMetadata?: boolean;
-  /** SAP System ID (SID) - e.g., 'BHF', 'S0D' (default: from CLI --sid flag) */
+  /** SAP System ID (SID) - e.g., 'D01', 'S0D' (default: from CLI --sid flag) */
   sid?: string;
   /** Enable capture plugin to capture raw XML and parsed JSON (default: false) */
   capture?: boolean;

--- a/packages/adt-cli/src/lib/utils/destinations.ts
+++ b/packages/adt-cli/src/lib/utils/destinations.ts
@@ -37,7 +37,7 @@ export async function getConfig(): Promise<LoadedConfig> {
 
 /**
  * Get a destination by name (SID)
- * @param name Destination name (e.g., 'D01', 'S0D')
+ * @param name Destination name (e.g., 'TRL')
  */
 export async function getDestination(
   name: string,

--- a/packages/adt-cli/src/lib/utils/destinations.ts
+++ b/packages/adt-cli/src/lib/utils/destinations.ts
@@ -37,7 +37,7 @@ export async function getConfig(): Promise<LoadedConfig> {
 
 /**
  * Get a destination by name (SID)
- * @param name Destination name (e.g., 'BHF', 'S0D')
+ * @param name Destination name (e.g., 'D01', 'S0D')
  */
 export async function getDestination(
   name: string,

--- a/packages/adt-client/fixtures/sap/bc/adt/oo/classes/zcl_age_sample_class.xml
+++ b/packages/adt-client/fixtures/sap/bc/adt/oo/classes/zcl_age_sample_class.xml
@@ -11,7 +11,7 @@
         abapsource:activeUnicodeCheck="true"
         adtcore:responsible="PPLENKOV"
         adtcore:masterLanguage="EN"
-        adtcore:masterSystem="BHF"
+        adtcore:masterSystem="D01"
         adtcore:abapLanguageVersion="X"
         adtcore:name="ZCL_AGE_SAMPLE_CLASS"
         adtcore:type="CLAS/OC"

--- a/packages/adt-client/fixtures/sap/bc/adt/oo/classes/zcl_age_sample_class.xml
+++ b/packages/adt-client/fixtures/sap/bc/adt/oo/classes/zcl_age_sample_class.xml
@@ -11,7 +11,7 @@
         abapsource:activeUnicodeCheck="true"
         adtcore:responsible="PPLENKOV"
         adtcore:masterLanguage="EN"
-        adtcore:masterSystem="D01"
+        adtcore:masterSystem="TRL"
         adtcore:abapLanguageVersion="X"
         adtcore:name="ZCL_AGE_SAMPLE_CLASS"
         adtcore:type="CLAS/OC"

--- a/packages/adt-client/src/client.ts
+++ b/packages/adt-client/src/client.ts
@@ -50,7 +50,7 @@ export interface BoundedTextFetchOptions {
  *
  * // Contract access
  * const session = await client.adt.core.http.sessions.getSession();
- * const transport = await client.adt.cts.transportrequests.get('S0DK900001');
+ * const transport = await client.adt.cts.transportrequests.get('TRLK900001');
  *
  * // Generic fetch utility
  * const response = await client.fetch('/sap/bc/adt/arbitrary/endpoint', {
@@ -61,7 +61,7 @@ export interface BoundedTextFetchOptions {
  * // For business logic, use ADK:
  * // import { initializeAdk, AdkTransportRequest } from '@abapify/adk';
  * // initializeAdk(client);
- * // const transport = await AdkTransportRequest.get('S0DK900001');
+ * // const transport = await AdkTransportRequest.get('TRLK900001');
  */
 
 // Re-export AdtClientType from adt-contracts for consumers

--- a/packages/adt-client/tests/source-history.test.ts
+++ b/packages/adt-client/tests/source-history.test.ts
@@ -35,12 +35,12 @@ describe('normalizeSourceVersionFeed', () => {
                   etag: 'head-etag',
                 },
                 {
-                  href: '/sap/bc/adt/cts/transportrequests/BHFK900236',
+                  href: '/sap/bc/adt/cts/transportrequests/D01K900236',
                   rel: 'http://www.sap.com/adt/relations/transport',
-                  title: 'BHFK900236',
+                  title: 'D01K900236',
                 },
                 {
-                  href: '/sap/bc/adt/cts/transportrequests/BHFK900237',
+                  href: '/sap/bc/adt/cts/transportrequests/D01K900237',
                   rel: 'http://www.sap.com/adt/relations/transport',
                 },
               ],
@@ -55,7 +55,7 @@ describe('normalizeSourceVersionFeed', () => {
                   type: 'text/plain; charset=utf-8',
                 },
                 {
-                  href: '/sap/bc/adt/cts/transportrequests/BHFK900101',
+                  href: '/sap/bc/adt/cts/transportrequests/D01K900101',
                   rel: 'http://www.sap.com/adt/relations/transport',
                 },
               ],
@@ -77,7 +77,7 @@ describe('normalizeSourceVersionFeed', () => {
         etag: 'head-etag',
         updatedAt: '2026-07-17T10:00:00Z',
         author: 'DEVELOPER',
-        transports: ['BHFK900236', 'BHFK900237'],
+        transports: ['D01K900236', 'D01K900237'],
       },
       {
         id: '00001',
@@ -87,7 +87,7 @@ describe('normalizeSourceVersionFeed', () => {
           '/sap/bc/adt/oo/classes/zcl_example/includes/implementations/versions/00001/content',
         contentType: 'text/plain; charset=utf-8',
         updatedAt: '2026-07-16T09:00:00Z',
-        transports: ['BHFK900101'],
+        transports: ['D01K900101'],
       },
     ]);
   });
@@ -105,11 +105,11 @@ describe('normalizeSourceVersionFeed', () => {
                 type: 'text/plain',
               },
               {
-                href: '/sap/bc/adt/cts/transportrequests/BHFK900236',
+                href: '/sap/bc/adt/cts/transportrequests/D01K900236',
                 rel: 'http://www.sap.com/adt/relations/transport',
               },
               {
-                href: '/sap/bc/adt/cts/transportrequests/BHFK900236',
+                href: '/sap/bc/adt/cts/transportrequests/D01K900236',
                 rel: 'http://www.sap.com/adt/relations/transport',
               },
             ],
@@ -121,7 +121,7 @@ describe('normalizeSourceVersionFeed', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]?.sourceUri).toBe(`${versionsUri}/00000/content`);
-    expect(result[0]?.transports).toEqual(['BHFK900236']);
+    expect(result[0]?.transports).toEqual(['D01K900236']);
   });
 
   it('uses Atom content src when SAP puts immutable source versions there', () => {
@@ -136,7 +136,7 @@ describe('normalizeSourceVersionFeed', () => {
             },
             link: [
               {
-                href: '/sap/bc/adt/cts/transportrequests/BHFK900236',
+                href: '/sap/bc/adt/cts/transportrequests/D01K900236',
                 rel: 'http://www.sap.com/adt/relations/transport/request',
               },
             ],
@@ -153,7 +153,7 @@ describe('normalizeSourceVersionFeed', () => {
         sourceUri:
           '/sap/bc/adt/programs/programs/ztest_gcts_program/source/main/versions/00042',
         contentType: 'text/plain',
-        transports: ['BHFK900236'],
+        transports: ['D01K900236'],
       },
     ]);
   });
@@ -172,7 +172,7 @@ describe('normalizeSourceVersionFeed', () => {
                 id: '00000',
                 link: [
                   {
-                    href: '/sap/bc/adt/cts/transportrequests/BHFK900236',
+                    href: '/sap/bc/adt/cts/transportrequests/D01K900236',
                     rel: 'http://www.sap.com/adt/relations/transport',
                   },
                 ],
@@ -332,7 +332,7 @@ describe('SourceHistoryService', () => {
             <atom:author><atom:name>DEVELOPER</atom:name></atom:author>
             <atom:content type="text/plain" src="/sap/bc/adt/programs/programs/ztest_gcts_program/source/main/versions/00042"/>
             <atom:id>00042</atom:id>
-            <atom:link href="/sap/bc/adt/cts/transportrequests/BHFK900236" rel="http://www.sap.com/adt/relations/transport/request"/>
+            <atom:link href="/sap/bc/adt/cts/transportrequests/D01K900236" rel="http://www.sap.com/adt/relations/transport/request"/>
             <atom:title>Version 42</atom:title>
             <atom:updated>2026-07-17T10:00:00Z</atom:updated>
           </atom:entry>
@@ -359,7 +359,7 @@ describe('SourceHistoryService', () => {
           id: '00042',
           sourceUri:
             '/sap/bc/adt/programs/programs/ztest_gcts_program/source/main/versions/00042',
-          transports: ['BHFK900236'],
+          transports: ['D01K900236'],
         },
       ]);
     } finally {

--- a/packages/adt-client/tests/source-history.test.ts
+++ b/packages/adt-client/tests/source-history.test.ts
@@ -35,12 +35,12 @@ describe('normalizeSourceVersionFeed', () => {
                   etag: 'head-etag',
                 },
                 {
-                  href: '/sap/bc/adt/cts/transportrequests/D01K900236',
+                  href: '/sap/bc/adt/cts/transportrequests/TRLK900236',
                   rel: 'http://www.sap.com/adt/relations/transport',
-                  title: 'D01K900236',
+                  title: 'TRLK900236',
                 },
                 {
-                  href: '/sap/bc/adt/cts/transportrequests/D01K900237',
+                  href: '/sap/bc/adt/cts/transportrequests/TRLK900237',
                   rel: 'http://www.sap.com/adt/relations/transport',
                 },
               ],
@@ -55,7 +55,7 @@ describe('normalizeSourceVersionFeed', () => {
                   type: 'text/plain; charset=utf-8',
                 },
                 {
-                  href: '/sap/bc/adt/cts/transportrequests/D01K900101',
+                  href: '/sap/bc/adt/cts/transportrequests/TRLK900101',
                   rel: 'http://www.sap.com/adt/relations/transport',
                 },
               ],
@@ -77,7 +77,7 @@ describe('normalizeSourceVersionFeed', () => {
         etag: 'head-etag',
         updatedAt: '2026-07-17T10:00:00Z',
         author: 'DEVELOPER',
-        transports: ['D01K900236', 'D01K900237'],
+        transports: ['TRLK900236', 'TRLK900237'],
       },
       {
         id: '00001',
@@ -87,7 +87,7 @@ describe('normalizeSourceVersionFeed', () => {
           '/sap/bc/adt/oo/classes/zcl_example/includes/implementations/versions/00001/content',
         contentType: 'text/plain; charset=utf-8',
         updatedAt: '2026-07-16T09:00:00Z',
-        transports: ['D01K900101'],
+        transports: ['TRLK900101'],
       },
     ]);
   });
@@ -105,11 +105,11 @@ describe('normalizeSourceVersionFeed', () => {
                 type: 'text/plain',
               },
               {
-                href: '/sap/bc/adt/cts/transportrequests/D01K900236',
+                href: '/sap/bc/adt/cts/transportrequests/TRLK900236',
                 rel: 'http://www.sap.com/adt/relations/transport',
               },
               {
-                href: '/sap/bc/adt/cts/transportrequests/D01K900236',
+                href: '/sap/bc/adt/cts/transportrequests/TRLK900236',
                 rel: 'http://www.sap.com/adt/relations/transport',
               },
             ],
@@ -121,7 +121,7 @@ describe('normalizeSourceVersionFeed', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]?.sourceUri).toBe(`${versionsUri}/00000/content`);
-    expect(result[0]?.transports).toEqual(['D01K900236']);
+    expect(result[0]?.transports).toEqual(['TRLK900236']);
   });
 
   it('uses Atom content src when SAP puts immutable source versions there', () => {
@@ -136,7 +136,7 @@ describe('normalizeSourceVersionFeed', () => {
             },
             link: [
               {
-                href: '/sap/bc/adt/cts/transportrequests/D01K900236',
+                href: '/sap/bc/adt/cts/transportrequests/TRLK900236',
                 rel: 'http://www.sap.com/adt/relations/transport/request',
               },
             ],
@@ -153,7 +153,7 @@ describe('normalizeSourceVersionFeed', () => {
         sourceUri:
           '/sap/bc/adt/programs/programs/ztest_gcts_program/source/main/versions/00042',
         contentType: 'text/plain',
-        transports: ['D01K900236'],
+        transports: ['TRLK900236'],
       },
     ]);
   });
@@ -172,7 +172,7 @@ describe('normalizeSourceVersionFeed', () => {
                 id: '00000',
                 link: [
                   {
-                    href: '/sap/bc/adt/cts/transportrequests/D01K900236',
+                    href: '/sap/bc/adt/cts/transportrequests/TRLK900236',
                     rel: 'http://www.sap.com/adt/relations/transport',
                   },
                 ],
@@ -332,7 +332,7 @@ describe('SourceHistoryService', () => {
             <atom:author><atom:name>DEVELOPER</atom:name></atom:author>
             <atom:content type="text/plain" src="/sap/bc/adt/programs/programs/ztest_gcts_program/source/main/versions/00042"/>
             <atom:id>00042</atom:id>
-            <atom:link href="/sap/bc/adt/cts/transportrequests/D01K900236" rel="http://www.sap.com/adt/relations/transport/request"/>
+            <atom:link href="/sap/bc/adt/cts/transportrequests/TRLK900236" rel="http://www.sap.com/adt/relations/transport/request"/>
             <atom:title>Version 42</atom:title>
             <atom:updated>2026-07-17T10:00:00Z</atom:updated>
           </atom:entry>
@@ -359,7 +359,7 @@ describe('SourceHistoryService', () => {
           id: '00042',
           sourceUri:
             '/sap/bc/adt/programs/programs/ztest_gcts_program/source/main/versions/00042',
-          transports: ['D01K900236'],
+          transports: ['TRLK900236'],
         },
       ]);
     } finally {

--- a/packages/adt-config/src/index.ts
+++ b/packages/adt-config/src/index.ts
@@ -11,7 +11,7 @@
  *
  * export default defineConfig({
  *   destinations: {
- *     D01: { type: 'puppeteer', options: { url: '...', client: '100' } },
+ *     TRL: { type: 'puppeteer', options: { url: '...', client: '100' } },
  *   }
  * });
  * ```

--- a/packages/adt-config/src/index.ts
+++ b/packages/adt-config/src/index.ts
@@ -11,7 +11,7 @@
  *
  * export default defineConfig({
  *   destinations: {
- *     BHF: { type: 'puppeteer', options: { url: '...', client: '100' } },
+ *     D01: { type: 'puppeteer', options: { url: '...', client: '100' } },
  *   }
  * });
  * ```

--- a/packages/adt-contracts/src/adt/cts/transports.ts
+++ b/packages/adt-contracts/src/adt/cts/transports.ts
@@ -86,7 +86,7 @@ export interface TransportFindParams {
  * Single transport header from the response
  */
 export interface CtsReqHeader {
-  /** Transport number (e.g., S0DK921630) */
+  /** Transport number (e.g., TRLK921630) */
   TRKORR: string;
   /** Transport function code */
   TRFUNCTION: string;

--- a/packages/adt-fixtures/TODO.md
+++ b/packages/adt-fixtures/TODO.md
@@ -49,7 +49,7 @@ Real SAP XML responses needed for complete test coverage. Collect from SAP syste
 
 ## Security Reminder
 
-⚠️ **Never commit real abapify data to this submodule**
+⚠️ **Never commit real SAP system data to this submodule**
 
 - No real transport numbers (use DEVK*, MOCK*, TEST\*)
 - No real usernames

--- a/packages/adt-fixtures/TODO.md
+++ b/packages/adt-fixtures/TODO.md
@@ -49,7 +49,7 @@ Real SAP XML responses needed for complete test coverage. Collect from SAP syste
 
 ## Security Reminder
 
-⚠️ **Never commit real Booking.com data to this submodule**
+⚠️ **Never commit real abapify data to this submodule**
 
 - No real transport numbers (use DEVK*, MOCK*, TEST\*)
 - No real usernames

--- a/packages/adt-fixtures/src/fixtures/registry.ts
+++ b/packages/adt-fixtures/src/fixtures/registry.ts
@@ -58,7 +58,7 @@ export const registry = {
       quickSearch: 'repository/search/quickSearch.xml',
     },
     sourceversions: {
-      // Sanitized metadata-only D01 response. It intentionally contains no
+      // Sanitized metadata-only TRL response. It intentionally contains no
       // ABAP source body; immutable source is represented by atom:content/@src.
       program: 'repository/sourceversions/program.xml',
     },

--- a/packages/adt-fixtures/src/fixtures/registry.ts
+++ b/packages/adt-fixtures/src/fixtures/registry.ts
@@ -58,7 +58,7 @@ export const registry = {
       quickSearch: 'repository/search/quickSearch.xml',
     },
     sourceversions: {
-      // Sanitized metadata-only BHF response. It intentionally contains no
+      // Sanitized metadata-only D01 response. It intentionally contains no
       // ABAP source body; immutable source is represented by atom:content/@src.
       program: 'repository/sourceversions/program.xml',
     },

--- a/packages/adt-locks/src/service.ts
+++ b/packages/adt-locks/src/service.ts
@@ -178,7 +178,7 @@ export function createLockService(
 
     async forceUnlock(objectUri) {
       // A second LOCK cannot recover a lost handle: real SAP systems such as
-      // D01 reject it with an "already locked in request" conflict. Re-locking
+      // TRL reject it with an "already locked in request" conflict. Re-locking
       // also risks creating a new CTS lock on systems that permit it. Only a
       // handle registered by a previous successful LOCK is safe to use.
       const entry = store?.list()?.find((item) => item.objectUri === objectUri);

--- a/packages/adt-locks/src/service.ts
+++ b/packages/adt-locks/src/service.ts
@@ -178,7 +178,7 @@ export function createLockService(
 
     async forceUnlock(objectUri) {
       // A second LOCK cannot recover a lost handle: real SAP systems such as
-      // BHF reject it with an "already locked in request" conflict. Re-locking
+      // D01 reject it with an "already locked in request" conflict. Re-locking
       // also risks creating a new CTS lock on systems that permit it. Only a
       // handle registered by a previous successful LOCK is safe to use.
       const entry = store?.list()?.find((item) => item.objectUri === objectUri);

--- a/packages/adt-mcp/src/lib/http/auth.ts
+++ b/packages/adt-mcp/src/lib/http/auth.ts
@@ -12,7 +12,7 @@
  *   - `oauth`  — validate an OIDC-issued JWT (Okta, Entra ID, Cognito, …)
  *                against the configured issuer + audience + scopes. See
  *                `./oauth.ts` for the validator implementation.
- *   - `invocation` — validate an ARM-issued ES256 invocation credential and
+ *   - `invocation` — validate an ADT-issued ES256 invocation credential and
  *                surface only its immutable, trusted claims to the transport.
  *
  * The middleware writes a 401 JSON response on failure and returns
@@ -37,7 +37,7 @@ export interface AuthMiddlewareOptions {
   token?: string;
   /** Required when mode==='oauth'. OIDC issuer / audience / scopes. */
   oauth?: OAuthOptions;
-  /** Required when mode==='invocation'. ARM ES256 credential verifier. */
+  /** Required when mode==='invocation'. ADT ES256 credential verifier. */
   invocationVerifier?: McpInvocationVerifier;
   /**
    * Test-only hook: invoked synchronously whenever an OAuth request

--- a/packages/adt-mcp/src/lib/http/invocation.ts
+++ b/packages/adt-mcp/src/lib/http/invocation.ts
@@ -1,5 +1,5 @@
 /**
- * Verification for ARM-issued MCP invocation credentials.
+ * Verification for ADT-issued MCP invocation credentials.
  *
  * This module is deliberately transport-independent: callers pass the
  * complete Authorization header and receive either immutable, trusted claims
@@ -39,7 +39,7 @@ export type McpInvocationJsonValue =
   | readonly McpInvocationJsonValue[]
   | Readonly<Record<string, McpInvocationJsonValue>>;
 
-/** Claims proved by a verified, ARM-issued invocation credential. */
+/** Claims proved by a verified, ADT-issued invocation credential. */
 export interface TrustedMcpInvocationClaims {
   readonly tokenId: string;
   readonly principal: string;
@@ -56,7 +56,7 @@ export interface TrustedMcpInvocationClaims {
 
 /**
  * Fully enforced narrowing policy for an AI Review source read. `sourceRef`
- * remains opaque to MCP clients and models; only ARM's private broker can
+ * remains opaque to MCP clients and models; only ADT's private broker can
  * redeem it after this policy has selected the exact canonical object and
  * source component.
  */
@@ -77,7 +77,7 @@ export interface McpInvocationVerifierOptions {
   publicKey: CryptoKey | KeyObject;
   /** The exact key id required in both JWS header and JWT payload. */
   keyId: string;
-  /** The exact ARM API issuer expected in `iss`. */
+  /** The exact ADT API issuer expected in `iss`. */
   issuer: string;
   /** The exact audience expected in `aud`. */
   audience: string;
@@ -150,7 +150,7 @@ export function isMcpInvocationDispatchPolicySupported(
 
 /**
  * The autonomous agent may inspect exactly one System through exactly one
- * Destination. Its execution id binds every ADT activity to ARM's durable
+ * Destination. Its execution id binds every ADT activity to ADT's durable
  * Agent Execution, while the sidecar's ordinary scope catalogue continues to
  * deny write tools. No ambient limits or additional constraints are accepted.
  */
@@ -584,7 +584,7 @@ function currentDate(now: (() => Date | number) | undefined): Date {
 }
 
 /**
- * Build a fail-closed verifier for the one ARM-to-ADT-Server invocation key.
+ * Build a fail-closed verifier for the one ADT-Server invocation key.
  * Configuration failures throw before serving traffic; credential failures
  * always resolve to `undefined` without logging token-derived information.
  */

--- a/packages/adt-mcp/src/lib/http/server.ts
+++ b/packages/adt-mcp/src/lib/http/server.ts
@@ -82,7 +82,7 @@ export interface HttpServerOptions {
    */
   oauth?: OAuthOptions;
   /**
-   * ARM-issued invocation verifier (required when `authMode ===
+   * ADT-issued invocation verifier (required when `authMode ===
    * 'invocation'`). Its trusted claims are the only source for identity and
    * scope in destination-aware sidecar mode.
    */

--- a/packages/adt-mcp/src/lib/server.ts
+++ b/packages/adt-mcp/src/lib/server.ts
@@ -48,7 +48,7 @@ export interface McpServerOptions {
   requestAccess?: (extra: {
     sessionId?: string;
   }) => McpRequestAccess | undefined;
-  /** Private ARM broker resolver for signed frozen-source capabilities. */
+  /** Private ADT broker resolver for signed frozen-source capabilities. */
   resolveFrozenSource: ToolContext['resolveFrozenSource'];
 }
 

--- a/packages/adt-mcp/src/lib/tools/cts-delete-transport.ts
+++ b/packages/adt-mcp/src/lib/tools/cts-delete-transport.ts
@@ -21,7 +21,7 @@ export function registerCtsDeleteTransportTool(
       ...sessionOrConnectionShape,
       transport: z
         .string()
-        .describe('Transport number to delete (e.g. S0DK900001)'),
+        .describe('Transport number to delete (e.g. TRLK900001)'),
     },
     async (args, extra) => {
       try {

--- a/packages/adt-mcp/src/lib/tools/cts-get-transport.ts
+++ b/packages/adt-mcp/src/lib/tools/cts-get-transport.ts
@@ -19,7 +19,7 @@ export function registerCtsGetTransportTool(
     'Get details of a specific transport request',
     {
       ...sessionOrConnectionShape,
-      transport: z.string().describe('Transport number (e.g. S0DK900001)'),
+      transport: z.string().describe('Transport number (e.g. TRLK900001)'),
     },
     async (args, extra) => {
       try {

--- a/packages/adt-mcp/src/lib/tools/cts-reassign-transport.ts
+++ b/packages/adt-mcp/src/lib/tools/cts-reassign-transport.ts
@@ -32,7 +32,7 @@ export function registerCtsReassignTransportTool(
       ...sessionOrConnectionShape,
       transportNumber: z
         .string()
-        .describe('Transport number (e.g. S0DK900123)'),
+        .describe('Transport number (e.g. TRLK900123)'),
       targetUser: z.string().describe('SAP username of the new owner'),
       recursive: z
         .boolean()

--- a/packages/adt-mcp/src/lib/tools/cts-release-transport.ts
+++ b/packages/adt-mcp/src/lib/tools/cts-release-transport.ts
@@ -23,7 +23,7 @@ export function registerCtsReleaseTransportTool(
       ...sessionOrConnectionShape,
       transport: z
         .string()
-        .describe('Transport number to release (e.g. S0DK900001)'),
+        .describe('Transport number to release (e.g. TRLK900001)'),
     },
     async (args, extra) => {
       try {

--- a/packages/adt-mcp/src/lib/tools/cts-update-transport.ts
+++ b/packages/adt-mcp/src/lib/tools/cts-update-transport.ts
@@ -33,7 +33,7 @@ export function registerCtsUpdateTransportTool(
       ...sessionOrConnectionShape,
       transportNumber: z
         .string()
-        .describe('Transport number (e.g. S0DK900123)'),
+        .describe('Transport number (e.g. TRLK900123)'),
       description: z.string().optional().describe('New transport description'),
       target: z.string().optional().describe('New target system'),
       project: z.string().optional().describe('CTS project name'),

--- a/packages/adt-mcp/src/lib/tools/destination-mode.ts
+++ b/packages/adt-mcp/src/lib/tools/destination-mode.ts
@@ -27,7 +27,7 @@ import {
 const destination = z
   .string()
   .regex(/^[a-z][a-z0-9-]{1,62}$/u)
-  .describe('ARM-managed destination key');
+  .describe('ADT-managed destination key');
 
 const forbiddenConnectionFields = {
   baseUrl: z.never().optional(),

--- a/packages/adt-mcp/src/lib/tools/get-frozen-source.ts
+++ b/packages/adt-mcp/src/lib/tools/get-frozen-source.ts
@@ -3,7 +3,7 @@
  *
  * The model supplies an accepted canonical object component, never an ADT URI
  * or an opaque capability. Destination mode checks the signed policy before
- * this handler, then ARM's private broker redeems the hidden capability.
+ * this handler, then ADT's private broker redeems the hidden capability.
  */
 
 import { Buffer } from 'node:buffer';

--- a/packages/adt-mcp/src/lib/tools/scope-catalogue.ts
+++ b/packages/adt-mcp/src/lib/tools/scope-catalogue.ts
@@ -35,7 +35,7 @@ export interface McpFrozenSourceAccess {
     readonly canonicalKey: string;
     /** Immutable source component within the canonical review object. */
     readonly componentId: string;
-    /** Opaque ARM capability; never accepted as a model/tool argument. */
+    /** Opaque ADT capability; never accepted as a model/tool argument. */
     readonly sourceRef: string;
   }[];
   readonly maxSourceBytes: number;

--- a/packages/adt-mcp/src/lib/types.ts
+++ b/packages/adt-mcp/src/lib/types.ts
@@ -54,7 +54,7 @@ export interface ToolContext {
     sessionId?: string;
   }) => McpRequestAccess | undefined;
   /**
-   * Redeems an opaque ARM source capability after destination-mode policy has
+   * Redeems an opaque ADT source capability after destination-mode policy has
    * selected it. The resolver may return only a trusted server-relative URI.
    */
   resolveFrozenSource?: (input: {

--- a/packages/adt-mcp/tests/http-invocation-auth.test.ts
+++ b/packages/adt-mcp/tests/http-invocation-auth.test.ts
@@ -1,5 +1,5 @@
 /**
- * Integration tests for ARM invocation authentication on the MCP HTTP
+ * Integration tests for ADT invocation authentication on the MCP HTTP
  * transport. These prove that only verified claims become session identity
  * and scope, and that a session cannot be continued with another JTI.
  */
@@ -15,9 +15,9 @@ import {
 } from '../src/lib/http/server.js';
 import { createDestinationContextRegistry } from '../src/lib/session/destination-registry.js';
 
-const issuer = 'arm-api';
+const issuer = 'adt-api';
 const audience = 'adt-server-mcp';
-const keyId = 'arm-mcp-integration-test';
+const keyId = 'adt-mcp-integration-test';
 
 async function signInvocation(
   privateKey: CryptoKey,
@@ -60,7 +60,7 @@ async function signInvocation(
     .sign(privateKey);
 }
 
-test('ARM invocation auth snapshots verified read scope and binds continuation to its JTI', async () => {
+test('ADT invocation auth snapshots verified read scope and binds continuation to its JTI', async () => {
   const { privateKey, publicKey } = await generateKeyPair('ES256');
   let leases = 0;
   let contexts = 0;
@@ -172,7 +172,7 @@ test('ARM invocation auth snapshots verified read scope and binds continuation t
   }
 });
 
-test('ARM invocation auth fails closed for an AI Review policy the sidecar cannot yet enforce', async () => {
+test('ADT invocation auth fails closed for an AI Review policy the sidecar cannot yet enforce', async () => {
   const { privateKey, publicKey } = await generateKeyPair('ES256');
   let leases = 0;
   let contexts = 0;
@@ -465,7 +465,7 @@ test('AI Review redeems only the signed source component before acquiring its de
   }
 });
 
-test('ARM invocation auth rejects credentials that request write authority', async () => {
+test('ADT invocation auth rejects credentials that request write authority', async () => {
   const { privateKey, publicKey } = await generateKeyPair('ES256');
   const destinationRegistry = createDestinationContextRegistry({
     leaseProvider: {
@@ -518,7 +518,7 @@ test('ARM invocation auth rejects credentials that request write authority', asy
   }
 });
 
-test('ARM invocation mode requires a verifier and destination scope source', () => {
+test('ADT invocation mode requires a verifier and destination scope source', () => {
   assert.throws(
     () =>
       createHttpMcpHandler({

--- a/packages/adt-mcp/tests/http-invocation.test.ts
+++ b/packages/adt-mcp/tests/http-invocation.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for ARM's signed MCP invocation credentials. These run against
+ * Unit tests for ADT's signed MCP invocation credentials. These run against
  * real ES256 JWS values — the verifier never trusts decoded, unsigned data.
  */
 import assert from 'node:assert/strict';
@@ -15,9 +15,9 @@ import {
   isMcpInvocationDispatchPolicySupported,
 } from '../src/lib/http/invocation.js';
 
-const issuer = 'arm-api';
+const issuer = 'adt-api';
 const audience = 'adt-server-mcp';
-const keyId = 'arm-mcp-2026-07';
+const keyId = 'adt-mcp-2026-07';
 const now = new Date('2026-07-19T12:00:00.000Z');
 const nowSeconds = Math.floor(now.getTime() / 1_000);
 
@@ -43,9 +43,9 @@ function claims(overrides: JWTPayload = {}): JWTPayload {
     principal: 'petr.plenkov',
     agentId: 'system-assistant',
     classes: ['server', 'read'],
-    destinationKeys: ['bhf-rise'],
+    destinationKeys: ['d01-rise'],
     correlationId: 'correlation-001',
-    constraint: { systemSid: 'BHF', frozenScope: ['ZCL_ARM_REVIEW'] },
+    constraint: { systemSid: 'D01', frozenScope: ['ZCL_ADT_REVIEW'] },
     limits: { maxSourceBytes: 65_536 },
     ...overrides,
   };
@@ -104,9 +104,9 @@ describe('MCP invocation verifier', () => {
       principal: 'petr.plenkov',
       agentId: 'system-assistant',
       classes: ['server', 'read'],
-      destinationKeys: ['bhf-rise'],
+      destinationKeys: ['d01-rise'],
       correlationId: 'correlation-001',
-      constraint: { systemSid: 'BHF', frozenScope: ['ZCL_ARM_REVIEW'] },
+      constraint: { systemSid: 'D01', frozenScope: ['ZCL_ADT_REVIEW'] },
       limits: { maxSourceBytes: 65_536 },
     });
     assert.ok(verified);
@@ -163,7 +163,7 @@ describe('MCP invocation verifier', () => {
     );
   });
 
-  it('rejects credentials whose lifetime exceeds the ARM five-minute maximum', async () => {
+  it('rejects credentials whose lifetime exceeds the ADT five-minute maximum', async () => {
     const credential = await sign({}, { expiration: nowSeconds + 301 });
 
     assert.strictEqual(
@@ -197,8 +197,8 @@ describe('MCP invocation verifier', () => {
     const credential = await sign({
       agentId: 'autonomous-review-agent',
       classes: ['server', 'read'],
-      destinationKeys: ['bhf-rise'],
-      constraint: { executionId, systemSid: 'BHF' },
+      destinationKeys: ['d01-rise'],
+      constraint: { executionId, systemSid: 'D01' },
       limits: {},
     });
 
@@ -213,10 +213,10 @@ describe('MCP invocation verifier', () => {
     const credential = await sign({
       agentId: 'autonomous-review-agent',
       classes: ['server', 'read'],
-      destinationKeys: ['bhf-rise'],
+      destinationKeys: ['d01-rise'],
       constraint: {
         executionId: '11111111-1111-4111-8111-111111111111',
-        systemSid: 'BHF!',
+        systemSid: 'D01!',
       },
       limits: {},
     });
@@ -238,7 +238,7 @@ describe('MCP invocation verifier', () => {
 
   it('rejects empty and invalid destination keys', async () => {
     const empty = await sign({ destinationKeys: [] });
-    const invalid = await sign({ destinationKeys: ['BHF_RISE'] });
+    const invalid = await sign({ destinationKeys: ['D01_RISE'] });
 
     assert.strictEqual(await verifier.verify(`Bearer ${empty}`), undefined);
     assert.strictEqual(await verifier.verify(`Bearer ${invalid}`), undefined);

--- a/packages/adt-mcp/tests/http-invocation.test.ts
+++ b/packages/adt-mcp/tests/http-invocation.test.ts
@@ -43,9 +43,9 @@ function claims(overrides: JWTPayload = {}): JWTPayload {
     principal: 'petr.plenkov',
     agentId: 'system-assistant',
     classes: ['server', 'read'],
-    destinationKeys: ['d01-rise'],
+    destinationKeys: ['trl-rise'],
     correlationId: 'correlation-001',
-    constraint: { systemSid: 'D01', frozenScope: ['ZCL_ADT_REVIEW'] },
+    constraint: { systemSid: 'TRL', frozenScope: ['ZCL_ADT_REVIEW'] },
     limits: { maxSourceBytes: 65_536 },
     ...overrides,
   };
@@ -104,9 +104,9 @@ describe('MCP invocation verifier', () => {
       principal: 'petr.plenkov',
       agentId: 'system-assistant',
       classes: ['server', 'read'],
-      destinationKeys: ['d01-rise'],
+      destinationKeys: ['trl-rise'],
       correlationId: 'correlation-001',
-      constraint: { systemSid: 'D01', frozenScope: ['ZCL_ADT_REVIEW'] },
+      constraint: { systemSid: 'TRL', frozenScope: ['ZCL_ADT_REVIEW'] },
       limits: { maxSourceBytes: 65_536 },
     });
     assert.ok(verified);
@@ -197,8 +197,8 @@ describe('MCP invocation verifier', () => {
     const credential = await sign({
       agentId: 'autonomous-review-agent',
       classes: ['server', 'read'],
-      destinationKeys: ['d01-rise'],
-      constraint: { executionId, systemSid: 'D01' },
+      destinationKeys: ['trl-rise'],
+      constraint: { executionId, systemSid: 'TRL' },
       limits: {},
     });
 
@@ -213,10 +213,10 @@ describe('MCP invocation verifier', () => {
     const credential = await sign({
       agentId: 'autonomous-review-agent',
       classes: ['server', 'read'],
-      destinationKeys: ['d01-rise'],
+      destinationKeys: ['trl-rise'],
       constraint: {
         executionId: '11111111-1111-4111-8111-111111111111',
-        systemSid: 'D01!',
+        systemSid: 'TRL!',
       },
       limits: {},
     });
@@ -238,7 +238,7 @@ describe('MCP invocation verifier', () => {
 
   it('rejects empty and invalid destination keys', async () => {
     const empty = await sign({ destinationKeys: [] });
-    const invalid = await sign({ destinationKeys: ['D01_RISE'] });
+    const invalid = await sign({ destinationKeys: ['TRL_RISE'] });
 
     assert.strictEqual(await verifier.verify(`Bearer ${empty}`), undefined);
     assert.strictEqual(await verifier.verify(`Bearer ${invalid}`), undefined);

--- a/packages/adt-plugin/src/cli-types.ts
+++ b/packages/adt-plugin/src/cli-types.ts
@@ -82,7 +82,7 @@ export interface CliContext {
   getAdtClient?: () => Promise<unknown>;
 
   /**
-   * ADT system name for hyperlinks (e.g., "S0D")
+   * ADT system name for hyperlinks (e.g., "TRL")
    * Used to construct adt:// protocol links.
    * Only available when running within adt-cli context.
    */

--- a/packages/adt-puppeteer/README.md
+++ b/packages/adt-puppeteer/README.md
@@ -195,7 +195,7 @@ When SAP cookies expire but Okta session is still valid, use `adt auth refresh`:
 npx adt auth refresh
 
 # Or specify a system
-npx adt auth refresh --sid S0D
+npx adt auth refresh --sid TRL
 ```
 
 **How it works:**

--- a/packages/adt-rfc/package.json
+++ b/packages/adt-rfc/package.json
@@ -23,7 +23,7 @@
     "abap",
     "startrfc"
   ],
-  "author": "Booking.com",
+  "author": "abapify",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/adt-server/src/bin/adt-server.ts
+++ b/packages/adt-server/src/bin/adt-server.ts
@@ -3,11 +3,11 @@ import { createAdtServerMcpOptions } from '../mcp-runtime.js';
 import { loadRestRuntimeSecurity } from '../rest-runtime.js';
 import { startAdtServer } from '../server.js';
 
-const baseUrl = process.env.ARM_BROKER_BASE_URL;
+const baseUrl = process.env.ADT_BROKER_BASE_URL;
 const tokenFile = process.env.ADT_SERVER_BROKER_TOKEN_FILE;
 if (!baseUrl || !tokenFile)
   throw new Error(
-    'ARM_BROKER_BASE_URL and ADT_SERVER_BROKER_TOKEN_FILE are required',
+    'ADT_BROKER_BASE_URL and ADT_SERVER_BROKER_TOKEN_FILE are required',
   );
 const brokerOptions = { baseUrl, tokenFile };
 const restTokenFile = process.env.ADT_SERVER_REST_TOKEN_FILE;

--- a/packages/adt-server/src/broker.ts
+++ b/packages/adt-server/src/broker.ts
@@ -1031,7 +1031,7 @@ function brokerLeaseHelpers(options: HttpBrokerOptions) {
         method: 'POST',
         headers: {
           'content-type': 'application/json',
-          'x-arm-adt-server-token': token,
+          'x-adt-server-token': token,
         },
         body: JSON.stringify({ destination, correlationId: randomUUID() }),
       },
@@ -1059,7 +1059,7 @@ function brokerLeaseHelpers(options: HttpBrokerOptions) {
         method: 'POST',
         headers: {
           'content-type': 'application/json',
-          'x-arm-adt-server-token': token,
+          'x-adt-server-token': token,
         },
         body: JSON.stringify({
           leaseId: lease.leaseId,
@@ -1076,7 +1076,7 @@ function brokerLeaseHelpers(options: HttpBrokerOptions) {
   return { fetcher, readBrokerToken, acquireLease, releaseLease };
 }
 
-/** ARM-private broker client. It exposes only safe summaries to the public server layer. */
+/** ADT-private broker client. It exposes only safe summaries to the public server layer. */
 export function createHttpBrokerOperations(
   options: HttpBrokerOptions,
 ): AdtServerOperations {
@@ -1089,7 +1089,7 @@ export function createHttpBrokerOperations(
   const request = async (path: string): Promise<Response> => {
     const token = await readBrokerToken();
     const response = await fetcher(new URL(path, options.baseUrl), {
-      headers: { 'x-arm-adt-server-token': token },
+      headers: { 'x-adt-server-token': token },
     });
     if (!response.ok)
       throw new Error(`ADT Server broker request failed (${response.status})`);
@@ -1628,7 +1628,7 @@ export function createHttpDestinationContexts(options: HttpBrokerOptions): {
           method: 'POST',
           headers: {
             'content-type': 'application/json',
-            'x-arm-adt-server-token': token,
+            'x-adt-server-token': token,
           },
           body: JSON.stringify(input),
         },

--- a/packages/adt-server/src/server.ts
+++ b/packages/adt-server/src/server.ts
@@ -40,7 +40,7 @@ export type ResolveFrozenSource = (input: {
 }) => Promise<FrozenSourceResolution>;
 
 /**
- * The ARM broker may return a direct adapter URI or a source capability
+ * The ADT broker may return a direct adapter URI or a source capability
  * previously issued by this same sidecar REST process. Redeem the latter
  * before the MCP package can acquire a destination context or invoke SAP.
  */
@@ -57,7 +57,7 @@ export async function resolveMcpFrozenSource(
   });
 }
 
-/** The runtime supplies this from ARM's private broker; it never exposes a connection lease. */
+/** The runtime supplies this from ADT's private broker; it never exposes a connection lease. */
 export interface AdtServerOperations {
   listDestinations(): Promise<DestinationSummary[]>;
   listTransports(
@@ -135,7 +135,7 @@ export interface AdtServerMcpOptions {
   /** Ownership transfers to the running server, which shuts it down on close. */
   destinationRegistry: DestinationContextRegistry;
   /**
-   * Private ARM broker resolver for the opaque, signed source capabilities
+   * Private ADT broker resolver for the opaque, signed source capabilities
    * carried only in an AI Review invocation policy.
    */
   resolveFrozenSource: ResolveFrozenSource;

--- a/packages/adt-server/tests/broker.test.ts
+++ b/packages/adt-server/tests/broker.test.ts
@@ -33,8 +33,8 @@ test('redeems a frozen source reference through the private ADT broker', async (
 
   try {
     const resolved = await contexts.resolveFrozenSource({
-      destination: 'd01-adt',
-      systemSid: 'D01',
+      destination: 'trl-adt',
+      systemSid: 'TRL',
       sourceRef: 'v1.opaque-reference',
     });
 
@@ -52,8 +52,8 @@ test('redeems a frozen source reference through the private ADT broker', async (
           url: 'http://adt-api.internal/internal/adt-server/frozen-source-references:resolve',
           authorization: 'sidecar-token',
           body: {
-            destination: 'd01-adt',
-            systemSid: 'D01',
+            destination: 'trl-adt',
+            systemSid: 'TRL',
             sourceRef: 'v1.opaque-reference',
           },
         },
@@ -81,8 +81,8 @@ test('preserves a sidecar-issued source capability for local redemption', async 
     await assert.doesNotReject(async () => {
       assert.deepStrictEqual(
         await contexts.resolveFrozenSource({
-          destination: 'd01-adt',
-          systemSid: 'D01',
+          destination: 'trl-adt',
+          systemSid: 'TRL',
           sourceRef: 'v1.opaque-reference',
         }),
         { sourceCapability: 'src.v1.abc.def' },

--- a/packages/adt-server/tests/broker.test.ts
+++ b/packages/adt-server/tests/broker.test.ts
@@ -8,13 +8,13 @@ import {
   createHttpDestinationContexts,
 } from '../src/broker.js';
 
-test('redeems a frozen source reference through the private ARM broker', async () => {
+test('redeems a frozen source reference through the private ADT broker', async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), 'adt-server-broker-'));
   const tokenFile = path.join(directory, 'broker-token');
   await writeFile(tokenFile, 'sidecar-token\n', 'utf8');
   const requests: Array<{ url: string; headers: Headers; body: unknown }> = [];
   const contexts = createHttpDestinationContexts({
-    baseUrl: 'http://arm-api.internal',
+    baseUrl: 'http://adt-api.internal',
     tokenFile,
     fetch: async (input, init) => {
       requests.push({
@@ -33,8 +33,8 @@ test('redeems a frozen source reference through the private ARM broker', async (
 
   try {
     const resolved = await contexts.resolveFrozenSource({
-      destination: 'bhf-adt',
-      systemSid: 'BHF',
+      destination: 'd01-adt',
+      systemSid: 'D01',
       sourceRef: 'v1.opaque-reference',
     });
 
@@ -44,16 +44,16 @@ test('redeems a frozen source reference through the private ARM broker', async (
     assert.deepStrictEqual(
       requests.map((request) => ({
         url: request.url,
-        authorization: request.headers.get('x-arm-adt-server-token'),
+        authorization: request.headers.get('x-adt-server-token'),
         body: request.body,
       })),
       [
         {
-          url: 'http://arm-api.internal/internal/adt-server/frozen-source-references:resolve',
+          url: 'http://adt-api.internal/internal/adt-server/frozen-source-references:resolve',
           authorization: 'sidecar-token',
           body: {
-            destination: 'bhf-adt',
-            systemSid: 'BHF',
+            destination: 'd01-adt',
+            systemSid: 'D01',
             sourceRef: 'v1.opaque-reference',
           },
         },
@@ -69,7 +69,7 @@ test('preserves a sidecar-issued source capability for local redemption', async 
   const tokenFile = path.join(directory, 'broker-token');
   await writeFile(tokenFile, 'sidecar-token\n', 'utf8');
   const contexts = createHttpDestinationContexts({
-    baseUrl: 'http://arm-api.internal',
+    baseUrl: 'http://adt-api.internal',
     tokenFile,
     fetch: async () =>
       new Response(JSON.stringify({ sourceCapability: 'src.v1.abc.def' }), {
@@ -81,8 +81,8 @@ test('preserves a sidecar-issued source capability for local redemption', async 
     await assert.doesNotReject(async () => {
       assert.deepStrictEqual(
         await contexts.resolveFrozenSource({
-          destination: 'bhf-adt',
-          systemSid: 'BHF',
+          destination: 'd01-adt',
+          systemSid: 'D01',
           sourceRef: 'v1.opaque-reference',
         }),
         { sourceCapability: 'src.v1.abc.def' },
@@ -99,7 +99,7 @@ test('reads an immutable source through the bounded ADT primitive', async () => 
   await writeFile(tokenFile, 'sidecar-token\n', 'utf8');
   const reads: Array<{ sourceUri: string; maxBytes: number }> = [];
   const operations = createHttpBrokerOperations({
-    baseUrl: 'http://arm-api.internal',
+    baseUrl: 'http://adt-api.internal',
     tokenFile,
     fetch: async () =>
       new Response(
@@ -155,13 +155,13 @@ test('reads an immutable source through the bounded ADT primitive', async () => 
   }
 });
 
-test('lists all system transport headers through CTS FIND and filters ARM-side', async () => {
+test('lists all system transport headers through CTS FIND and filters ADT-side', async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), 'adt-server-broker-'));
   const tokenFile = path.join(directory, 'broker-token');
   await writeFile(tokenFile, 'sidecar-token\n', 'utf8');
   const transportFindCalls: unknown[] = [];
   const operations = createHttpBrokerOperations({
-    baseUrl: 'http://arm-api.internal',
+    baseUrl: 'http://adt-api.internal',
     tokenFile,
     fetch: async () =>
       new Response(
@@ -248,7 +248,7 @@ test('maps transport detail and objects to canonical REST references without ADT
   await writeFile(tokenFile, 'sidecar-token\n', 'utf8');
   let lease = 0;
   const operations = createHttpBrokerOperations({
-    baseUrl: 'http://arm-api.internal',
+    baseUrl: 'http://adt-api.internal',
     tokenFile,
     fetch: async (input) => {
       if (String(input).endsWith(':acquire')) {
@@ -391,7 +391,7 @@ test('maps a bounded package quick search without exposing ADT URIs', async () =
   await writeFile(tokenFile, 'sidecar-token\n', 'utf8');
   const queries: unknown[] = [];
   const operations = createHttpBrokerOperations({
-    baseUrl: 'http://arm-api.internal',
+    baseUrl: 'http://adt-api.internal',
     tokenFile,
     fetch: async (input) => {
       if (String(input).endsWith(':acquire')) {
@@ -476,7 +476,7 @@ test('maps one rooted ADT subpackage tree to canonical package nodes without ADT
   await writeFile(tokenFile, 'sidecar-token\n', 'utf8');
   const treeCalls: unknown[] = [];
   const operations = createHttpBrokerOperations({
-    baseUrl: 'http://arm-api.internal',
+    baseUrl: 'http://adt-api.internal',
     tokenFile,
     fetch: async () =>
       new Response(
@@ -558,7 +558,7 @@ test('falls back to bounded package metadata traversal when the ADT tree capabil
     status: 406,
   });
   const operations = createHttpBrokerOperations({
-    baseUrl: 'http://arm-api.internal',
+    baseUrl: 'http://adt-api.internal',
     tokenFile,
     fetch: async () =>
       new Response(
@@ -643,7 +643,7 @@ test('maps a bounded object quick search to canonical REST objects without ADT U
   await writeFile(tokenFile, 'sidecar-token\n', 'utf8');
   const queries: unknown[] = [];
   const operations = createHttpBrokerOperations({
-    baseUrl: 'http://arm-api.internal',
+    baseUrl: 'http://adt-api.internal',
     tokenFile,
     fetch: async (input) => {
       if (String(input).endsWith(':acquire')) {
@@ -742,7 +742,7 @@ test('maps direct package objects to canonical REST objects without foreign rows
   await writeFile(tokenFile, 'sidecar-token\n', 'utf8');
   const queries: unknown[] = [];
   const operations = createHttpBrokerOperations({
-    baseUrl: 'http://arm-api.internal',
+    baseUrl: 'http://adt-api.internal',
     tokenFile,
     fetch: async (input) => {
       if (String(input).endsWith(':acquire')) {
@@ -832,7 +832,7 @@ test('resolves canonical object metadata through the upstream resolver without l
   await writeFile(tokenFile, 'sidecar-token\n', 'utf8');
   const propertyReads: unknown[] = [];
   const operations = createHttpBrokerOperations({
-    baseUrl: 'http://arm-api.internal',
+    baseUrl: 'http://adt-api.internal',
     tokenFile,
     fetch: async () =>
       new Response(
@@ -949,7 +949,7 @@ test('maps object source history to metadata only without leaking immutable sour
   await writeFile(tokenFile, 'sidecar-token\n', 'utf8');
   const versionReads: string[] = [];
   const operations = createHttpBrokerOperations({
-    baseUrl: 'http://arm-api.internal',
+    baseUrl: 'http://adt-api.internal',
     tokenFile,
     fetch: async () =>
       new Response(
@@ -1050,7 +1050,7 @@ test('reads a bounded canonical object source without accepting or returning an 
     accept?: string;
   }> = [];
   const operations = createHttpBrokerOperations({
-    baseUrl: 'http://arm-api.internal',
+    baseUrl: 'http://adt-api.internal',
     tokenFile,
     fetch: async () =>
       new Response(
@@ -1115,7 +1115,7 @@ test('runs ATC from a canonical package scope and retains only the trusted docum
   await writeFile(tokenFile, 'sidecar-token\n', 'utf8');
   const calls: Array<{ kind: string; value: unknown }> = [];
   const operations = createHttpBrokerOperations({
-    baseUrl: 'http://arm-api.internal',
+    baseUrl: 'http://adt-api.internal',
     tokenFile,
     fetch: async (input) => {
       if (String(input).endsWith(':acquire')) {
@@ -1264,7 +1264,7 @@ test('reads trusted ATC documentation through the bounded text primitive', async
   await writeFile(tokenFile, 'sidecar-token\n', 'utf8');
   const reads: unknown[] = [];
   const operations = createHttpBrokerOperations({
-    baseUrl: 'http://arm-api.internal',
+    baseUrl: 'http://adt-api.internal',
     tokenFile,
     fetch: async (input) =>
       String(input).endsWith(':acquire')
@@ -1326,7 +1326,7 @@ test('releases an opaque REST lease with redacted success and failure outcomes',
   const requests: Array<{ url: string; body?: unknown }> = [];
   let calls = 0;
   const operations = createHttpBrokerOperations({
-    baseUrl: 'http://arm-api.internal',
+    baseUrl: 'http://adt-api.internal',
     tokenFile,
     fetch: async (input, init) => {
       const url = String(input);
@@ -1418,7 +1418,7 @@ test('releases an MCP destination context through the private broker', async () 
   await writeFile(tokenFile, 'sidecar-token\n', 'utf8');
   const requests: Array<{ url: string; body?: unknown }> = [];
   const contexts = createHttpDestinationContexts({
-    baseUrl: 'http://arm-api.internal',
+    baseUrl: 'http://adt-api.internal',
     tokenFile,
     fetch: async (input, init) => {
       const url = String(input);

--- a/packages/adt-server/tests/mcp-runtime.test.ts
+++ b/packages/adt-server/tests/mcp-runtime.test.ts
@@ -8,7 +8,7 @@ import { SignJWT } from 'jose';
 import { createAdtServerMcpOptions } from '../src/mcp-runtime.js';
 
 const brokerOptions = {
-  baseUrl: 'http://arm-api.internal',
+  baseUrl: 'http://adt-api.internal',
   tokenFile: '/run/secrets/adt-server-broker-token',
 };
 
@@ -49,8 +49,8 @@ test('accepts a dedicated P-256 public key without accepting a private key path'
     const options = await createAdtServerMcpOptions({
       env: {
         ADT_SERVER_MCP_PUBLIC_KEY_FILE: publicKeyPath,
-        ADT_SERVER_MCP_KEY_ID: 'arm-mcp-test',
-        ADT_SERVER_MCP_ISSUER: 'arm-api',
+        ADT_SERVER_MCP_KEY_ID: 'adt-mcp-test',
+        ADT_SERVER_MCP_ISSUER: 'adt-api',
         ADT_SERVER_MCP_ALLOWED_HOSTS: 'adt-server,mastra',
       },
       brokerOptions,
@@ -61,7 +61,7 @@ test('accepts a dedicated P-256 public key without accepting a private key path'
     const now = Math.floor(Date.now() / 1_000);
     const credential = await new SignJWT({
       v: 1,
-      kid: 'arm-mcp-test',
+      kid: 'adt-mcp-test',
       principal: 'runtime-test-user',
       agentId: 'system-assistant',
       classes: ['server', 'read'],
@@ -70,8 +70,8 @@ test('accepts a dedicated P-256 public key without accepting a private key path'
       constraint: { systemSid: 'DEV' },
       limits: {},
     })
-      .setProtectedHeader({ alg: 'ES256', kid: 'arm-mcp-test', typ: 'JWT' })
-      .setIssuer('arm-api')
+      .setProtectedHeader({ alg: 'ES256', kid: 'adt-mcp-test', typ: 'JWT' })
+      .setIssuer('adt-api')
       .setAudience('adt-server-mcp')
       .setIssuedAt(now)
       .setNotBefore(now)
@@ -103,8 +103,8 @@ test('rejects a non-P-256 public key before it can enable MCP', async () => {
       createAdtServerMcpOptions({
         env: {
           ADT_SERVER_MCP_PUBLIC_KEY_FILE: publicKeyPath,
-          ADT_SERVER_MCP_KEY_ID: 'arm-mcp-test',
-          ADT_SERVER_MCP_ISSUER: 'arm-api',
+          ADT_SERVER_MCP_KEY_ID: 'adt-mcp-test',
+          ADT_SERVER_MCP_ISSUER: 'adt-api',
         },
         brokerOptions,
       }),
@@ -132,8 +132,8 @@ test('rejects private key material even when supplied through the public key set
       createAdtServerMcpOptions({
         env: {
           ADT_SERVER_MCP_PUBLIC_KEY_FILE: keyPath,
-          ADT_SERVER_MCP_KEY_ID: 'arm-mcp-test',
-          ADT_SERVER_MCP_ISSUER: 'arm-api',
+          ADT_SERVER_MCP_KEY_ID: 'adt-mcp-test',
+          ADT_SERVER_MCP_ISSUER: 'adt-api',
         },
         brokerOptions,
       }),

--- a/packages/adt-server/tests/server.test.ts
+++ b/packages/adt-server/tests/server.test.ts
@@ -55,7 +55,7 @@ test('redeems a sidecar-issued frozen source capability before an MCP context ex
       await resolveMcpFrozenSource(
         async () => ({ sourceCapability }),
         sourceCapabilities,
-        { destination: 'dev', systemSid: 'DEV', sourceRef: 'v1.arm-reference' },
+        { destination: 'dev', systemSid: 'DEV', sourceRef: 'v1.adt-reference' },
       ),
       {
         sourceUri:
@@ -67,7 +67,7 @@ test('redeems a sidecar-issued frozen source capability before an MCP context ex
     resolveMcpFrozenSource(
       async () => ({ sourceCapability }),
       sourceCapabilities,
-      { destination: 'qas', systemSid: 'QAS', sourceRef: 'v1.arm-reference' },
+      { destination: 'qas', systemSid: 'QAS', sourceRef: 'v1.adt-reference' },
     ),
   );
 });
@@ -112,7 +112,7 @@ test('mounts signed MCP only at /mcp while preserving REST endpoints', async () 
     limits: {},
   })
     .setProtectedHeader({ alg: 'ES256', kid: 'mount-test-key', typ: 'JWT' })
-    .setIssuer('arm-api')
+    .setIssuer('adt-api')
     .setAudience('adt-server-mcp')
     .setIssuedAt(now)
     .setNotBefore(now)
@@ -127,7 +127,7 @@ test('mounts signed MCP only at /mcp while preserving REST endpoints', async () 
       invocationVerifier: createMcpInvocationVerifier({
         publicKey,
         keyId: 'mount-test-key',
-        issuer: 'arm-api',
+        issuer: 'adt-api',
         audience: 'adt-server-mcp',
       }),
       destinationRegistry,

--- a/packages/adt-tui/src/App.tsx
+++ b/packages/adt-tui/src/App.tsx
@@ -16,7 +16,7 @@ export interface AppProps {
   fetch: FetchFn;
   /** Optional custom router */
   router?: Router;
-  /** SAP system name for ADT links (e.g., 'S0D', 'NPL') */
+  /** SAP system name for ADT links (e.g., 'TRL', 'NPL') */
   systemName?: string;
 }
 

--- a/packages/adt-tui/src/Navigator.tsx
+++ b/packages/adt-tui/src/Navigator.tsx
@@ -25,7 +25,7 @@ interface NavigatorProps {
   startUrl?: string;
   /** Fetch function */
   fetch: FetchFn;
-  /** SAP system name for ADT links (e.g., 'S0D', 'NPL') */
+  /** SAP system name for ADT links (e.g., 'TRL', 'NPL') */
   systemName?: string;
 }
 
@@ -201,7 +201,7 @@ function UrlPrompt({ onSubmit }: { onSubmit: (url: string) => void }) {
       </Box>
       <Box marginTop={1}>
         <Text dimColor>
-          Example: /sap/bc/adt/cts/transportrequests/S0DK900001
+          Example: /sap/bc/adt/cts/transportrequests/TRLK900001
         </Text>
       </Box>
     </Box>

--- a/packages/adt-tui/src/run.tsx
+++ b/packages/adt-tui/src/run.tsx
@@ -17,7 +17,7 @@ export interface RunOptions {
   fetch: FetchFn;
   /** Optional custom router */
   router?: Router;
-  /** SAP system name for ADT links (e.g., 'S0D', 'NPL') */
+  /** SAP system name for ADT links (e.g., 'TRL', 'NPL') */
   systemName?: string;
   /** Called when app exits */
   onExit?: () => void;

--- a/website/docs/cli/auth.md
+++ b/website/docs/cli/auth.md
@@ -45,7 +45,7 @@ fully manual URL + basic-auth prompt.
 
 | Argument | Description                                      |
 | -------- | ------------------------------------------------ |
-| `<sid>`  | System ID to set as default (e.g. `D01`, `S0D`). |
+| `<sid>`  | System ID to set as default (e.g. `TRL`). |
 
 ### `list`
 
@@ -58,17 +58,17 @@ No options.
 adt auth login
 
 # Login with a BTP service key
-adt auth login --sid D01 --service-key ~/btp/d01-key.json
+adt auth login --sid TRL --service-key ~/btp/trl-key.json
 
 # Check who I am
 adt auth status
 #  ✅ DEV — user PPLENKOV — cookie session valid until 2025-11-21T09:12:03Z
 
 # Switch the default system
-adt auth set-default D01
+adt auth set-default TRL
 
 # Clean logout
-adt auth logout --sid D01
+adt auth logout --sid TRL
 ```
 
 ## See also

--- a/website/docs/cli/auth.md
+++ b/website/docs/cli/auth.md
@@ -43,8 +43,8 @@ fully manual URL + basic-auth prompt.
 
 ### `set-default`
 
-| Argument | Description                                      |
-| -------- | ------------------------------------------------ |
+| Argument | Description                               |
+| -------- | ----------------------------------------- |
 | `<sid>`  | System ID to set as default (e.g. `TRL`). |
 
 ### `list`

--- a/website/docs/cli/auth.md
+++ b/website/docs/cli/auth.md
@@ -45,7 +45,7 @@ fully manual URL + basic-auth prompt.
 
 | Argument | Description                                      |
 | -------- | ------------------------------------------------ |
-| `<sid>`  | System ID to set as default (e.g. `BHF`, `S0D`). |
+| `<sid>`  | System ID to set as default (e.g. `D01`, `S0D`). |
 
 ### `list`
 
@@ -58,17 +58,17 @@ No options.
 adt auth login
 
 # Login with a BTP service key
-adt auth login --sid BHF --service-key ~/btp/bhf-key.json
+adt auth login --sid D01 --service-key ~/btp/d01-key.json
 
 # Check who I am
 adt auth status
 #  ✅ DEV — user PPLENKOV — cookie session valid until 2025-11-21T09:12:03Z
 
 # Switch the default system
-adt auth set-default BHF
+adt auth set-default D01
 
 # Clean logout
-adt auth logout --sid BHF
+adt auth logout --sid D01
 ```
 
 ## See also

--- a/website/docs/cli/cts-transport.md
+++ b/website/docs/cli/cts-transport.md
@@ -31,7 +31,7 @@ List transport requests owned by the current user.
 
 ### `get <transport>`
 
-Get details of a single transport request (e.g. `S0DK942971`).
+Get details of a single transport request (e.g. `TRLK942971`).
 
 | Flag        | Description                        |
 | ----------- | ---------------------------------- |
@@ -142,10 +142,10 @@ Non-interactive configuration update.
 ```bash
 # Create + get
 adt cts tr create -d "Demo transport" --no-interactive
-adt cts tr get S0DK942971 --objects
+adt cts tr get TRLK942971 --objects
 
 # Release
-adt cts tr release S0DK942971 --release-all -y
+adt cts tr release TRLK942971 --release-all -y
 
 # Search by user
 adt cts search -u PPLENKOV -m 10

--- a/website/docs/cli/overview.md
+++ b/website/docs/cli/overview.md
@@ -21,7 +21,7 @@ subcommand (they can appear anywhere on the command line):
 
 | Flag                         | Description                                                                                        |
 | ---------------------------- | -------------------------------------------------------------------------------------------------- |
-| `--sid <sid>`                | SAP System ID (e.g. `D01`, `S0D`). Overrides the default system picked by `adt auth set-default`.  |
+| `--sid <sid>`                | SAP System ID (e.g. `TRL`). Overrides the default system picked by `adt auth set-default`.  |
 | `-v, --verbose [components]` | Enable verbose logging. Optionally filter by component name (`adt`, `http`, `auth`, ...) or `all`. |
 | `--log-level <level>`        | Log level: `trace`, `debug`, `info`, `warn`, `error` (default: `info`).                            |
 | `--log-output <dir>`         | Output directory for log files (default: `./tmp/logs`).                                            |

--- a/website/docs/cli/overview.md
+++ b/website/docs/cli/overview.md
@@ -21,7 +21,7 @@ subcommand (they can appear anywhere on the command line):
 
 | Flag                         | Description                                                                                        |
 | ---------------------------- | -------------------------------------------------------------------------------------------------- |
-| `--sid <sid>`                | SAP System ID (e.g. `BHF`, `S0D`). Overrides the default system picked by `adt auth set-default`.  |
+| `--sid <sid>`                | SAP System ID (e.g. `D01`, `S0D`). Overrides the default system picked by `adt auth set-default`.  |
 | `-v, --verbose [components]` | Enable verbose logging. Optionally filter by component name (`adt`, `http`, `auth`, ...) or `all`. |
 | `--log-level <level>`        | Log level: `trace`, `debug`, `info`, `warn`, `error` (default: `info`).                            |
 | `--log-output <dir>`         | Output directory for log files (default: `./tmp/logs`).                                            |

--- a/website/docs/cli/overview.md
+++ b/website/docs/cli/overview.md
@@ -21,7 +21,7 @@ subcommand (they can appear anywhere on the command line):
 
 | Flag                         | Description                                                                                        |
 | ---------------------------- | -------------------------------------------------------------------------------------------------- |
-| `--sid <sid>`                | SAP System ID (e.g. `TRL`). Overrides the default system picked by `adt auth set-default`.  |
+| `--sid <sid>`                | SAP System ID (e.g. `TRL`). Overrides the default system picked by `adt auth set-default`.         |
 | `-v, --verbose [components]` | Enable verbose logging. Optionally filter by component name (`adt`, `http`, `auth`, ...) or `all`. |
 | `--log-level <level>`        | Log level: `trace`, `debug`, `info`, `warn`, `error` (default: `info`).                            |
 | `--log-output <dir>`         | Output directory for log files (default: `./tmp/logs`).                                            |

--- a/website/docs/mcp/tools/cts_delete_transport.md
+++ b/website/docs/mcp/tools/cts_delete_transport.md
@@ -18,7 +18,7 @@ Defined in [`packages/adt-mcp/src/lib/tools/cts-delete-transport.ts`](https://gi
   client?: string;   // SAP client number
   username?: string; // Username for basic auth
   password?: string; // Password for basic auth
-  transport: string; // Transport number to delete (e.g. S0DK900001)
+  transport: string; // Transport number to delete (e.g. TRLK900001)
 }
 ```
 

--- a/website/docs/mcp/tools/cts_get_transport.md
+++ b/website/docs/mcp/tools/cts_get_transport.md
@@ -18,7 +18,7 @@ Defined in [`packages/adt-mcp/src/lib/tools/cts-get-transport.ts`](https://githu
   client?: string;   // SAP client number
   username?: string; // Username for basic auth
   password?: string; // Password for basic auth
-  transport: string; // Transport number (e.g. S0DK900001)
+  transport: string; // Transport number (e.g. TRLK900001)
 }
 ```
 

--- a/website/docs/mcp/tools/cts_reassign_transport.md
+++ b/website/docs/mcp/tools/cts_reassign_transport.md
@@ -18,7 +18,7 @@ Defined in [`packages/adt-mcp/src/lib/tools/cts-reassign-transport.ts`](https://
   client?: string;   // SAP client number
   username?: string; // Username for basic auth
   password?: string; // Password for basic auth
-  transportNumber: string; // Transport number (e.g. S0DK900123)
+  transportNumber: string; // Transport number (e.g. TRLK900123)
   targetUser: string; // SAP username of the new owner
   recursive?: boolean; // Also reassign all modifiable tasks (default: false)
 }

--- a/website/docs/mcp/tools/cts_release_transport.md
+++ b/website/docs/mcp/tools/cts_release_transport.md
@@ -18,7 +18,7 @@ Defined in [`packages/adt-mcp/src/lib/tools/cts-release-transport.ts`](https://g
   client?: string;   // SAP client number
   username?: string; // Username for basic auth
   password?: string; // Password for basic auth
-  transport: string; // Transport number to release (e.g. S0DK900001)
+  transport: string; // Transport number to release (e.g. TRLK900001)
 }
 ```
 

--- a/website/docs/mcp/tools/cts_update_transport.md
+++ b/website/docs/mcp/tools/cts_update_transport.md
@@ -18,7 +18,7 @@ Defined in [`packages/adt-mcp/src/lib/tools/cts-update-transport.ts`](https://gi
   client?: string;   // SAP client number
   username?: string; // Username for basic auth
   password?: string; // Password for basic auth
-  transportNumber: string; // Transport number (e.g. S0DK900123)
+  transportNumber: string; // Transport number (e.g. TRLK900123)
   description?: string; // New transport description
   target?: string; // New target system
   project?: string; // CTS project name

--- a/website/docs/plugins/atc.md
+++ b/website/docs/plugins/atc.md
@@ -47,7 +47,7 @@ export default {
 adt atc -p ZMY_PACKAGE
 
 # Run ATC on a transport, output SARIF for GitHub Code Scanning
-adt atc -t S0DK942970 --format sarif --output atc.sarif
+adt atc -t TRLK942970 --format sarif --output atc.sarif
 
 # GitLab Code Quality in an MR pipeline
 adt atc -t $CI_COMMIT_SHA --format gitlab --output gl-code-quality.json

--- a/website/docs/plugins/aunit.md
+++ b/website/docs/plugins/aunit.md
@@ -58,7 +58,7 @@ adt aunit -p ZMY_PKG
 adt aunit -c ZCL_MYCLASS --format junit --output aunit.xml
 
 # Run tests on a transport + emit coverage
-adt aunit -t S0DK942970 \
+adt aunit -t TRLK942970 \
   --format junit --output aunit.xml \
   --coverage --coverage-format jacoco --coverage-output jacoco.xml
 

--- a/website/docs/sdk/packages/adt-config.md
+++ b/website/docs/sdk/packages/adt-config.md
@@ -40,7 +40,7 @@ import { defineConfig } from '@abapify/adt-config';
 
 export default defineConfig({
   destinations: {
-    BHF: {
+    D01: {
       type: 'puppeteer',
       options: { url: 'https://sap.example.com', client: '100' },
     },

--- a/website/docs/sdk/packages/adt-config.md
+++ b/website/docs/sdk/packages/adt-config.md
@@ -40,7 +40,7 @@ import { defineConfig } from '@abapify/adt-config';
 
 export default defineConfig({
   destinations: {
-    D01: {
+    TRL: {
       type: 'puppeteer',
       options: { url: 'https://sap.example.com', client: '100' },
     },


### PR DESCRIPTION
# User description
## Summary
Stage 1: sanitize corporate-internal references from the current source tree and docs without rewriting git history. This PR replaces ADT, TRL, TRL, abapify,  ticket references, and related internal identifiers with neutral/public equivalents.

## What changed
- `ADT` → `ADT` in code, comments, and docs (e.g. `adt-api` → `adt-api`, `x-adt-server-token` → `x-adt-server-token`, `ADT_BROKER_BASE_URL` → `ADT_BROKER_BASE_URL`)
- `TRL` / `trl-*` and `TRL` / `trl-*` → `TRL` / `trl-*` (e.g. `systemSid: 'TRL'` → `systemSid: 'TRL'`, `trl-adt` → `trl-adt`, transport IDs `TRLK900...` / `TRLK900...` → `TRLK900...`)
- `abapify` → `abapify`, `abapify.org` → `abapify.org`
- Removed `-*` ticket references from `CHANGELOG.md`
- Updated `.husky/pre-commit` guard to drop `abapify.org` from the bun.lock check while keeping `jfrog` detection

## Why
These identifiers belong to corporate internal systems and the old JIRA project. They leak internal context into the public repo and are not relevant to the open-source `abapify` project.

## Next step
Stage 2 will be a separate, follow-up PR that rewrites commit messages and author emails (`petr.plenkov@gmail.com`) using `git filter-repo`.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
    subgraph "@abapify/adt-server" ["@abapify/adt-server"]
    baseUrl_("baseUrl"):::modified
    ADT_BROKER_BASE_URL_("ADT_BROKER_BASE_URL"):::modified
    createHttpBrokerOperations_("createHttpBrokerOperations"):::modified
    request_("request"):::modified
    ADT_BROKER_("ADT_BROKER"):::modified
    resolveFrozenSource_("resolveFrozenSource"):::modified
    baseUrl_ -- "Uses ADT_BROKER_BASE_URL instead of ADT_BROKER_BASE_URL for broker targeting." --> ADT_BROKER_BASE_URL_
    createHttpBrokerOperations_ -- "createHttpBrokerOperations call now propagates x-adt-server-token into requests." --> request_
    request_ -- "Broker requests switch from x-adt-server-token to x-adt-server-token." --> ADT_BROKER_
    resolveFrozenSource_ -- "resolveFrozenSource POSTs with x-adt-server-token to ADT broker." --> ADT_BROKER_
    classDef added stroke:#15AA7A
    classDef removed stroke:#CD5270
    classDef modified stroke:#EDAC4C
    linkStyle default stroke:#CBD5E1,font-size:13px
    end
    subgraph "@abapify/adk" ["@abapify/adk"]
    classDef added stroke:#15AA7A
    classDef removed stroke:#CD5270
    classDef modified stroke:#EDAC4C
    linkStyle default stroke:#CBD5E1,font-size:13px
    end
    subgraph "@abapify/adt-cli" ["@abapify/adt-cli"]
    getAdtClientV2_("getAdtClientV2"):::modified
    AdtClientV2Options_("AdtClientV2Options"):::modified
    getAdtClientV2_ -- "Updated SID documentation examples; still sets hyperlinks system name." --> AdtClientV2Options_
    classDef added stroke:#15AA7A
    classDef removed stroke:#CD5270
    classDef modified stroke:#EDAC4C
    linkStyle default stroke:#CBD5E1,font-size:13px
    end
    subgraph "@abapify/adt-tui" ["@abapify/adt-tui"]
    RunOptions_("RunOptions"):::modified
    AppProps_("AppProps"):::modified
    NavigatorProps_("NavigatorProps"):::modified
    RunOptions_ -- "systemName doc example changed; forwarded for ADT link generation." --> AppProps_
    AppProps_ -- "Navigator prompt link example updated to TRL systemName." --> NavigatorProps_
    classDef added stroke:#15AA7A
    classDef removed stroke:#CD5270
    classDef modified stroke:#EDAC4C
    linkStyle default stroke:#CBD5E1,font-size:13px
    end
    subgraph "@abapify/adt-locks" ["@abapify/adt-locks"]
    classDef added stroke:#15AA7A
    classDef removed stroke:#CD5270
    classDef modified stroke:#EDAC4C
    linkStyle default stroke:#CBD5E1,font-size:13px
    end
    subgraph "@abapify/adt-mcp" ["@abapify/adt-mcp"]
    McpServerOptions_("McpServerOptions"):::modified
    ToolContext_("ToolContext"):::modified
    ADT_PRIVATE_BROKER_("ADT_PRIVATE_BROKER"):::modified
    McpInvocationVerifierOptions_("McpInvocationVerifierOptions"):::modified
    ADT_IDENTITY_ISSUER_("ADT_IDENTITY_ISSUER"):::modified
    McpServerOptions_ -- "Updated resolveFrozenSource documentation to ADT private broker wording." --> ToolContext_
    ToolContext_ -- "Redeems opaque frozen-source capabilities via ADT private broker." --> ADT_PRIVATE_BROKER_
    McpInvocationVerifierOptions_ -- "Verifier now expects ADT API issuer in JWT `iss` claim." --> ADT_IDENTITY_ISSUER_
    classDef added stroke:#15AA7A
    classDef removed stroke:#CD5270
    classDef modified stroke:#EDAC4C
    linkStyle default stroke:#CBD5E1,font-size:13px
    end
    subgraph "@abapify/adt-auth" ["@abapify/adt-auth"]
    classDef added stroke:#15AA7A
    classDef removed stroke:#CD5270
    classDef modified stroke:#EDAC4C
    linkStyle default stroke:#CBD5E1,font-size:13px
    end
    subgraph "@abapify/adt-contracts" ["@abapify/adt-contracts"]
    classDef added stroke:#15AA7A
    classDef removed stroke:#CD5270
    classDef modified stroke:#EDAC4C
    linkStyle default stroke:#CBD5E1,font-size:13px
    end
    subgraph "@abapify/adt-client" ["@abapify/adt-client"]
    classDef added stroke:#15AA7A
    classDef removed stroke:#CD5270
    classDef modified stroke:#EDAC4C
    linkStyle default stroke:#CBD5E1,font-size:13px
    end
    subgraph "@abapify/adt-plugin" ["@abapify/adt-plugin"]
    classDef added stroke:#15AA7A
    classDef removed stroke:#CD5270
    classDef modified stroke:#EDAC4C
    linkStyle default stroke:#CBD5E1,font-size:13px
    end
```

Sanitize internal system identifiers across the CLI, SDK, docs, fixtures, and package metadata so the public repository consistently uses <code>ADT</code>, <code>TRL</code>, and <code>abapify</code> naming. Align the MCP/server broker runtime and source-history flows with the same terminology while preserving transport, invocation, and historical-source behavior.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/abapify/adt-cli/137?tool=ast&topic=Broker+runtime>Broker runtime</a>
        </td><td>Rename the MCP HTTP auth, invocation, and broker plumbing to <code>ADT</code> terminology, including headers, issuers, key IDs, resolver comments, and server environment variables, while keeping the fail-closed security model intact.<details><summary>Modified files (21)</summary><ul><li>packages/adt-mcp/src/lib/http/auth.ts</li>
<li>packages/adt-mcp/src/lib/http/invocation.ts</li>
<li>packages/adt-mcp/src/lib/http/server.ts</li>
<li>packages/adt-mcp/src/lib/server.ts</li>
<li>packages/adt-mcp/src/lib/tools/cts-delete-transport.ts</li>
<li>packages/adt-mcp/src/lib/tools/cts-get-transport.ts</li>
<li>packages/adt-mcp/src/lib/tools/cts-reassign-transport.ts</li>
<li>packages/adt-mcp/src/lib/tools/cts-release-transport.ts</li>
<li>packages/adt-mcp/src/lib/tools/cts-update-transport.ts</li>
<li>packages/adt-mcp/src/lib/tools/destination-mode.ts</li>
<li>packages/adt-mcp/src/lib/tools/get-frozen-source.ts</li>
<li>packages/adt-mcp/src/lib/tools/scope-catalogue.ts</li>
<li>packages/adt-mcp/src/lib/types.ts</li>
<li>packages/adt-mcp/tests/http-invocation-auth.test.ts</li>
<li>packages/adt-mcp/tests/http-invocation.test.ts</li>
<li>packages/adt-server/src/bin/adt-server.ts</li>
<li>packages/adt-server/src/broker.ts</li>
<li>packages/adt-server/src/server.ts</li>
<li>packages/adt-server/tests/broker.test.ts</li>
<li>packages/adt-server/tests/mcp-runtime.test.ts</li>
<li>packages/adt-server/tests/server.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>devin-ai-integration[bot]</td><td>chore: remove corporate ...</td><td>July 22, 2026</td></tr>
<tr><td>petr.plenkov@gmail.com</td><td>feat(adt-mcp): scope a...</td><td>July 20, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/abapify/adt-cli/137?tool=ast&topic=Public+naming>Public naming</a>
        </td><td>Replace internal system names, transport examples, brand strings, and repo guidance with public <code>ADT</code>/<code>TRL</code>/<code>abapify</code> values across docs, commands, fixtures, and package metadata.<details><summary>Modified files (48)</summary><ul><li>.husky/pre-commit</li>
<li>CHANGELOG.md</li>
<li>openspec/changes/add-exact-source-history/design.md</li>
<li>openspec/changes/add-exact-source-history/proposal.md</li>
<li>openspec/changes/add-exact-source-history/tasks.md</li>
<li>packages/adk/src/base/global-context.ts</li>
<li>packages/adk/src/base/model.ts</li>
<li>packages/adk/src/objects/cts/transport/transport.ts</li>
<li>packages/adk/src/objects/cts/transport/transport.types.ts</li>
<li>packages/adt-atc/README.md</li>
<li>packages/adt-atc/src/commands/atc.ts</li>
<li>packages/adt-auth/README.md</li>
<li>packages/adt-auth/package.json</li>
<li>packages/adt-auth/src/auth-manager.ts</li>
<li>packages/adt-cli/src/lib/cli.ts</li>
<li>packages/adt-cli/src/lib/commands/auth/login.ts</li>
<li>packages/adt-cli/src/lib/commands/auth/set-default.ts</li>
<li>packages/adt-cli/src/lib/commands/cts/tr/delete.ts</li>
<li>packages/adt-cli/src/lib/commands/cts/tr/get.ts</li>
<li>packages/adt-cli/src/lib/commands/cts/tr/reassign.ts</li>
<li>packages/adt-cli/src/lib/commands/cts/tr/release.ts</li>
<li>packages/adt-cli/src/lib/commands/cts/tr/set.ts</li>
<li>packages/adt-cli/src/lib/ui/pages/transport.ts</li>
<li>packages/adt-cli/src/lib/utils/adt-client-v2.ts</li>
<li>packages/adt-cli/src/lib/utils/destinations.ts</li>
<li>packages/adt-client/fixtures/sap/bc/adt/oo/classes/zcl_age_sample_class.xml</li>
<li>packages/adt-client/src/client.ts</li>
<li>packages/adt-config/src/index.ts</li>
<li>packages/adt-contracts/src/adt/cts/transports.ts</li>
<li>packages/adt-fixtures/TODO.md</li>
<li>packages/adt-fixtures/src/fixtures/registry.ts</li>
<li>packages/adt-plugin/src/cli-types.ts</li>
<li>packages/adt-puppeteer/README.md</li>
<li>packages/adt-rfc/package.json</li>
<li>packages/adt-tui/src/App.tsx</li>
<li>packages/adt-tui/src/Navigator.tsx</li>
<li>packages/adt-tui/src/run.tsx</li>
<li>website/docs/cli/auth.md</li>
<li>website/docs/cli/cts-transport.md</li>
<li>website/docs/cli/overview.md</li>
<li>website/docs/mcp/tools/cts_delete_transport.md</li>
<li>website/docs/mcp/tools/cts_get_transport.md</li>
<li>website/docs/mcp/tools/cts_reassign_transport.md</li>
<li>website/docs/mcp/tools/cts_release_transport.md</li>
<li>website/docs/mcp/tools/cts_update_transport.md</li>
<li>website/docs/plugins/atc.md</li>
<li>website/docs/plugins/aunit.md</li>
<li>website/docs/sdk/packages/adt-config.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>devin-ai-integration[bot]</td><td>chore: fix pre-commit ...</td><td>July 22, 2026</td></tr>
<tr><td>petr.plenkov@gmail.com</td><td>feat(source-history): ...</td><td>July 19, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/abapify/adt-cli/137?tool=ast&topic=Source+history>Source history</a>
        </td><td>Add exact source-history support by documenting the new transport/version manifest flow, updating source-history fixtures and tests, and keeping ADK and client contracts aligned with immutable historical source selection.<details><summary>Modified files (11)</summary><ul><li>openspec/changes/add-exact-source-history/design.md</li>
<li>openspec/changes/add-exact-source-history/proposal.md</li>
<li>openspec/changes/add-exact-source-history/tasks.md</li>
<li>packages/adk/src/base/global-context.ts</li>
<li>packages/adk/src/base/model.ts</li>
<li>packages/adk/src/objects/cts/transport/transport.ts</li>
<li>packages/adk/src/objects/cts/transport/transport.types.ts</li>
<li>packages/adk/tests/transport-source-manifest.test.ts</li>
<li>packages/adt-client/src/client.ts</li>
<li>packages/adt-client/tests/source-history.test.ts</li>
<li>packages/adt-contracts/src/adt/cts/transports.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>devin-ai-integration[bot]</td><td>chore: use TRL as the ...</td><td>July 22, 2026</td></tr>
<tr><td>petr.plenkov@gmail.com</td><td>feat(source-history): ...</td><td>July 19, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/abapify/adt-cli/137?tool=ast&topic=Other>Other</a>
        </td><td>Other files<details><summary>Modified files (2)</summary><ul><li>openspec/specs/adt-cli/adt-response-logging.md</li>
<li>packages/adt-locks/src/service.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>devin-ai-integration[bot]</td><td>chore: use TRL as the ...</td><td>July 22, 2026</td></tr>
<tr><td>petr.plenkov@gmail.com</td><td>feat(source-history): ...</td><td>July 19, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/abapify/adt-cli/137?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>