### PR TITLE
feat(adt-mcp): classify bounded analysis execution

### DIFF
--- a/openspec/changes/add-bounded-analysis-class/design.md
+++ b/openspec/changes/add-bounded-analysis-class/design.md
@@ -1,0 +1,32 @@
+# Design: bounded analysis execution class
+
+## Decision
+
+`safe_execute` is a distinct semantic operation class. It does not imply
+`read` or `write` authority.
+
+The first catalogue member is `atc_run`: an ATC execution cannot modify ABAP
+repository objects, but it creates a temporary server-side worklist and may
+consume meaningful system resources. A read grant therefore must not expose
+it.
+
+## Enforcement
+
+The MCP tool catalogue remains the authority on each tool's class. Destination
+mode filters both tool discovery and dispatch through that catalogue before a
+destination lease or tool handler is reached.
+
+The signed-invocation parser accepts the class so future credentials can have
+a stable vocabulary. Dispatch remains denied until a subsequent change defines
+and implements one exact policy for target scope, check variant, result cap,
+runtime cap, and replay protection. Accepting a claim before enforcing all of
+those fields would widen authority.
+
+## Alternatives rejected
+
+- Classify ATC as `read`: rejected because it causes server-side analysis
+  state.
+- Classify ATC as `write`: rejected because it conflates analysis with ABAP
+  repository mutation.
+- Enable a generic execution grant now: rejected because a class alone does
+  not constrain scope, resources, or replay.

--- a/openspec/changes/add-bounded-analysis-class/proposal.md
+++ b/openspec/changes/add-bounded-analysis-class/proposal.md
@@ -1,0 +1,28 @@
+# Add an explicit bounded-analysis operation class
+
+## Why
+
+Some SAP diagnostic operations create temporary server-side analysis state.
+Treating them as ordinary reads makes a signed read grant broader than its
+meaning.
+
+## What changes
+
+- Add `safe_execute` as an MCP operation class.
+- Reclassify `atc_run` from `read` to `safe_execute`.
+- Parse the new class in signed invocation claims, while keeping it
+  non-dispatchable until a later change defines an exact, enforceable policy.
+
+## Non-goals
+
+- This change adds no issuer-specific policy, agent identity, or execution
+  workflow.
+- This change does not enable a diagnostic run through signed HTTP invocation.
+- This change does not alter ABAP repository write permissions.
+
+## Validation
+
+- Scope tests prove a read grant cannot call `atc_run`.
+- Scope tests prove only `safe_execute` can dispatch `atc_run`.
+- Invocation tests prove an unimplemented `safe_execute` policy remains
+  fail-closed.

--- a/openspec/changes/add-bounded-analysis-class/specs/adt-mcp/spec.md
+++ b/openspec/changes/add-bounded-analysis-class/specs/adt-mcp/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Bounded analysis is a separate operation class
+
+The server SHALL classify every MCP tool that creates diagnostic analysis
+state as `safe_execute`, independently of its HTTP method and independently
+of repository mutation authority.
+
+#### Scenario: Read credential requests ATC
+
+- **WHEN** a credential contains only the `read` class
+- **THEN** `atc_run` is absent from the destination-mode tool list and a direct
+  call is denied before a destination lease or tool handler
+
+#### Scenario: Explicit bounded-analysis credential requests ATC
+
+- **WHEN** a trusted request access snapshot contains `safe_execute`
+- **THEN** the scope catalogue permits `atc_run` subject to all other
+  destination and resource checks
+
+### Requirement: Unsupported signed policies fail closed
+
+The server SHALL not dispatch a signed invocation that includes
+`safe_execute` until it can enforce every policy field required for that
+operation.
+
+#### Scenario: Future-form safe-execution credential arrives early
+
+- **WHEN** a valid signed credential contains `safe_execute` but no supported
+  exact execution policy exists
+- **THEN** the server exposes no MCP tools through that invocation

--- a/openspec/changes/add-bounded-analysis-class/tasks.md
+++ b/openspec/changes/add-bounded-analysis-class/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] Add `safe_execute` to the operation-class vocabulary.
+- [x] Reclassify `atc_run` and prove ordinary reads cannot dispatch it.
+- [x] Keep signed `safe_execute` claims fail-closed until exact scope
+      enforcement exists.
+- [ ] Run package build, typecheck, tests, lint, and full-tree formatting.

--- a/packages/adt-mcp/README.md
+++ b/packages/adt-mcp/README.md
@@ -498,6 +498,10 @@ Delete a transport request.
 
 Run ABAP Test Cockpit checks on an object or package and return the resulting findings worklist.
 
+In destination mode, this operation requires an explicit `safe_execute`
+grant. A `read` grant is insufficient because SAP creates a temporary
+server-side worklist for the analysis.
+
 **Parameters:**
 
 | Parameter | Type   | Description                                                                                                                                             |

--- a/packages/adt-mcp/src/lib/http/invocation.ts
+++ b/packages/adt-mcp/src/lib/http/invocation.ts
@@ -27,9 +27,9 @@ const trustedAgentIds = new Set([
   'system-assistant',
   'autonomous-review-agent',
 ]);
-const trustedOperationClasses = new Set(['server', 'read']);
+const trustedOperationClasses = new Set(['server', 'read', 'safe_execute']);
 
-export type McpTrustedOperationClass = 'server' | 'read';
+export type McpTrustedOperationClass = 'server' | 'read' | 'safe_execute';
 
 export type McpInvocationJsonValue =
   | boolean
@@ -44,9 +44,7 @@ export interface TrustedMcpInvocationClaims {
   readonly tokenId: string;
   readonly principal: string;
   readonly agentId:
-    | 'ai-review'
-    | 'system-assistant'
-    | 'autonomous-review-agent';
+    'ai-review' | 'system-assistant' | 'autonomous-review-agent';
   readonly classes: readonly McpTrustedOperationClass[];
   readonly destinationKeys: readonly string[];
   readonly correlationId: string;
@@ -108,7 +106,12 @@ export interface McpInvocationVerifier {
 function isSystemAssistantPolicySupported(
   claims: TrustedMcpInvocationClaims,
 ): boolean {
-  if (Object.keys(claims.limits).length !== 0) return false;
+  if (
+    !hasServerReadClasses(claims) ||
+    Object.keys(claims.limits).length !== 0
+  ) {
+    return false;
+  }
   const constraintKeys = Object.keys(claims.constraint);
   return (
     constraintKeys.length === 1 &&

--- a/packages/adt-mcp/src/lib/tools/scope-catalogue.ts
+++ b/packages/adt-mcp/src/lib/tools/scope-catalogue.ts
@@ -6,14 +6,19 @@
  * catalogue is the single source of truth for the operation a tool performs.
  */
 
-export type McpOperationClass = 'server' | 'read' | 'write';
+export type McpOperationClass = 'server' | 'read' | 'safe_execute' | 'write';
 
 const destinationKeyPattern = /^[a-z][a-z0-9-]{1,62}$/u;
 
 export function isMcpOperationClass(
   value: unknown,
 ): value is McpOperationClass {
-  return value === 'server' || value === 'read' || value === 'write';
+  return (
+    value === 'server' ||
+    value === 'read' ||
+    value === 'safe_execute' ||
+    value === 'write'
+  );
 }
 
 export function isMcpDestinationKey(value: unknown): value is string {
@@ -58,6 +63,13 @@ const read = (names: readonly string[]): Record<string, StaticToolScope> =>
 const write = (names: readonly string[]): Record<string, StaticToolScope> =>
   Object.fromEntries(names.map((name) => [name, { operationClass: 'write' }]));
 
+const safeExecute = (
+  names: readonly string[],
+): Record<string, StaticToolScope> =>
+  Object.fromEntries(
+    names.map((name) => [name, { operationClass: 'safe_execute' }]),
+  );
+
 /**
  * Every registered MCP tool has one entry. A mixed-action tool resolves its
  * operation class from validated arguments; the default remains `write`.
@@ -65,7 +77,6 @@ const write = (names: readonly string[]): Record<string, StaticToolScope> =>
 export const MCP_TOOL_SCOPE_CATALOGUE: Readonly<Record<string, McpToolScope>> =
   {
     ...read([
-      'atc_run',
       'check_syntax',
       'discovery',
       'find_definition',
@@ -132,6 +143,9 @@ export const MCP_TOOL_SCOPE_CATALOGUE: Readonly<Record<string, McpToolScope>> =
       'cts_transport_objects',
       'cts_transport_source_manifest',
     ]),
+    // ATC creates a server-side worklist even though it does not mutate ABAP
+    // repository objects. It therefore needs an explicit execution grant.
+    ...safeExecute(['atc_run']),
     ...write([
       'activate_object',
       'activate_package',

--- a/packages/adt-mcp/tests/http-destination-scope.test.ts
+++ b/packages/adt-mcp/tests/http-destination-scope.test.ts
@@ -49,11 +49,11 @@ test('HTTP destination mode projects only read-scoped tools without weakening hi
     const names = new Set(tools.tools.map((tool) => tool.name));
     const gctsConfig = tools.tools.find((tool) => tool.name === 'gcts_config');
     const gctsActionSchema = gctsConfig?.inputSchema.properties?.action as
-      | { enum?: unknown[] }
-      | undefined;
+      { enum?: unknown[] } | undefined;
 
     assert.ok(names.has('system_info'));
     assert.ok(names.has('gcts_config'));
+    assert.ok(!names.has('atc_run'));
     assert.ok(!names.has('lock_object'));
     assert.ok(!names.has('activate_object'));
     assert.deepStrictEqual(gctsActionSchema?.enum, ['get', 'list']);
@@ -340,8 +340,7 @@ test('HTTP destination mode fails closed when trusted access is absent', async (
   let contexts = 0;
   // eslint-disable-next-line prefer-const
   let access:
-    | { classes: Array<'read'>; destinationKeys: Array<string> }
-    | undefined;
+    { classes: Array<'read'>; destinationKeys: Array<string> } | undefined;
   const destinations = createDestinationContextRegistry({
     leaseProvider: {
       async acquire({ destination }) {

--- a/packages/adt-mcp/tests/http-invocation.test.ts
+++ b/packages/adt-mcp/tests/http-invocation.test.ts
@@ -120,6 +120,20 @@ describe('MCP invocation verifier', () => {
     });
   });
 
+  it('recognises but does not dispatch an unimplemented safe-execution policy', async () => {
+    const credential = await sign({
+      classes: ['server', 'safe_execute'],
+      constraint: { systemSid: 'TRL' },
+      limits: {},
+    });
+
+    const verified = await verifier.verify(`Bearer ${credential}`);
+
+    assert.deepStrictEqual(verified?.classes, ['server', 'safe_execute']);
+    assert.ok(verified);
+    assert.strictEqual(isMcpInvocationDispatchPolicySupported(verified), false);
+  });
+
   it('rejects a credential with an invalid ES256 signature', async () => {
     const { privateKey: untrustedPrivateKey } = await generateKeyPair('ES256');
     const credential = await sign({}, { signingKey: untrustedPrivateKey });

--- a/packages/adt-mcp/tests/scope-enforcement.test.ts
+++ b/packages/adt-mcp/tests/scope-enforcement.test.ts
@@ -80,6 +80,49 @@ test('a read-scoped caller can dispatch a permitted read tool', async () => {
   assert.strictEqual(calls, 1);
 });
 
+test('ATC analysis requires an explicit safe-execution class', async () => {
+  const target = new CapturingServer();
+  let calls = 0;
+  const readServer = destinationModeServer(target as unknown as McpServer, {
+    requestAccess: () => ({ classes: ['read'], destinationKeys: ['dev'] }),
+  });
+  readServer.tool('atc_run', {}, async () => {
+    calls++;
+    return { content: [{ type: 'text' as const, text: 'unexpected' }] };
+  });
+
+  const denied = await target.handlers.get('atc_run')!(
+    { destination: 'dev' },
+    { sessionId: 'session-1' },
+  );
+  assert.strictEqual(denied.isError, true);
+  assert.strictEqual(denied.content[0]?.text, 'mcp_scope_denied');
+  assert.strictEqual(calls, 0);
+
+  const permittedTarget = new CapturingServer();
+  const safeExecutionServer = destinationModeServer(
+    permittedTarget as unknown as McpServer,
+    {
+      requestAccess: () => ({
+        classes: ['safe_execute'],
+        destinationKeys: ['dev'],
+      }),
+    },
+  );
+  safeExecutionServer.tool('atc_run', {}, async () => {
+    calls++;
+    return { content: [{ type: 'text' as const, text: 'permitted' }] };
+  });
+
+  const permitted = await permittedTarget.handlers.get('atc_run')!(
+    { destination: 'dev' },
+    { sessionId: 'session-2' },
+  );
+  assert.notStrictEqual(permitted.isError, true);
+  assert.strictEqual(permitted.content[0]?.text, 'permitted');
+  assert.strictEqual(calls, 1);
+});
+
 test('a read-scoped caller cannot dispatch a permitted read tool on an unauthorised destination', async () => {
   let leases = 0;
   let contexts = 0;
@@ -260,8 +303,7 @@ test('destination mode exposes capability-bound immutable source selection witho
       (candidate) => candidate.name === 'get_source_version',
     );
     const properties = tool?.inputSchema.properties as
-      | Record<string, unknown>
-      | undefined;
+      Record<string, unknown> | undefined;
 
     assert.ok(tool);
     assert.ok(properties?.sourceCapability);
@@ -293,8 +335,7 @@ test('destination mode hides and rejects the legacy raw ATC URI target', async (
       (candidate) => candidate.name === 'atc_run',
     );
     const properties = tool?.inputSchema.properties as
-      | Record<string, unknown>
-      | undefined;
+      Record<string, unknown> | undefined;
 
     assert.ok(tool);
     assert.ok(properties?.scope);
@@ -343,8 +384,7 @@ test('destination mode hides raw URI fields from all canonical read tools', asyn
     for (const [name, forbiddenField] of Object.entries(forbiddenFields)) {
       const tool = tools.tools.find((candidate) => candidate.name === name);
       const properties = tool?.inputSchema.properties as
-        | Record<string, unknown>
-        | undefined;
+        Record<string, unknown> | undefined;
       assert.ok(tool, `${name} must be listed to a read-scoped caller`);
       assert.ok(
         !Object.hasOwn(properties ?? {}, forbiddenField),


### PR DESCRIPTION
# User description
## Summary
Add safe_execute as a distinct MCP operation class and reclassify atc_run from read to safe_execute.

## Changes
- Add safe_execute to the operation-class vocabulary
- Reclassify atc_run and prove ordinary reads cannot dispatch it
- Keep signed safe_execute claims fail-closed until exact scope enforcement exists
- Add corresponding tests and documentation

## Context
This change adds a new operation class for bounded analysis operations that create temporary server-side state. ATC runs now require an explicit safe_execute grant instead of being included in read.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
isMcpOperationClass_("isMcpOperationClass"):::modified
McpOperationClass_("McpOperationClass"):::modified
safeExecute_("safeExecute"):::added
TrustedMcpInvocationClaims_("TrustedMcpInvocationClaims"):::modified
McpTrustedOperationClass_("McpTrustedOperationClass"):::modified
isSystemAssistantPolicySupported_("isSystemAssistantPolicySupported"):::modified
isMcpOperationClass_ -- "Validation now accepts `safe_execute` operation class values." --> McpOperationClass_
safeExecute_ -- "Adds scopes marking tools as `safe_execute` operations." --> McpOperationClass_
TrustedMcpInvocationClaims_ -- "Trusted invocation classes now allow `safe_execute`." --> McpTrustedOperationClass_
isSystemAssistantPolicySupported_ -- "Now rejects claims lacking server/read classes or with nonempty limits." --> TrustedMcpInvocationClaims_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Add a distinct <code>safe_execute</code> MCP operation class for bounded analysis and reclassify <code>atc_run</code> in <code>scope-catalogue</code> so destination-mode access checks and documentation require an explicit grant instead of treating ATC as read-only. Extend <code>invocation.ts</code> to recognize <code>safe_execute</code> in trusted claims while keeping signed dispatch fail-closed until exact scope enforcement is implemented.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/abapify/adt-cli/141?tool=ast&topic=ATC+scope>ATC scope</a>
        </td><td>Reclassify <code>atc_run</code> as <code>safe_execute</code>, update the MCP scope catalogue and destination-mode checks to block read-only callers, and document the explicit grant required for bounded analysis.<details><summary>Modified files (8)</summary><ul><li>openspec/changes/add-bounded-analysis-class/design.md</li>
<li>openspec/changes/add-bounded-analysis-class/proposal.md</li>
<li>openspec/changes/add-bounded-analysis-class/specs/adt-mcp/spec.md</li>
<li>openspec/changes/add-bounded-analysis-class/tasks.md</li>
<li>packages/adt-mcp/README.md</li>
<li>packages/adt-mcp/src/lib/tools/scope-catalogue.ts</li>
<li>packages/adt-mcp/tests/http-destination-scope.test.ts</li>
<li>packages/adt-mcp/tests/scope-enforcement.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>petr.plenkov@gmail.com</td><td>feat(adt-mcp): classif...</td><td>July 22, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/abapify/adt-cli/141?tool=ast&topic=Invocation+policy>Invocation policy</a>
        </td><td>Accept <code>safe_execute</code> in trusted invocation claims, but keep signed dispatch disabled until a full policy exists, with tests covering the fail-closed path.<details><summary>Modified files (2)</summary><ul><li>packages/adt-mcp/src/lib/http/invocation.ts</li>
<li>packages/adt-mcp/tests/http-invocation.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>petr.plenkov@gmail.com</td><td>feat(adt-mcp): classif...</td><td>July 22, 2026</td></tr>
<tr><td>devin-ai-integration[bot]</td><td>refactor(adt-mcp): ext...</td><td>July 21, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/abapify/adt-cli/141?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new MCP operation class `safe_execute` for bounded analysis and move `atc_run` into it. Read-only access can no longer run ATC; only explicit `safe_execute` is allowed, and signed invocations stay fail-closed until an execution policy exists.

- **New Features**
  - Added `safe_execute` to the `adt-mcp` operation-class vocabulary.
  - Reclassified `atc_run` to `safe_execute`; it’s hidden from read-only tool lists and blocked before destination leasing.
  - Invocation verifier now recognizes `safe_execute` and tightens system-assistant checks: requires `server`+`read` classes and no limits; still refuses dispatch without an exact policy.

- **Migration**
  - Destination mode: request `safe_execute` to run `atc_run`; `read` alone is insufficient.
  - Signed HTTP: credentials with `safe_execute` are parsed but cannot execute until the policy is implemented.

<sup>Written for commit 09d7cd7e713f5e6c1b4eb5a2ac3e2c9ceae9211b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

