### PR TITLE
feat(adt-mcp): enforce scoped safe execution

### DIFF
--- a/packages/adt-client/src/adapter.ts
+++ b/packages/adt-client/src/adapter.ts
@@ -10,6 +10,7 @@ import type { HttpAdapter, HttpRequestOptions } from '@abapify/adt-contracts';
 import type { ResponsePlugin, ResponseContext } from './plugins/types';
 import { SessionManager } from './utils/session';
 import { createAdtError } from './errors';
+import { activeAdtAbortSignal } from './cancellation';
 
 // Re-export HttpAdapter type for consumers
 /**
@@ -123,6 +124,32 @@ async function readResponseTextBounded(
   return new TextDecoder().decode(combined);
 }
 
+function executionAbortController(): {
+  abortController: AbortController;
+  dispose: () => void;
+} {
+  const abortController = new AbortController();
+  const executionSignal = activeAdtAbortSignal();
+  if (!executionSignal) {
+    return { abortController, dispose: () => undefined };
+  }
+
+  const abortFromExecution = () =>
+    abortController.abort(executionSignal.reason);
+  if (executionSignal.aborted) {
+    abortFromExecution();
+  } else {
+    executionSignal.addEventListener('abort', abortFromExecution, {
+      once: true,
+    });
+  }
+  return {
+    abortController,
+    dispose: () =>
+      executionSignal.removeEventListener('abort', abortFromExecution),
+  };
+}
+
 /**
  * Create ADT HTTP adapter with Basic or SAML Authentication and plugin support
  */
@@ -176,6 +203,8 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
     async request<TResponse = unknown>(
       options: HttpRequestOptions,
     ): Promise<TResponse> {
+      const executionSignal = activeAdtAbortSignal();
+      executionSignal?.throwIfAborted();
       logger?.debug('=== ADAPTER REQUEST START ===');
       logger?.debug('options.url:', options.url);
       logger?.debug('options.method:', options.method);
@@ -223,6 +252,7 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
           authHeader, // undefined for cookie auth — SessionManager uses stored cookies
           client,
           language,
+          executionSignal,
         );
       }
 
@@ -241,8 +271,7 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
       // Get schemas from speci's standard fields
       // Check if bodySchema is Serializable (has build method from adt-schemas)
       let bodySerializableSchema:
-        | { build: (data: unknown) => string }
-        | undefined;
+        { build: (data: unknown) => string } | undefined;
       if (options.bodySchema && typeof options.bodySchema === 'object') {
         if (
           'build' in options.bodySchema &&
@@ -363,6 +392,7 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
         method: options.method,
         headers,
         body: requestBody,
+        signal: executionSignal,
       });
 
       // Process response for session management (cookies, CSRF, ETags)
@@ -538,32 +568,36 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
       };
       if (authHeader) headers.Authorization = authHeader;
 
-      const abortController = new AbortController();
-      // nosemgrep
-      const response = await fetch(url, {
-        method: 'GET',
-        headers,
-        signal: abortController.signal,
-      });
-      sessionManager.processResponse(response, url.pathname);
+      const { abortController, dispose } = executionAbortController();
+      try {
+        // nosemgrep
+        const response = await fetch(url, {
+          method: 'GET',
+          headers,
+          signal: abortController.signal,
+        });
+        sessionManager.processResponse(response, url.pathname);
 
-      const text = await readResponseTextBounded(
-        response,
-        maxBytes,
-        abortController,
-      );
-
-      if (!response.ok) {
-        throw createAdtError(
-          response.status,
-          response.statusText,
-          url.toString(),
-          'GET',
-          text,
+        const text = await readResponseTextBounded(
+          response,
+          maxBytes,
+          abortController,
         );
-      }
 
-      return text;
+        if (!response.ok) {
+          throw createAdtError(
+            response.status,
+            response.statusText,
+            url.toString(),
+            'GET',
+            text,
+          );
+        }
+
+        return text;
+      } finally {
+        dispose();
+      }
     },
   };
 }

--- a/packages/adt-client/src/cancellation.ts
+++ b/packages/adt-client/src/cancellation.ts
@@ -1,0 +1,20 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const adtAbortSignal = new AsyncLocalStorage<AbortSignal>();
+
+/**
+ * Runs an ADT operation with an execution-scoped abort signal. Async local
+ * storage keeps concurrent clients and invocations isolated without mutating
+ * shared client state.
+ */
+export function runWithAdtAbortSignal<T>(
+  signal: AbortSignal,
+  operation: () => Promise<T>,
+): Promise<T> {
+  signal.throwIfAborted();
+  return adtAbortSignal.run(signal, operation);
+}
+
+export function activeAdtAbortSignal(): AbortSignal | undefined {
+  return adtAbortSignal.getStore();
+}

--- a/packages/adt-client/src/index.ts
+++ b/packages/adt-client/src/index.ts
@@ -35,6 +35,7 @@ export {
   type AdtHttpAdapter,
   type BoundedTextRequestOptions,
 } from './adapter';
+export { runWithAdtAbortSignal } from './cancellation';
 
 // Export plugins
 export {

--- a/packages/adt-client/src/utils/session.ts
+++ b/packages/adt-client/src/utils/session.ts
@@ -411,7 +411,9 @@ export class SessionManager {
     authHeader?: string,
     client?: string,
     language?: string,
+    signal?: AbortSignal,
   ): Promise<boolean> {
+    signal?.throwIfAborted();
     const sessionsUrl = new URL('/sap/bc/adt/core/http/sessions', baseUrl);
 
     if (client) {
@@ -442,7 +444,9 @@ export class SessionManager {
           ...baseHeaders(),
           'x-sap-security-session': 'create',
         },
+        signal,
       });
+      signal?.throwIfAborted();
 
       if (!createResponse.ok) {
         this.logger?.warn(
@@ -456,6 +460,7 @@ export class SessionManager {
 
       // Extract session URL from response body for later DELETE
       const createBody = await createResponse.text();
+      signal?.throwIfAborted();
       const sessionHrefMatch = createBody.match(
         /href="([^"]*\/sessions\/[^"]*)"/,
       );
@@ -470,7 +475,9 @@ export class SessionManager {
           'x-sap-security-session': 'use',
           'x-csrf-token': 'Fetch',
         },
+        signal,
       });
+      signal?.throwIfAborted();
 
       if (!csrfResponse.ok) {
         this.logger?.warn(
@@ -509,9 +516,12 @@ export class SessionManager {
               'x-sap-security-session': 'use',
               'x-csrf-token': this.csrfManager.getCached()!,
             },
+            signal,
           });
+          signal?.throwIfAborted();
           this.logger?.debug('Session: Security session deleted');
-        } catch {
+        } catch (error) {
+          if (signal?.aborted) throw error;
           // Best-effort — session will time out anyway
           this.logger?.debug(
             'Session: Failed to delete security session (will expire)',
@@ -521,6 +531,10 @@ export class SessionManager {
 
       return true;
     } catch (error) {
+      if (signal?.aborted) {
+        this.clear();
+        throw error;
+      }
       this.logger?.error(
         `Session: CSRF initialization error: ${error instanceof Error ? error.message : String(error)}`,
       );

--- a/packages/adt-client/tests/adapter-cancellation.test.ts
+++ b/packages/adt-client/tests/adapter-cancellation.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createAdtAdapter } from '../src/adapter';
+import { runWithAdtAbortSignal } from '../src/cancellation';
+
+function waitForFetch(fetch: ReturnType<typeof vi.fn>, calls: number) {
+  return vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(calls));
+}
+
+describe('ADT execution-scoped cancellation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('passes the execution abort signal to the SAP request and response body', async () => {
+    let requestSignal: AbortSignal | undefined;
+    let bodyController: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        bodyController = controller;
+      },
+    });
+    const fetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
+      requestSignal = init?.signal ?? undefined;
+      requestSignal?.addEventListener('abort', () => {
+        bodyController?.error(requestSignal?.reason);
+      });
+      return Promise.resolve(
+        new Response(body, { headers: { 'content-type': 'text/plain' } }),
+      );
+    });
+    vi.stubGlobal('fetch', fetch);
+    const adapter = createAdtAdapter({
+      baseUrl: 'https://sap.example.test',
+      username: 'test',
+      password: 'test',
+    });
+    const abortController = new AbortController();
+
+    const request = runWithAdtAbortSignal(abortController.signal, () =>
+      adapter.request({
+        method: 'GET',
+        url: '/sap/bc/adt/repository/informationsystem/search',
+      }),
+    );
+    await waitForFetch(fetch, 1);
+    abortController.abort(new Error('execution deadline exceeded'));
+
+    await expect(request).rejects.toThrow('execution deadline exceeded');
+    expect(requestSignal).toBe(abortController.signal);
+  });
+
+  it('aborts CSRF initialization without dispatching later session or write requests', async () => {
+    let requestSignal: AbortSignal | undefined;
+    const fetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
+      requestSignal = init?.signal ?? undefined;
+      return new Promise<Response>((_resolve, reject) => {
+        requestSignal?.addEventListener(
+          'abort',
+          () => reject(requestSignal?.reason),
+          { once: true },
+        );
+      });
+    });
+    vi.stubGlobal('fetch', fetch);
+    const adapter = createAdtAdapter({
+      baseUrl: 'https://sap.example.test',
+      username: 'test',
+      password: 'test',
+    });
+    const abortController = new AbortController();
+
+    const request = runWithAdtAbortSignal(abortController.signal, () =>
+      adapter.request({
+        method: 'POST',
+        url: '/sap/bc/adt/atc/runs',
+        body: '<run />',
+      }),
+    );
+    await waitForFetch(fetch, 1);
+    abortController.abort(new Error('execution deadline exceeded'));
+
+    await expect(request).rejects.toThrow('execution deadline exceeded');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(requestSignal).toBe(abortController.signal);
+  });
+
+  it('isolates concurrent execution signals', async () => {
+    const observed = new Map<
+      string,
+      {
+        signal: AbortSignal;
+        resolve: (response: Response) => void;
+        reject: (error: unknown) => void;
+      }
+    >();
+    const fetch = vi.fn().mockImplementation((input, init?: RequestInit) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error('missing request signal');
+      const url = String(input);
+      return new Promise<Response>((resolve, reject) => {
+        observed.set(url, { signal, resolve, reject });
+        signal.addEventListener('abort', () => reject(signal.reason), {
+          once: true,
+        });
+      });
+    });
+    vi.stubGlobal('fetch', fetch);
+    const adapter = createAdtAdapter({
+      baseUrl: 'https://sap.example.test',
+      username: 'test',
+      password: 'test',
+    });
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+
+    const first = runWithAdtAbortSignal(firstController.signal, () =>
+      adapter.request<string>({ method: 'GET', url: '/first' }),
+    );
+    const second = runWithAdtAbortSignal(secondController.signal, () =>
+      adapter.request<string>({ method: 'GET', url: '/second' }),
+    );
+    await waitForFetch(fetch, 2);
+    firstController.abort(new Error('first deadline exceeded'));
+
+    const firstRequest = observed.get('https://sap.example.test/first');
+    const secondRequest = observed.get('https://sap.example.test/second');
+    expect(firstRequest?.signal.aborted).toBe(true);
+    expect(secondRequest?.signal.aborted).toBe(false);
+    secondRequest?.resolve(
+      new Response('second result', {
+        headers: { 'content-type': 'text/plain' },
+      }),
+    );
+
+    await expect(first).rejects.toThrow('first deadline exceeded');
+    await expect(second).resolves.toBe('second result');
+  });
+});

--- a/packages/adt-mcp/src/index.ts
+++ b/packages/adt-mcp/src/index.ts
@@ -47,10 +47,14 @@ export {
 } from './lib/http/server';
 export {
   createMcpInvocationVerifier,
+  parseJessAdtInvocationPolicy,
+  parseSafeExecutePolicy,
+  type JessAdtInvocationPolicy,
   type McpInvocationJsonValue,
   type McpInvocationVerifier,
   type McpInvocationVerifierOptions,
   type McpTrustedOperationClass,
+  type SafeExecutePolicy,
   type TrustedMcpInvocationClaims,
 } from './lib/http/invocation.js';
 export {

--- a/packages/adt-mcp/src/lib/http/invocation.ts
+++ b/packages/adt-mcp/src/lib/http/invocation.ts
@@ -17,17 +17,24 @@ const MAX_TOKEN_LIFETIME_SECONDS = 5 * 60;
 const MAX_FROZEN_SOURCES = 500;
 const MAX_SOURCE_REFERENCE_LENGTH = 8 * 1024;
 const MAX_FROZEN_SOURCE_BYTES = 2 * 1024 * 1024;
+const MAX_JESS_OBJECT_KEYS = 100;
+const MAX_JESS_TOOL_CALLS = 12;
+const MAX_SAFE_EXECUTE_GRANT_BYTES = 16 * 1024;
 const destinationKeyPattern = /^[a-z][a-z0-9-]{1,62}$/u;
 const canonicalKeyPattern = /^[A-Z0-9_]+:.+$/u;
+const jessCanonicalObjectKeyPattern = /^[A-Z0-9_]{2,30}:[A-Z0-9_/$-]{1,128}$/u;
+const compactJwsPattern = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/u;
 const uuidPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
 
-const trustedAgentIds = new Set([
-  'ai-review',
-  'system-assistant',
-  'autonomous-review-agent',
-]);
+const trustedAgentIds = new Set(['ai-review', 'jess']);
 const trustedOperationClasses = new Set(['server', 'read', 'safe_execute']);
+const jessReadTools = new Set([
+  'get_object',
+  'get_object_structure',
+  'cts_get_transport',
+  'cts_transport_objects',
+]);
 
 export type McpTrustedOperationClass = 'server' | 'read' | 'safe_execute';
 
@@ -43,8 +50,7 @@ export type McpInvocationJsonValue =
 export interface TrustedMcpInvocationClaims {
   readonly tokenId: string;
   readonly principal: string;
-  readonly agentId:
-    'ai-review' | 'system-assistant' | 'autonomous-review-agent';
+  readonly agentId: 'ai-review' | 'jess';
   readonly classes: readonly McpTrustedOperationClass[];
   readonly destinationKeys: readonly string[];
   readonly correlationId: string;
@@ -68,6 +74,56 @@ export interface AiReviewFrozenSourcePolicy {
     readonly sourceRef: string;
   }[];
   readonly maxSourceBytes: number;
+}
+
+export type SafeExecutePolicy =
+  | {
+      readonly operationId: 'atc_run';
+      readonly check: 'atc';
+      readonly maxDurationMs: number;
+      readonly maxResultBytes: number;
+      readonly maxFindings: number;
+      readonly maxObjects: number;
+      readonly maxPackages: number;
+      readonly maxVariants: number;
+    }
+  | {
+      readonly operationId: 'run_unit_tests';
+      readonly check: 'aunit';
+      readonly effectiveWithCoverage: false;
+      readonly effectiveCoverageFormat: null;
+      readonly maxDurationMs: number;
+      readonly maxResultBytes: number;
+      readonly maxFindings: number;
+      readonly maxObjects: number;
+      readonly maxTestClasses: number;
+      readonly maxTestMethods: number;
+    }
+  | {
+      readonly operationId: 'run_unit_tests';
+      readonly check: 'coverage';
+      readonly effectiveWithCoverage: true;
+      readonly effectiveCoverageFormat: 'jacoco' | 'sonar-generic';
+      readonly maxDurationMs: number;
+      readonly maxResultBytes: number;
+      readonly maxFindings: number;
+      readonly maxObjects: number;
+      readonly maxPrograms: number;
+      readonly maxMeasurements: number;
+    };
+
+export interface JessAdtInvocationPolicy {
+  readonly threadId: string;
+  readonly executionId: string;
+  readonly systemSid: string;
+  readonly objectKeys: readonly string[];
+  readonly toolNames: readonly string[];
+  readonly operationClass: 'read' | 'safe_execute';
+  readonly maxToolCalls: number;
+  readonly safeExecutePolicy?: SafeExecutePolicy;
+  /** Server-owned opaque grant material; never exposed in a tool schema. */
+  readonly safeExecuteGrantJti?: string;
+  readonly safeExecuteGrant?: string;
 }
 
 export interface McpInvocationVerifierOptions {
@@ -99,47 +155,22 @@ export interface McpInvocationVerifier {
  * access; accepting a syntactically valid policy without enforcing it would
  * widen the signed credential.
  *
- * The initial system-assistant policy is fully enforced by its exact
- * destination key plus the selected System marker. AI Review stays fail
- * closed until the frozen-object/capability policy is implemented at dispatch.
+ * Only the exact Jess execution policy and AI Review frozen-source policy are
+ * dispatchable. Retired and structurally incomplete policies fail closed.
  */
-function isSystemAssistantPolicySupported(
-  claims: TrustedMcpInvocationClaims,
-): boolean {
-  if (
-    !hasServerReadClasses(claims) ||
-    Object.keys(claims.limits).length !== 0
-  ) {
-    return false;
-  }
-  const constraintKeys = Object.keys(claims.constraint);
-  return (
-    constraintKeys.length === 1 &&
-    constraintKeys[0] === 'systemSid' &&
-    requiredIdentifier(claims.constraint.systemSid) !== undefined
-  );
-}
-
 function hasServerReadClasses(claims: TrustedMcpInvocationClaims): boolean {
   return (
     claims.classes.length === 2 &&
-    claims.classes.includes('server') &&
-    claims.classes.includes('read')
+    claims.classes[0] === 'server' &&
+    claims.classes[1] === 'read'
   );
 }
 
 export function isMcpInvocationDispatchPolicySupported(
   claims: TrustedMcpInvocationClaims,
 ): boolean {
-  if (claims.agentId === 'system-assistant') {
-    return isSystemAssistantPolicySupported(claims);
-  }
-  if (claims.agentId === 'autonomous-review-agent') {
-    return (
-      hasServerReadClasses(claims) &&
-      claims.destinationKeys.length === 1 &&
-      parseAutonomousReviewAgentPolicy(claims) !== undefined
-    );
+  if (claims.agentId === 'jess') {
+    return parseJessAdtInvocationPolicy(claims) !== undefined;
   }
   if (claims.agentId === 'ai-review') {
     return (
@@ -151,29 +182,6 @@ export function isMcpInvocationDispatchPolicySupported(
   return false;
 }
 
-/**
- * The autonomous agent may inspect exactly one System through exactly one
- * Destination. Its execution id binds every ADT activity to ADT's durable
- * Agent Execution, while the sidecar's ordinary scope catalogue continues to
- * deny write tools. No ambient limits or additional constraints are accepted.
- */
-export function parseAutonomousReviewAgentPolicy(
-  claims: TrustedMcpInvocationClaims,
-): { readonly executionId: string; readonly systemSid: string } | undefined {
-  if (claims.agentId !== 'autonomous-review-agent') return undefined;
-  if (Object.keys(claims.limits).length !== 0) return undefined;
-  const constraintKeys = Object.keys(claims.constraint).sort((a, b) =>
-    a.localeCompare(b),
-  );
-  if (constraintKeys.length !== 2) return undefined;
-  if (constraintKeys[0] !== 'executionId') return undefined;
-  if (constraintKeys[1] !== 'systemSid') return undefined;
-  const executionId = requiredUuid(claims.constraint.executionId);
-  const systemSid = requiredSystemSid(claims.constraint.systemSid);
-  if (!executionId || !systemSid) return undefined;
-  return Object.freeze({ executionId, systemSid });
-}
-
 function requiredUuid(value: unknown): string | undefined {
   return typeof value === 'string' && uuidPattern.test(value)
     ? value
@@ -182,6 +190,323 @@ function requiredUuid(value: unknown): string | undefined {
 
 function requiredSourceReference(value: unknown): string | undefined {
   return requiredString(value, { maxLength: MAX_SOURCE_REFERENCE_LENGTH });
+}
+
+function hasExactSortedKeys(
+  value: Readonly<Record<string, unknown>>,
+  expected: readonly string[],
+): boolean {
+  const actual = Object.keys(value).sort((left, right) =>
+    left.localeCompare(right),
+  );
+  const sortedExpected = [...expected].sort((left, right) =>
+    left.localeCompare(right),
+  );
+  return (
+    actual.length === sortedExpected.length &&
+    actual.every((key, index) => key === sortedExpected[index])
+  );
+}
+
+function positiveSafeInteger(value: unknown): number | undefined {
+  return Number.isSafeInteger(value) && (value as number) > 0
+    ? (value as number)
+    : undefined;
+}
+
+function parseSafeExecuteCommon(
+  value: Readonly<Record<string, McpInvocationJsonValue>>,
+):
+  | {
+      maxDurationMs: number;
+      maxResultBytes: number;
+      maxFindings: number;
+      maxObjects: number;
+    }
+  | undefined {
+  const maxDurationMs = positiveSafeInteger(value.maxDurationMs);
+  const maxResultBytes = positiveSafeInteger(value.maxResultBytes);
+  const maxFindings = positiveSafeInteger(value.maxFindings);
+  const maxObjects = positiveSafeInteger(value.maxObjects);
+  if (
+    maxDurationMs === undefined ||
+    maxResultBytes === undefined ||
+    maxFindings === undefined ||
+    maxObjects === undefined
+  ) {
+    return undefined;
+  }
+  return { maxDurationMs, maxResultBytes, maxFindings, maxObjects };
+}
+
+const safeExecuteCommonKeys = [
+  'operationId',
+  'check',
+  'maxDurationMs',
+  'maxResultBytes',
+  'maxFindings',
+  'maxObjects',
+] as const;
+
+export function parseSafeExecutePolicy(
+  value: unknown,
+): SafeExecutePolicy | undefined {
+  if (!isPlainObject(value)) return undefined;
+  const cloned = cloneJsonRecord(value);
+  if (!cloned) return undefined;
+  const common = parseSafeExecuteCommon(cloned);
+  if (!common) return undefined;
+
+  if (
+    cloned.operationId === 'atc_run' &&
+    cloned.check === 'atc' &&
+    hasExactSortedKeys(cloned, [
+      ...safeExecuteCommonKeys,
+      'maxPackages',
+      'maxVariants',
+    ])
+  ) {
+    const maxPackages = positiveSafeInteger(cloned.maxPackages);
+    const maxVariants = positiveSafeInteger(cloned.maxVariants);
+    if (maxPackages === undefined || maxVariants === undefined) {
+      return undefined;
+    }
+    return Object.freeze({
+      operationId: 'atc_run',
+      check: 'atc',
+      ...common,
+      maxPackages,
+      maxVariants,
+    });
+  }
+
+  if (
+    cloned.operationId === 'run_unit_tests' &&
+    cloned.check === 'aunit' &&
+    cloned.effectiveWithCoverage === false &&
+    cloned.effectiveCoverageFormat === null &&
+    hasExactSortedKeys(cloned, [
+      ...safeExecuteCommonKeys,
+      'effectiveWithCoverage',
+      'effectiveCoverageFormat',
+      'maxTestClasses',
+      'maxTestMethods',
+    ])
+  ) {
+    const maxTestClasses = positiveSafeInteger(cloned.maxTestClasses);
+    const maxTestMethods = positiveSafeInteger(cloned.maxTestMethods);
+    if (maxTestClasses === undefined || maxTestMethods === undefined) {
+      return undefined;
+    }
+    return Object.freeze({
+      operationId: 'run_unit_tests',
+      check: 'aunit',
+      effectiveWithCoverage: false,
+      effectiveCoverageFormat: null,
+      ...common,
+      maxTestClasses,
+      maxTestMethods,
+    });
+  }
+
+  if (
+    cloned.operationId === 'run_unit_tests' &&
+    cloned.check === 'coverage' &&
+    cloned.effectiveWithCoverage === true &&
+    (cloned.effectiveCoverageFormat === 'jacoco' ||
+      cloned.effectiveCoverageFormat === 'sonar-generic') &&
+    hasExactSortedKeys(cloned, [
+      ...safeExecuteCommonKeys,
+      'effectiveWithCoverage',
+      'effectiveCoverageFormat',
+      'maxPrograms',
+      'maxMeasurements',
+    ])
+  ) {
+    const maxPrograms = positiveSafeInteger(cloned.maxPrograms);
+    const maxMeasurements = positiveSafeInteger(cloned.maxMeasurements);
+    if (maxPrograms === undefined || maxMeasurements === undefined) {
+      return undefined;
+    }
+    return Object.freeze({
+      operationId: 'run_unit_tests',
+      check: 'coverage',
+      effectiveWithCoverage: true,
+      effectiveCoverageFormat: cloned.effectiveCoverageFormat,
+      ...common,
+      maxPrograms,
+      maxMeasurements,
+    });
+  }
+
+  return undefined;
+}
+
+function parseSortedUniqueStrings(
+  value: unknown,
+  options: {
+    maxItems: number;
+    minItems: number;
+    matches: (item: string) => boolean;
+  },
+): readonly string[] | undefined {
+  if (
+    !Array.isArray(value) ||
+    value.length < options.minItems ||
+    value.length > options.maxItems
+  ) {
+    return undefined;
+  }
+  const parsed: string[] = [];
+  for (const item of value) {
+    if (
+      typeof item !== 'string' ||
+      !options.matches(item) ||
+      parsed.includes(item)
+    ) {
+      return undefined;
+    }
+    parsed.push(item);
+  }
+  const sorted = [...parsed].sort((left, right) => left.localeCompare(right));
+  if (!parsed.every((item, index) => item === sorted[index])) return undefined;
+  return Object.freeze(parsed);
+}
+
+function parseJessObjectKeys(value: unknown): readonly string[] | undefined {
+  return parseSortedUniqueStrings(value, {
+    maxItems: MAX_JESS_OBJECT_KEYS,
+    minItems: 0,
+    matches: (item) => jessCanonicalObjectKeyPattern.test(item),
+  });
+}
+
+function parseJessToolNames(
+  value: unknown,
+  operationClass: 'read' | 'safe_execute',
+  safeExecutePolicy: SafeExecutePolicy | undefined,
+): readonly string[] | undefined {
+  const toolNames = parseSortedUniqueStrings(value, {
+    maxItems: operationClass === 'read' ? jessReadTools.size : 1,
+    minItems: 1,
+    matches: (item) =>
+      operationClass === 'read'
+        ? jessReadTools.has(item)
+        : item === 'atc_run' || item === 'run_unit_tests',
+  });
+  if (!toolNames) return undefined;
+  if (operationClass === 'read') {
+    return safeExecutePolicy === undefined ? toolNames : undefined;
+  }
+  return safeExecutePolicy && toolNames[0] === safeExecutePolicy.operationId
+    ? toolNames
+    : undefined;
+}
+
+function parseOpaqueSafeExecuteGrant(value: unknown): string | undefined {
+  return typeof value === 'string' &&
+    value.length <= MAX_SAFE_EXECUTE_GRANT_BYTES &&
+    compactJwsPattern.test(value)
+    ? value
+    : undefined;
+}
+
+export function parseJessAdtInvocationPolicy(
+  claims: TrustedMcpInvocationClaims,
+): JessAdtInvocationPolicy | undefined {
+  if (claims.agentId !== 'jess' || claims.destinationKeys.length !== 1) {
+    return undefined;
+  }
+  if (
+    claims.classes.length !== 2 ||
+    claims.classes[0] !== 'server' ||
+    (claims.classes[1] !== 'read' && claims.classes[1] !== 'safe_execute')
+  ) {
+    return undefined;
+  }
+  const operationClass = claims.classes[1];
+  const safeExecute = operationClass === 'safe_execute';
+  const expectedConstraintKeys = [
+    'kind',
+    'threadId',
+    'executionId',
+    'systemSid',
+    'objectKeys',
+    'toolNames',
+    ...(safeExecute
+      ? ['safeExecutePolicy', 'safeExecuteGrantJti', 'safeExecuteGrant']
+      : []),
+  ];
+  if (!hasExactSortedKeys(claims.constraint, expectedConstraintKeys)) {
+    return undefined;
+  }
+  if (
+    claims.constraint.kind !== 'jess-adt-v1' ||
+    !hasExactSortedKeys(claims.limits, ['maxToolCalls'])
+  ) {
+    return undefined;
+  }
+
+  const threadId = requiredUuid(claims.constraint.threadId);
+  const executionId = requiredUuid(claims.constraint.executionId);
+  const systemSid = requiredSystemSid(claims.constraint.systemSid);
+  const objectKeys = parseJessObjectKeys(claims.constraint.objectKeys);
+  const maxToolCalls = positiveSafeInteger(claims.limits.maxToolCalls);
+  if (
+    !threadId ||
+    !executionId ||
+    !systemSid ||
+    !objectKeys ||
+    maxToolCalls === undefined ||
+    maxToolCalls > MAX_JESS_TOOL_CALLS
+  ) {
+    return undefined;
+  }
+
+  const safeExecutePolicy = safeExecute
+    ? parseSafeExecutePolicy(claims.constraint.safeExecutePolicy)
+    : undefined;
+  if (safeExecute && objectKeys.length === 0) return undefined;
+  const toolNames = parseJessToolNames(
+    claims.constraint.toolNames,
+    operationClass,
+    safeExecutePolicy,
+  );
+  if (!toolNames) return undefined;
+
+  if (!safeExecute) {
+    return Object.freeze({
+      threadId,
+      executionId,
+      systemSid,
+      objectKeys,
+      toolNames,
+      operationClass,
+      maxToolCalls,
+    });
+  }
+
+  const safeExecuteGrantJti = requiredUuid(
+    claims.constraint.safeExecuteGrantJti,
+  );
+  const safeExecuteGrant = parseOpaqueSafeExecuteGrant(
+    claims.constraint.safeExecuteGrant,
+  );
+  if (!safeExecutePolicy || !safeExecuteGrantJti || !safeExecuteGrant) {
+    return undefined;
+  }
+  return Object.freeze({
+    threadId,
+    executionId,
+    systemSid,
+    objectKeys,
+    toolNames,
+    operationClass,
+    maxToolCalls,
+    safeExecutePolicy,
+    safeExecuteGrantJti,
+    safeExecuteGrant,
+  });
 }
 
 export function parseFrozenSource(
@@ -405,7 +730,9 @@ function cloneTrustedClasses(
   if (!Array.isArray(value) || value.length === 0) return undefined;
   const classes: McpTrustedOperationClass[] = [];
   for (const item of value) {
-    if (!isTrustedOperationClass(item)) return undefined;
+    if (!isTrustedOperationClass(item) || classes.includes(item)) {
+      return undefined;
+    }
     classes.push(item);
   }
   return Object.freeze(classes);
@@ -415,7 +742,11 @@ function cloneDestinationKeys(value: unknown): readonly string[] | undefined {
   if (!Array.isArray(value) || value.length === 0) return undefined;
   const destinationKeys: string[] = [];
   for (const item of value) {
-    if (typeof item !== 'string' || !destinationKeyPattern.test(item)) {
+    if (
+      typeof item !== 'string' ||
+      !destinationKeyPattern.test(item) ||
+      destinationKeys.includes(item)
+    ) {
       return undefined;
     }
     destinationKeys.push(item);
@@ -574,6 +905,27 @@ function claimsFromPayload(
 ): TrustedMcpInvocationClaims | undefined {
   const record = payload as Record<string, unknown>;
   if (
+    !hasExactSortedKeys(record, [
+      'v',
+      'kid',
+      'iss',
+      'aud',
+      'iat',
+      'nbf',
+      'exp',
+      'jti',
+      'principal',
+      'agentId',
+      'classes',
+      'destinationKeys',
+      'correlationId',
+      'constraint',
+      'limits',
+    ])
+  ) {
+    return undefined;
+  }
+  if (
     !isValidTokenHeader(record, expectedKeyId, expectedIssuer, expectedAudience)
   ) {
     return undefined;
@@ -618,7 +970,19 @@ export function createMcpInvocationVerifier(
           audience,
           currentDate: currentDate(now),
         });
-        if (verified.protectedHeader.kid !== keyId) return undefined;
+        const protectedHeader = verified.protectedHeader;
+        if (
+          !hasExactSortedKeys(protectedHeader as Record<string, unknown>, [
+            'alg',
+            'kid',
+            'typ',
+          ]) ||
+          protectedHeader.alg !== 'ES256' ||
+          protectedHeader.kid !== keyId ||
+          protectedHeader.typ !== 'JWT'
+        ) {
+          return undefined;
+        }
         return claimsFromPayload(verified.payload, keyId, issuer, audience);
       } catch {
         return undefined;

--- a/packages/adt-mcp/src/lib/http/server.ts
+++ b/packages/adt-mcp/src/lib/http/server.ts
@@ -28,6 +28,7 @@ import {
   isMcpDestinationKey,
   isMcpOperationClass,
   type McpFrozenSourceAccess,
+  type McpJessAccess,
   type McpRequestAccess,
 } from '../tools/scope-catalogue.js';
 import {
@@ -39,6 +40,8 @@ import {
   isMcpInvocationDispatchPolicySupported,
   parseAiReviewFrozenSourcePolicy,
   parseFrozenSource,
+  parseJessAdtInvocationPolicy,
+  parseSafeExecutePolicy,
 } from './invocation.js';
 import type {
   McpInvocationVerifier,
@@ -120,6 +123,12 @@ export interface HttpServerOptions {
     resolveFrozenSource?: NonNullable<
       import('../types.js').ToolContext['resolveFrozenSource']
     >;
+    consumeSafeExecuteGrant?: NonNullable<
+      import('../types.js').ToolContext['consumeSafeExecuteGrant']
+    >;
+    executeSafeTool?: NonNullable<
+      import('../types.js').ToolContext['executeSafeTool']
+    >;
   };
   /** Inject a logger that writes to stderr by default. */
   log?: (level: 'info' | 'warn' | 'error', msg: string) => void;
@@ -175,11 +184,115 @@ function snapshotRequestAccess(
 
   const frozenSource = snapshotFrozenSourceAccess(access.frozenSource);
   if (access.frozenSource && !frozenSource) return undefined;
+  const jess = snapshotJessAccess(access.jess);
+  if (access.jess && !jess) return undefined;
+  if (
+    jess &&
+    (classes.length !== 2 ||
+      classes[0] !== 'server' ||
+      classes[1] !== jess.operationClass)
+  ) {
+    return undefined;
+  }
 
   return Object.freeze({
     classes: Object.freeze([...classes]),
     destinationKeys: Object.freeze([...destinationKeys]),
     ...(frozenSource ? { frozenSource } : {}),
+    ...(jess ? { jess } : {}),
+  });
+}
+
+function snapshotJessAccess(
+  access: McpJessAccess | undefined,
+): McpJessAccess | undefined {
+  if (!access) return undefined;
+  const uuid =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
+  const objectKey = /^[A-Z0-9_]{2,30}:[A-Z0-9_/$-]{1,128}$/u;
+  const readTools = new Set([
+    'get_object',
+    'get_object_structure',
+    'cts_get_transport',
+    'cts_transport_objects',
+  ]);
+  if (
+    typeof access.tokenId !== 'string' ||
+    !access.tokenId ||
+    typeof access.principal !== 'string' ||
+    !access.principal ||
+    typeof access.correlationId !== 'string' ||
+    !access.correlationId ||
+    !uuid.test(access.threadId) ||
+    !uuid.test(access.executionId) ||
+    !/^[A-Z0-9_-]{1,16}$/u.test(access.systemSid) ||
+    !Number.isSafeInteger(access.maxToolCalls) ||
+    access.maxToolCalls < 1 ||
+    access.maxToolCalls > 12 ||
+    !Array.isArray(access.objectKeys) ||
+    access.objectKeys.length > 100 ||
+    !Array.isArray(access.toolNames) ||
+    access.toolNames.length < 1
+  ) {
+    return undefined;
+  }
+  const objectKeys = [...access.objectKeys];
+  const toolNames = [...access.toolNames];
+  if (
+    objectKeys.some((key) => typeof key !== 'string' || !objectKey.test(key)) ||
+    new Set(objectKeys).size !== objectKeys.length ||
+    objectKeys.some(
+      (key, index) =>
+        key !==
+        [...objectKeys].sort((left, right) => left.localeCompare(right))[index],
+    ) ||
+    toolNames.some((name) => typeof name !== 'string') ||
+    new Set(toolNames).size !== toolNames.length ||
+    toolNames.some(
+      (name, index) =>
+        name !==
+        [...toolNames].sort((left, right) => left.localeCompare(right))[index],
+    )
+  ) {
+    return undefined;
+  }
+
+  if (access.operationClass === 'read') {
+    if (
+      toolNames.some((name) => !readTools.has(name)) ||
+      access.safeExecutePolicy !== undefined ||
+      access.safeExecuteGrantJti !== undefined ||
+      access.safeExecuteGrant !== undefined
+    ) {
+      return undefined;
+    }
+    return Object.freeze({
+      ...access,
+      objectKeys: Object.freeze(objectKeys),
+      toolNames: Object.freeze(toolNames),
+    });
+  }
+  if (access.operationClass !== 'safe_execute') return undefined;
+  const safeExecutePolicy = parseSafeExecutePolicy(access.safeExecutePolicy);
+  if (
+    !safeExecutePolicy ||
+    toolNames.length !== 1 ||
+    toolNames[0] !== safeExecutePolicy.operationId ||
+    typeof access.safeExecuteGrantJti !== 'string' ||
+    !uuid.test(access.safeExecuteGrantJti) ||
+    typeof access.safeExecuteGrant !== 'string' ||
+    access.safeExecuteGrant.length > 16 * 1024 ||
+    !/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/u.test(
+      access.safeExecuteGrant,
+    )
+  ) {
+    return undefined;
+  }
+  return Object.freeze({
+    ...access,
+    objectKeys: Object.freeze(objectKeys),
+    toolNames: Object.freeze(toolNames),
+    safeExecutePolicy,
   });
 }
 
@@ -256,10 +369,21 @@ function invocationRequestAccess(
     return undefined;
   }
   const frozenSource = parseAiReviewFrozenSourcePolicy(invocation);
+  const jessPolicy = parseJessAdtInvocationPolicy(invocation);
   return snapshotRequestAccess({
     classes: invocation.classes,
     destinationKeys: invocation.destinationKeys,
     ...(frozenSource ? { frozenSource } : {}),
+    ...(jessPolicy
+      ? {
+          jess: {
+            tokenId: invocation.tokenId,
+            principal: invocation.principal,
+            correlationId: invocation.correlationId,
+            ...jessPolicy,
+          },
+        }
+      : {}),
   });
 }
 
@@ -589,6 +713,17 @@ export function createHttpMcpHandler(
                   ? {
                       resolveFrozenSource:
                         destinationServer.resolveFrozenSource,
+                    }
+                  : {}),
+                ...(destinationServer.consumeSafeExecuteGrant
+                  ? {
+                      consumeSafeExecuteGrant:
+                        destinationServer.consumeSafeExecuteGrant,
+                    }
+                  : {}),
+                ...(destinationServer.executeSafeTool
+                  ? {
+                      executeSafeTool: destinationServer.executeSafeTool,
                     }
                   : {}),
               }

--- a/packages/adt-mcp/src/lib/http/server.ts
+++ b/packages/adt-mcp/src/lib/http/server.ts
@@ -126,6 +126,9 @@ export interface HttpServerOptions {
     consumeSafeExecuteGrant?: NonNullable<
       import('../types.js').ToolContext['consumeSafeExecuteGrant']
     >;
+    reportSafeExecuteGrantOutcome?: NonNullable<
+      import('../types.js').ToolContext['reportSafeExecuteGrantOutcome']
+    >;
     executeSafeTool?: NonNullable<
       import('../types.js').ToolContext['executeSafeTool']
     >;
@@ -719,6 +722,12 @@ export function createHttpMcpHandler(
                   ? {
                       consumeSafeExecuteGrant:
                         destinationServer.consumeSafeExecuteGrant,
+                    }
+                  : {}),
+                ...(destinationServer.reportSafeExecuteGrantOutcome
+                  ? {
+                      reportSafeExecuteGrantOutcome:
+                        destinationServer.reportSafeExecuteGrantOutcome,
                     }
                   : {}),
                 ...(destinationServer.executeSafeTool

--- a/packages/adt-mcp/src/lib/server.ts
+++ b/packages/adt-mcp/src/lib/server.ts
@@ -48,6 +48,10 @@ export interface McpServerOptions {
   requestAccess?: (extra: {
     sessionId?: string;
   }) => McpRequestAccess | undefined;
+  /** Atomic ARM grant-consumption hook required by Jess safe execution. */
+  consumeSafeExecuteGrant?: ToolContext['consumeSafeExecuteGrant'];
+  /** Hard-cancellable runtime required for Jess safe execution. */
+  executeSafeTool?: ToolContext['executeSafeTool'];
   /** Private ADT broker resolver for signed frozen-source capabilities. */
   resolveFrozenSource: ToolContext['resolveFrozenSource'];
 }
@@ -88,6 +92,14 @@ export function createMcpServer(options?: McpServerOptions): McpServer {
           destinationRegistry: options.destinationRegistry,
           requestIdentity: options.requestIdentity,
           requestAccess: options.requestAccess,
+          ...(options.consumeSafeExecuteGrant
+            ? {
+                consumeSafeExecuteGrant: options.consumeSafeExecuteGrant,
+              }
+            : {}),
+          ...(options.executeSafeTool
+            ? { executeSafeTool: options.executeSafeTool }
+            : {}),
           ...(options.resolveFrozenSource
             ? { resolveFrozenSource: options.resolveFrozenSource }
             : {}),
@@ -98,7 +110,11 @@ export function createMcpServer(options?: McpServerOptions): McpServer {
   const destinationMode = options?.destinationRegistry;
   registerTools(
     destinationMode
-      ? destinationModeServer(server, { requestAccess: options.requestAccess })
+      ? destinationModeServer(server, {
+          requestAccess: options.requestAccess,
+          consumeSafeExecuteGrant: options.consumeSafeExecuteGrant,
+          executeSafeTool: options.executeSafeTool,
+        })
       : server,
     ctx,
   );

--- a/packages/adt-mcp/src/lib/server.ts
+++ b/packages/adt-mcp/src/lib/server.ts
@@ -50,6 +50,8 @@ export interface McpServerOptions {
   }) => McpRequestAccess | undefined;
   /** Atomic ARM grant-consumption hook required by Jess safe execution. */
   consumeSafeExecuteGrant?: ToolContext['consumeSafeExecuteGrant'];
+  /** Single terminal ARM outcome hook required by Jess safe execution. */
+  reportSafeExecuteGrantOutcome?: ToolContext['reportSafeExecuteGrantOutcome'];
   /** Hard-cancellable runtime required for Jess safe execution. */
   executeSafeTool?: ToolContext['executeSafeTool'];
   /** Private ADT broker resolver for signed frozen-source capabilities. */
@@ -97,6 +99,12 @@ export function createMcpServer(options?: McpServerOptions): McpServer {
                 consumeSafeExecuteGrant: options.consumeSafeExecuteGrant,
               }
             : {}),
+          ...(options.reportSafeExecuteGrantOutcome
+            ? {
+                reportSafeExecuteGrantOutcome:
+                  options.reportSafeExecuteGrantOutcome,
+              }
+            : {}),
           ...(options.executeSafeTool
             ? { executeSafeTool: options.executeSafeTool }
             : {}),
@@ -113,6 +121,7 @@ export function createMcpServer(options?: McpServerOptions): McpServer {
       ? destinationModeServer(server, {
           requestAccess: options.requestAccess,
           consumeSafeExecuteGrant: options.consumeSafeExecuteGrant,
+          reportSafeExecuteGrantOutcome: options.reportSafeExecuteGrantOutcome,
           executeSafeTool: options.executeSafeTool,
         })
       : server,

--- a/packages/adt-mcp/src/lib/tools/atc-run.ts
+++ b/packages/adt-mcp/src/lib/tools/atc-run.ts
@@ -193,6 +193,12 @@ export function registerAtcRunTool(server: McpServer, ctx: ToolContext): void {
     },
     async (args, extra) => {
       try {
+        const access = ctx.requestAccess?.(extra ?? {});
+        const safePolicy =
+          access?.jess?.operationClass === 'safe_execute' &&
+          access.jess.safeExecutePolicy?.operationId === 'atc_run'
+            ? access.jess.safeExecutePolicy
+            : undefined;
         const { client } = await resolveClient(ctx, args, extra ?? {});
         const checkVariant = await resolveVariant(client, args.variant);
         const created = await client.adt.atc.worklists.create({
@@ -205,7 +211,7 @@ export function registerAtcRunTool(server: McpServer, ctx: ToolContext): void {
           { worklistId },
           {
             run: {
-              maximumVerdicts: 10_000,
+              maximumVerdicts: safePolicy?.maxFindings ?? 10_000,
               objectSets: {
                 objectSet: [
                   {
@@ -222,6 +228,18 @@ export function registerAtcRunTool(server: McpServer, ctx: ToolContext): void {
         const worklist = await client.adt.atc.worklists.get(worklistId, {
           includeExemptedFindings: 'false',
         });
+        const findings = canonicalFindings(worklist);
+        if (safePolicy && findings.length > safePolicy.maxFindings) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text' as const,
+                text: 'safe_execute_limit_exceeded',
+              },
+            ],
+          };
+        }
 
         return {
           content: [
@@ -230,7 +248,7 @@ export function registerAtcRunTool(server: McpServer, ctx: ToolContext): void {
               text: JSON.stringify(
                 {
                   checkVariant,
-                  findings: canonicalFindings(worklist),
+                  findings,
                 },
                 null,
                 2,

--- a/packages/adt-mcp/src/lib/tools/atc-run.ts
+++ b/packages/adt-mcp/src/lib/tools/atc-run.ts
@@ -12,7 +12,7 @@ import type { AdtClient } from '@abapify/adt-client';
 import type { ToolContext } from '../types';
 import { sessionOrConnectionShape } from './shared-schemas';
 import { resolveClient } from './session-helpers';
-import { resolveObjectUri } from './utils';
+import { isKnownAdtHttpFailure, resolveObjectUri } from './utils';
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -192,13 +192,13 @@ export function registerAtcRunTool(server: McpServer, ctx: ToolContext): void {
       objectUri: z.never().optional(),
     },
     async (args, extra) => {
+      const access = ctx.requestAccess?.(extra ?? {});
+      const safePolicy =
+        access?.jess?.operationClass === 'safe_execute' &&
+        access.jess.safeExecutePolicy?.operationId === 'atc_run'
+          ? access.jess.safeExecutePolicy
+          : undefined;
       try {
-        const access = ctx.requestAccess?.(extra ?? {});
-        const safePolicy =
-          access?.jess?.operationClass === 'safe_execute' &&
-          access.jess.safeExecutePolicy?.operationId === 'atc_run'
-            ? access.jess.safeExecutePolicy
-            : undefined;
         const { client } = await resolveClient(ctx, args, extra ?? {});
         const checkVariant = await resolveVariant(client, args.variant);
         const created = await client.adt.atc.worklists.create({
@@ -257,6 +257,7 @@ export function registerAtcRunTool(server: McpServer, ctx: ToolContext): void {
           ],
         };
       } catch (error) {
+        if (safePolicy && !isKnownAdtHttpFailure(error)) throw error;
         return {
           isError: true,
           content: [

--- a/packages/adt-mcp/src/lib/tools/destination-mode.ts
+++ b/packages/adt-mcp/src/lib/tools/destination-mode.ts
@@ -12,6 +12,7 @@ import type {
   McpServer,
   RegisteredTool,
 } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolContext } from '../types.js';
 import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import {
   actionClassesForMcpTool,
@@ -81,6 +82,8 @@ export interface DestinationModeOptions {
   requestAccess?: (extra: {
     sessionId?: string;
   }) => McpRequestAccess | undefined;
+  consumeSafeExecuteGrant?: ToolContext['consumeSafeExecuteGrant'];
+  executeSafeTool?: ToolContext['executeSafeTool'];
 }
 
 type DestinationToolListEntry = {
@@ -100,6 +103,17 @@ function scopeDeniedResult() {
     content: [{ type: 'text' as const, text: 'mcp_scope_denied' }],
   };
 }
+
+function safeExecuteLimitResult(
+  text: 'safe_execute_limit_exceeded' | 'outcome_unknown',
+) {
+  return {
+    isError: true as const,
+    content: [{ type: 'text' as const, text }],
+  };
+}
+
+type DispatchCounter = { admitted: number };
 
 function toolListEntry(
   name: string,
@@ -203,8 +217,7 @@ function transformToolInput(
 ): {
   transformedInputSchema: unknown;
   strictInputSchema:
-    | ReturnType<typeof strictCanonicalDestinationSchema>
-    | undefined;
+    ReturnType<typeof strictCanonicalDestinationSchema> | undefined;
   useRegisterTool: boolean;
 } {
   const requiresStrictCanonicalSchema = rawUriFieldsByTool.has(name);
@@ -229,6 +242,7 @@ function wrapToolHandler(
   handler: Handler,
   name: string,
   options: DestinationModeOptions,
+  counter: DispatchCounter,
 ): Handler {
   return async (...handlerArgs: unknown[]) => {
     const toolArguments =
@@ -252,7 +266,66 @@ function wrapToolHandler(
     ) {
       return scopeDeniedResult();
     }
-    return await handler(...handlerArgs);
+    const jess = access?.jess;
+    if (jess && counter.admitted >= jess.maxToolCalls) {
+      return scopeDeniedResult();
+    }
+
+    if (jess?.operationClass !== 'safe_execute') {
+      if (jess) counter.admitted++;
+      return await handler(...handlerArgs);
+    }
+
+    const policy = jess.safeExecutePolicy;
+    const grantJti = jess.safeExecuteGrantJti;
+    const opaqueGrant = jess.safeExecuteGrant;
+    const destinationKey = toolArguments.destination;
+    const consumeSafeExecuteGrant = options.consumeSafeExecuteGrant;
+    const executeSafeTool = options.executeSafeTool;
+    if (
+      !policy ||
+      !grantJti ||
+      !opaqueGrant ||
+      typeof destinationKey !== 'string' ||
+      !consumeSafeExecuteGrant ||
+      !executeSafeTool
+    ) {
+      return scopeDeniedResult();
+    }
+    try {
+      const consumed = await consumeSafeExecuteGrant({
+        grantJti,
+        opaqueGrant,
+        principal: jess.principal,
+        threadId: jess.threadId,
+        executionId: jess.executionId,
+        systemSid: jess.systemSid,
+        objectKeys: jess.objectKeys,
+        destination: destinationKey,
+        operationId: policy.operationId,
+        policy,
+      });
+      if (!consumed) return scopeDeniedResult();
+    } catch {
+      return scopeDeniedResult();
+    }
+
+    counter.admitted++;
+    try {
+      const result = await executeSafeTool({
+        maxDurationMs: policy.maxDurationMs,
+        operation: async () => await handler(...handlerArgs),
+      });
+      if (
+        new TextEncoder().encode(JSON.stringify(result)).byteLength >
+        policy.maxResultBytes
+      ) {
+        return safeExecuteLimitResult('safe_execute_limit_exceeded');
+      }
+      return result;
+    } catch {
+      return safeExecuteLimitResult('outcome_unknown');
+    }
   };
 }
 
@@ -262,8 +335,7 @@ function registerDestinationTool(
   description: string | undefined,
   transformedInputSchema: unknown,
   strictInputSchema:
-    | ReturnType<typeof strictCanonicalDestinationSchema>
-    | undefined,
+    ReturnType<typeof strictCanonicalDestinationSchema> | undefined,
   wrappedHandler: Handler,
   useRegisterTool: boolean,
 ): unknown {
@@ -317,6 +389,7 @@ export function destinationModeServer(
   options: DestinationModeOptions = {},
 ): McpServer {
   const inventory = new Map<string, DestinationToolListEntry>();
+  const counter: DispatchCounter = { admitted: 0 };
   destinationToolInventories.set(server, inventory);
   return new Proxy(server, {
     get(target, property, receiver) {
@@ -334,6 +407,7 @@ export function destinationModeServer(
           handler as Handler,
           name,
           options,
+          counter,
         );
         const registeredTool = registerDestinationTool(
           target,

--- a/packages/adt-mcp/src/lib/tools/destination-mode.ts
+++ b/packages/adt-mcp/src/lib/tools/destination-mode.ts
@@ -60,6 +60,7 @@ const rawUriFieldsByTool = new Map<string, readonly string[]>([
   ['find_references', ['objectUri']],
   ['get_callers_of', ['objectUri']],
   ['get_callees_of', ['objectUri']],
+  ['get_source_version', ['uri']],
   ['grep_objects', ['objectUris']],
 ]);
 
@@ -83,6 +84,7 @@ export interface DestinationModeOptions {
     sessionId?: string;
   }) => McpRequestAccess | undefined;
   consumeSafeExecuteGrant?: ToolContext['consumeSafeExecuteGrant'];
+  reportSafeExecuteGrantOutcome?: ToolContext['reportSafeExecuteGrantOutcome'];
   executeSafeTool?: ToolContext['executeSafeTool'];
 }
 
@@ -111,6 +113,15 @@ function safeExecuteLimitResult(
     isError: true as const,
     content: [{ type: 'text' as const, text }],
   };
+}
+
+function isToolErrorResult(result: unknown): boolean {
+  return (
+    !!result &&
+    typeof result === 'object' &&
+    !Array.isArray(result) &&
+    (result as { isError?: unknown }).isError === true
+  );
 }
 
 type DispatchCounter = { admitted: number };
@@ -281,6 +292,7 @@ function wrapToolHandler(
     const opaqueGrant = jess.safeExecuteGrant;
     const destinationKey = toolArguments.destination;
     const consumeSafeExecuteGrant = options.consumeSafeExecuteGrant;
+    const reportSafeExecuteGrantOutcome = options.reportSafeExecuteGrantOutcome;
     const executeSafeTool = options.executeSafeTool;
     if (
       !policy ||
@@ -288,6 +300,7 @@ function wrapToolHandler(
       !opaqueGrant ||
       typeof destinationKey !== 'string' ||
       !consumeSafeExecuteGrant ||
+      !reportSafeExecuteGrantOutcome ||
       !executeSafeTool
     ) {
       return scopeDeniedResult();
@@ -311,8 +324,10 @@ function wrapToolHandler(
     }
 
     counter.admitted++;
+    let outcome: 'succeeded' | 'failed' | 'outcome_unknown';
+    let result: unknown;
     try {
-      const result = await executeSafeTool({
+      result = await executeSafeTool({
         maxDurationMs: policy.maxDurationMs,
         operation: async () => await handler(...handlerArgs),
       });
@@ -320,12 +335,25 @@ function wrapToolHandler(
         new TextEncoder().encode(JSON.stringify(result)).byteLength >
         policy.maxResultBytes
       ) {
-        return safeExecuteLimitResult('safe_execute_limit_exceeded');
+        result = safeExecuteLimitResult('safe_execute_limit_exceeded');
       }
-      return result;
+      outcome = isToolErrorResult(result) ? 'failed' : 'succeeded';
+    } catch {
+      outcome = 'outcome_unknown';
+      result = safeExecuteLimitResult('outcome_unknown');
+    }
+
+    try {
+      const recorded = await reportSafeExecuteGrantOutcome({
+        grantJti,
+        opaqueGrant,
+        outcome,
+      });
+      if (!recorded) return safeExecuteLimitResult('outcome_unknown');
     } catch {
       return safeExecuteLimitResult('outcome_unknown');
     }
+    return result;
   };
 }
 

--- a/packages/adt-mcp/src/lib/tools/run-unit-tests.ts
+++ b/packages/adt-mcp/src/lib/tools/run-unit-tests.ts
@@ -14,7 +14,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ToolContext } from '../types';
 import { sessionOrConnectionShape } from './shared-schemas';
 import { resolveClient } from './session-helpers';
-import { resolveObjectUri } from './utils';
+import { isKnownAdtHttpFailure, resolveObjectUri } from './utils';
 import type { InferTypedSchema } from '@abapify/adt-schemas';
 import { aunitResult } from '@abapify/adt-schemas';
 import { extractCoverageMeasurementId } from '@abapify/adt-contracts';
@@ -234,6 +234,12 @@ export function registerRunUnitTestsTool(
         .describe('Coverage report format when coverage is enabled'),
     },
     async (args, extra) => {
+      const access = ctx.requestAccess?.(extra ?? {});
+      const safePolicy =
+        access?.jess?.operationClass === 'safe_execute' &&
+        access.jess.safeExecutePolicy?.operationId === 'run_unit_tests'
+          ? access.jess.safeExecutePolicy
+          : undefined;
       try {
         const normalizedOptions = normalizeUnitTestOptions(args);
         if (!normalizedOptions) {
@@ -247,12 +253,6 @@ export function registerRunUnitTestsTool(
             ],
           };
         }
-        const access = ctx.requestAccess?.(extra ?? {});
-        const safePolicy =
-          access?.jess?.operationClass === 'safe_execute' &&
-          access.jess.safeExecutePolicy?.operationId === 'run_unit_tests'
-            ? access.jess.safeExecutePolicy
-            : undefined;
         const { client } = await resolveClient(ctx, args, extra ?? {});
 
         const objectUri = await resolveObjectUri(
@@ -360,6 +360,7 @@ export function registerRunUnitTestsTool(
                   : toJacocoXml({ measurements, statements });
               coveragePayload = { format: fmt, xml };
             } catch (err) {
+              if (safePolicy) throw err;
               coveragePayload = {
                 format: normalizedOptions.effectiveCoverageFormat ?? 'jacoco',
                 xml: '',
@@ -382,6 +383,7 @@ export function registerRunUnitTestsTool(
           ],
         };
       } catch (error) {
+        if (safePolicy && !isKnownAdtHttpFailure(error)) throw error;
         return {
           isError: true,
           content: [

--- a/packages/adt-mcp/src/lib/tools/run-unit-tests.ts
+++ b/packages/adt-mcp/src/lib/tools/run-unit-tests.ts
@@ -22,6 +22,7 @@ import {
   toJacocoXml,
   toSonarGenericCoverageXml,
 } from '@abapify/adt-aunit/formatters/jacoco';
+import { normalizeUnitTestOptions } from './scope-catalogue.js';
 
 type AunitResultData = InferTypedSchema<typeof aunitResult>;
 type AunitProgram = NonNullable<
@@ -143,6 +144,61 @@ function normalizeResult(response: AunitResultData): {
   return { totalTests, passCount, failCount, errorCount, programs };
 }
 
+function resultCounts(programs: AunitProgram[]): {
+  programs: number;
+  testClasses: number;
+  testMethods: number;
+  findings: number;
+} {
+  let testClasses = 0;
+  let testMethods = 0;
+  let findings = 0;
+  for (const program of programs) {
+    const rawClasses = program.testClasses?.testClass ?? [];
+    const classes = Array.isArray(rawClasses) ? rawClasses : [rawClasses];
+    testClasses += classes.length;
+    for (const testClass of classes) {
+      const rawMethods = testClass?.testMethods?.testMethod ?? [];
+      const methods = Array.isArray(rawMethods) ? rawMethods : [rawMethods];
+      testMethods += methods.length;
+      for (const method of methods) {
+        const rawAlerts = method?.alerts?.alert ?? [];
+        findings += Array.isArray(rawAlerts) ? rawAlerts.length : 1;
+      }
+    }
+  }
+  return {
+    programs: programs.length,
+    testClasses,
+    testMethods,
+    findings,
+  };
+}
+
+function coverageMeasurementCount(value: unknown): number {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return 0;
+  const record = value as Record<string, unknown>;
+  const nodes = record.nodes;
+  if (!nodes || typeof nodes !== 'object' || Array.isArray(nodes)) return 0;
+  const rawChildren = (nodes as Record<string, unknown>).node;
+  const children = Array.isArray(rawChildren)
+    ? rawChildren
+    : rawChildren
+      ? [rawChildren]
+      : [];
+  return children.reduce(
+    (total, child) => total + 1 + coverageMeasurementCount(child),
+    0,
+  );
+}
+
+function limitExceeded() {
+  return {
+    isError: true as const,
+    content: [{ type: 'text' as const, text: 'safe_execute_limit_exceeded' }],
+  };
+}
+
 export function registerRunUnitTestsTool(
   server: McpServer,
   ctx: ToolContext,
@@ -164,7 +220,6 @@ export function registerRunUnitTestsTool(
       withCoverage: z
         .boolean()
         .optional()
-        .default(false)
         .describe('Whether to collect code coverage data'),
       coverage: z
         .boolean()
@@ -180,6 +235,24 @@ export function registerRunUnitTestsTool(
     },
     async (args, extra) => {
       try {
+        const normalizedOptions = normalizeUnitTestOptions(args);
+        if (!normalizedOptions) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text' as const,
+                text: 'Run unit tests failed: coverage options disagree',
+              },
+            ],
+          };
+        }
+        const access = ctx.requestAccess?.(extra ?? {});
+        const safePolicy =
+          access?.jess?.operationClass === 'safe_execute' &&
+          access.jess.safeExecutePolicy?.operationId === 'run_unit_tests'
+            ? access.jess.safeExecutePolicy
+            : undefined;
         const { client } = await resolveClient(ctx, args, extra ?? {});
 
         const objectUri = await resolveObjectUri(
@@ -199,8 +272,7 @@ export function registerRunUnitTestsTool(
           };
         }
 
-        const wantsCoverage =
-          (args.coverage ?? false) || (args.withCoverage ?? false);
+        const wantsCoverage = normalizedOptions.effectiveWithCoverage;
 
         const body = buildRunConfiguration([objectUri], wantsCoverage);
 
@@ -211,11 +283,29 @@ export function registerRunUnitTestsTool(
           body as Parameters<typeof client.adt.aunit.testruns.post>[0],
         );
         const result = normalizeResult(response as AunitResultData);
+        const counts = resultCounts(result.programs);
+        if (safePolicy) {
+          if (counts.findings > safePolicy.maxFindings) {
+            return limitExceeded();
+          }
+          if (
+            safePolicy.check === 'aunit' &&
+            (counts.testClasses > safePolicy.maxTestClasses ||
+              counts.testMethods > safePolicy.maxTestMethods)
+          ) {
+            return limitExceeded();
+          }
+          if (
+            safePolicy.check === 'coverage' &&
+            counts.programs > safePolicy.maxPrograms
+          ) {
+            return limitExceeded();
+          }
+        }
 
         // Optional: follow the coverage link and serialise a JaCoCo / Sonar report.
         let coveragePayload:
-          | { format: string; xml: string; warning?: string }
-          | undefined;
+          { format: string; xml: string; warning?: string } | undefined;
 
         if (wantsCoverage) {
           const measurementId = extractCoverageMeasurementId(response);
@@ -236,14 +326,14 @@ export function registerRunUnitTestsTool(
 
           if (!measurementId) {
             coveragePayload = {
-              format: args.coverageFormat ?? 'jacoco',
+              format: normalizedOptions.effectiveCoverageFormat ?? 'jacoco',
               xml: '',
               warning:
                 'Coverage requested but SAP returned no measurement link.',
             };
           } else if (!runtime) {
             coveragePayload = {
-              format: args.coverageFormat ?? 'jacoco',
+              format: normalizedOptions.effectiveCoverageFormat ?? 'jacoco',
               xml: '',
               warning: 'runtime/traces contract not available on this client.',
             };
@@ -253,10 +343,17 @@ export function registerRunUnitTestsTool(
               const measurements = (await cov.measurements.post(
                 measurementId,
               )) as Parameters<typeof toJacocoXml>[0]['measurements'];
+              if (
+                safePolicy?.check === 'coverage' &&
+                coverageMeasurementCount(measurements.result) >
+                  safePolicy.maxMeasurements
+              ) {
+                return limitExceeded();
+              }
               const statements = (await cov.statements.get(
                 measurementId,
               )) as Parameters<typeof toJacocoXml>[0]['statements'];
-              const fmt = args.coverageFormat ?? 'jacoco';
+              const fmt = normalizedOptions.effectiveCoverageFormat ?? 'jacoco';
               const xml =
                 fmt === 'sonar-generic'
                   ? toSonarGenericCoverageXml({ measurements, statements })
@@ -264,7 +361,7 @@ export function registerRunUnitTestsTool(
               coveragePayload = { format: fmt, xml };
             } catch (err) {
               coveragePayload = {
-                format: args.coverageFormat ?? 'jacoco',
+                format: normalizedOptions.effectiveCoverageFormat ?? 'jacoco',
                 xml: '',
                 warning: `Coverage fetch failed: ${err instanceof Error ? err.message : String(err)}`,
               };

--- a/packages/adt-mcp/src/lib/tools/scope-catalogue.ts
+++ b/packages/adt-mcp/src/lib/tools/scope-catalogue.ts
@@ -6,6 +6,8 @@
  * catalogue is the single source of truth for the operation a tool performs.
  */
 
+import type { SafeExecutePolicy } from '../http/invocation.js';
+
 export type McpOperationClass = 'server' | 'read' | 'safe_execute' | 'write';
 
 const destinationKeyPattern = /^[a-z][a-z0-9-]{1,62}$/u;
@@ -32,6 +34,24 @@ export interface McpRequestAccess {
   destinationKeys: readonly string[];
   /** A typed signed policy that removes ambient AI Review read authority. */
   frozenSource?: McpFrozenSourceAccess;
+  /** Exact execution-scoped Jess catalogue and dispatch policy. */
+  jess?: McpJessAccess;
+}
+
+export interface McpJessAccess {
+  readonly tokenId: string;
+  readonly principal: string;
+  readonly correlationId: string;
+  readonly threadId: string;
+  readonly executionId: string;
+  readonly systemSid: string;
+  readonly objectKeys: readonly string[];
+  readonly toolNames: readonly string[];
+  readonly operationClass: 'read' | 'safe_execute';
+  readonly maxToolCalls: number;
+  readonly safeExecutePolicy?: SafeExecutePolicy;
+  readonly safeExecuteGrantJti?: string;
+  readonly safeExecuteGrant?: string;
 }
 
 export interface McpFrozenSourceAccess {
@@ -131,7 +151,6 @@ export const MCP_TOOL_SCOPE_CATALOGUE: Readonly<Record<string, McpToolScope>> =
       'lookup_user',
       'pretty_print',
       'run_query',
-      'run_unit_tests',
       'sap_connect',
       'sap_disconnect',
       'search_objects',
@@ -145,7 +164,7 @@ export const MCP_TOOL_SCOPE_CATALOGUE: Readonly<Record<string, McpToolScope>> =
     ]),
     // ATC creates a server-side worklist even though it does not mutate ABAP
     // repository objects. It therefore needs an explicit execution grant.
-    ...safeExecute(['atc_run']),
+    ...safeExecute(['atc_run', 'run_unit_tests']),
     ...write([
       'activate_object',
       'activate_package',
@@ -247,11 +266,180 @@ export function isMcpToolAllowed(
   arguments_: Record<string, unknown> = {},
 ): boolean {
   const classes = access?.classes;
-  return Boolean(
+  const classAllowed = Boolean(
     Array.isArray(classes) &&
     classes.every(isMcpOperationClass) &&
     classes.includes(operationClassForMcpTool(name, arguments_)),
   );
+  if (!classAllowed) return false;
+  const jess = access?.jess;
+  return (
+    !jess ||
+    (jess.operationClass === operationClassForMcpTool(name, arguments_) &&
+      jess.toolNames.includes(name))
+  );
+}
+
+function canonicalObjectKey(
+  objectType: unknown,
+  objectName: unknown,
+): string | undefined {
+  if (typeof objectType !== 'string' || typeof objectName !== 'string') {
+    return undefined;
+  }
+  const key = `${objectType.trim().toUpperCase()}:${objectName
+    .trim()
+    .toUpperCase()}`;
+  return /^[A-Z0-9_]{2,30}:[A-Z0-9_/$-]{1,128}$/u.test(key) ? key : undefined;
+}
+
+function sortedUnique(
+  values: readonly string[],
+): readonly string[] | undefined {
+  if (new Set(values).size !== values.length) return undefined;
+  return [...values].sort((left, right) => left.localeCompare(right));
+}
+
+function exactStringArrays(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
+}
+
+export interface NormalizedUnitTestOptions {
+  readonly effectiveWithCoverage: boolean;
+  readonly effectiveCoverageFormat: 'jacoco' | 'sonar-generic' | null;
+}
+
+/**
+ * Canonicalises the accepted AUnit coverage spellings before policy
+ * comparison. The legacy alias is accepted only for compatibility and can
+ * never disagree with `withCoverage`.
+ */
+export function normalizeUnitTestOptions(
+  arguments_: Record<string, unknown>,
+): NormalizedUnitTestOptions | undefined {
+  const withCoverage = arguments_.withCoverage;
+  const coverage = arguments_.coverage;
+  const coverageFormat = arguments_.coverageFormat;
+  if (
+    (withCoverage !== undefined && typeof withCoverage !== 'boolean') ||
+    (coverage !== undefined && typeof coverage !== 'boolean') ||
+    (coverageFormat !== undefined &&
+      coverageFormat !== 'jacoco' &&
+      coverageFormat !== 'sonar-generic')
+  ) {
+    return undefined;
+  }
+  if (
+    withCoverage !== undefined &&
+    coverage !== undefined &&
+    withCoverage !== coverage
+  ) {
+    return undefined;
+  }
+  const effectiveWithCoverage =
+    (coverage as boolean | undefined) ??
+    (withCoverage as boolean | undefined) ??
+    false;
+  return {
+    effectiveWithCoverage,
+    effectiveCoverageFormat: effectiveWithCoverage
+      ? ((coverageFormat as 'jacoco' | 'sonar-generic' | undefined) ?? 'jacoco')
+      : null,
+  };
+}
+
+function isJessReadResourceAllowed(
+  jess: McpJessAccess,
+  name: string,
+  arguments_: Record<string, unknown>,
+): boolean {
+  if (name !== 'get_object' && name !== 'get_object_structure') return true;
+  const key = canonicalObjectKey(arguments_.objectType, arguments_.objectName);
+  return Boolean(key && jess.objectKeys.includes(key));
+}
+
+function isJessAtcResourceAllowed(
+  jess: McpJessAccess,
+  arguments_: Record<string, unknown>,
+): boolean {
+  const policy = jess.safeExecutePolicy;
+  const scope = arguments_.scope;
+  if (
+    !policy ||
+    policy.operationId !== 'atc_run' ||
+    policy.check !== 'atc' ||
+    !scope ||
+    typeof scope !== 'object' ||
+    Array.isArray(scope)
+  ) {
+    return false;
+  }
+  const scopeRecord = scope as Record<string, unknown>;
+  const variantCount = 1;
+  if (variantCount > policy.maxVariants) return false;
+
+  if (scopeRecord.kind === 'package') {
+    // A package selector would expand only after SAP I/O, too late to compare
+    // every object with the signed scope. ARM must materialise the expansion
+    // into this tool's canonical `objects` scope before issuing the grant.
+    return false;
+  }
+  if (scopeRecord.kind !== 'objects' || !Array.isArray(scopeRecord.objects)) {
+    // Transport expansion has no corresponding signed count bound.
+    return false;
+  }
+  const keys: string[] = [];
+  let packageCount = 0;
+  for (const object of scopeRecord.objects) {
+    if (!object || typeof object !== 'object' || Array.isArray(object)) {
+      return false;
+    }
+    const record = object as Record<string, unknown>;
+    const key = canonicalObjectKey(record.objectType, record.objectName);
+    if (!key) return false;
+    if (key.startsWith('DEVC:')) packageCount++;
+    keys.push(key);
+  }
+  const sortedKeys = sortedUnique(keys);
+  return Boolean(
+    sortedKeys &&
+    sortedKeys.length <= policy.maxObjects &&
+    packageCount <= policy.maxPackages &&
+    exactStringArrays(jess.objectKeys, sortedKeys),
+  );
+}
+
+function isJessUnitTestResourceAllowed(
+  jess: McpJessAccess,
+  arguments_: Record<string, unknown>,
+): boolean {
+  const policy = jess.safeExecutePolicy;
+  const key = canonicalObjectKey(arguments_.objectType, arguments_.objectName);
+  const normalized = normalizeUnitTestOptions(arguments_);
+  if (
+    !policy ||
+    policy.operationId !== 'run_unit_tests' ||
+    !key ||
+    !normalized ||
+    policy.maxObjects < 1 ||
+    !exactStringArrays(jess.objectKeys, [key])
+  ) {
+    return false;
+  }
+  return policy.check === 'aunit'
+    ? normalized.effectiveWithCoverage === false &&
+        normalized.effectiveCoverageFormat === null &&
+        policy.effectiveWithCoverage === false &&
+        policy.effectiveCoverageFormat === null
+    : normalized.effectiveWithCoverage === true &&
+        normalized.effectiveCoverageFormat === policy.effectiveCoverageFormat &&
+        policy.effectiveWithCoverage === true;
 }
 
 /**
@@ -264,6 +452,19 @@ export function isMcpToolResourceAllowed(
   name: string,
   arguments_: Record<string, unknown> = {},
 ): boolean {
+  const jess = access?.jess;
+  if (jess) {
+    if (jess.operationClass === 'read') {
+      return isJessReadResourceAllowed(jess, name, arguments_);
+    }
+    if (name === 'atc_run') {
+      return isJessAtcResourceAllowed(jess, arguments_);
+    }
+    if (name === 'run_unit_tests') {
+      return isJessUnitTestResourceAllowed(jess, arguments_);
+    }
+    return false;
+  }
   const frozenSource = access?.frozenSource;
   if (!frozenSource) return name !== 'get_frozen_source';
   if (name !== 'get_frozen_source') return false;
@@ -317,6 +518,14 @@ export function isMcpToolListed(
     return false;
   }
   if (access.frozenSource) return name === 'get_frozen_source';
+  if (access.jess) {
+    const operationClass =
+      'actionClasses' in entry ? undefined : entry.operationClass;
+    return (
+      operationClass === access.jess.operationClass &&
+      access.jess.toolNames.includes(name)
+    );
+  }
   if (name === 'get_frozen_source') return false;
   const classes =
     'actionClasses' in entry

--- a/packages/adt-mcp/src/lib/tools/utils.ts
+++ b/packages/adt-mcp/src/lib/tools/utils.ts
@@ -191,6 +191,23 @@ export function getErrorStatus(error: unknown): number | undefined {
 }
 
 /**
+ * A completed SAP HTTP error response is a deterministic failed execution.
+ * Network, body-stream, abort, and internal parsing errors deliberately do not
+ * match, because dispatch may have happened and their outcome is uncertain.
+ */
+export function isKnownAdtHttpFailure(error: unknown): boolean {
+  const status = getErrorStatus(error);
+  return (
+    error instanceof Error &&
+    error.name === 'AdtError' &&
+    typeof status === 'number' &&
+    Number.isInteger(status) &&
+    status >= 400 &&
+    status <= 599
+  );
+}
+
+/**
  * Build a standard MCP error result with BTP 404 awareness.
  */
 export function mcpErrorResult(

--- a/packages/adt-mcp/src/lib/types.ts
+++ b/packages/adt-mcp/src/lib/types.ts
@@ -10,6 +10,7 @@ import type {
   RequestIdentity,
 } from './session/destination-registry.js';
 import type { McpRequestAccess } from './tools/scope-catalogue.js';
+import type { SafeExecutePolicy } from './http/invocation.js';
 import type { createSourceCapabilityRegistry } from './source-capabilities.js';
 
 /**
@@ -53,6 +54,32 @@ export interface ToolContext {
   requestAccess?: (extra: {
     sessionId?: string;
   }) => McpRequestAccess | undefined;
+  /**
+   * Atomically consumes ARM's opaque Jess check grant. The implementation
+   * owns ADT Server service authentication and must return true only after
+   * ARM responds with the successful consume result.
+   */
+  consumeSafeExecuteGrant?: (input: {
+    grantJti: string;
+    opaqueGrant: string;
+    principal: string;
+    threadId: string;
+    executionId: string;
+    systemSid: string;
+    objectKeys: readonly string[];
+    destination: string;
+    operationId: 'atc_run' | 'run_unit_tests';
+    policy: SafeExecutePolicy;
+  }) => Promise<boolean>;
+  /**
+   * Executes a consumed safe check under a runtime that can actually
+   * terminate its SAP transport at `maxDurationMs`. Returning early while the
+   * supplied operation continues is forbidden.
+   */
+  executeSafeTool?: (input: {
+    maxDurationMs: number;
+    operation: () => Promise<unknown>;
+  }) => Promise<unknown>;
   /**
    * Redeems an opaque ADT source capability after destination-mode policy has
    * selected it. The resolver may return only a trusted server-relative URI.

--- a/packages/adt-mcp/src/lib/types.ts
+++ b/packages/adt-mcp/src/lib/types.ts
@@ -72,6 +72,16 @@ export interface ToolContext {
     policy: SafeExecutePolicy;
   }) => Promise<boolean>;
   /**
+   * Records the single terminal state of a consumed ARM grant. It is called
+   * exactly once after the SAP operation settles and must never trigger a
+   * retry of that operation.
+   */
+  reportSafeExecuteGrantOutcome?: (input: {
+    grantJti: string;
+    opaqueGrant: string;
+    outcome: 'succeeded' | 'failed' | 'outcome_unknown';
+  }) => Promise<boolean>;
+  /**
    * Executes a consumed safe check under a runtime that can actually
    * terminate its SAP transport at `maxDurationMs`. Returning early while the
    * supplied operation continues is forbidden.

--- a/packages/adt-mcp/tests/http-destination-scope.test.ts
+++ b/packages/adt-mcp/tests/http-destination-scope.test.ts
@@ -54,6 +54,7 @@ test('HTTP destination mode projects only read-scoped tools without weakening hi
     assert.ok(names.has('system_info'));
     assert.ok(names.has('gcts_config'));
     assert.ok(!names.has('atc_run'));
+    assert.ok(!names.has('run_unit_tests'));
     assert.ok(!names.has('lock_object'));
     assert.ok(!names.has('activate_object'));
     assert.deepStrictEqual(gctsActionSchema?.enum, ['get', 'list']);

--- a/packages/adt-mcp/tests/http-invocation-auth.test.ts
+++ b/packages/adt-mcp/tests/http-invocation-auth.test.ts
@@ -25,7 +25,7 @@ async function signInvocation(
     tokenId?: string;
     classes?: string[];
     destinationKeys?: string[];
-    agentId?: 'ai-review' | 'system-assistant';
+    agentId?: 'ai-review' | 'jess';
     constraint?: Record<string, unknown>;
     limits?: Record<string, unknown>;
   } = {},
@@ -35,7 +35,7 @@ async function signInvocation(
     v: 1,
     kid: keyId,
     principal: 'petr.plenkov',
-    agentId: overrides.agentId ?? 'system-assistant',
+    agentId: overrides.agentId ?? 'jess',
     classes: overrides.classes ?? ['server', 'read'],
     destinationKeys: overrides.destinationKeys ?? ['dev'],
     correlationId: 'correlation-http-invocation',
@@ -47,8 +47,21 @@ async function signInvocation(
             runId: 'run-1',
             frozenCanonicalKeys: ['CLAS:ZCL_SCOPE_TEST'],
           }
-        : { systemSid: 'DEV' }),
-    limits: overrides.limits ?? {},
+        : {
+            kind: 'jess-adt-v1',
+            threadId: '11111111-1111-4111-8111-111111111111',
+            executionId: '22222222-2222-4222-8222-222222222222',
+            systemSid: 'DEV',
+            objectKeys: ['CLAS:ZCL_SCOPE_TEST'],
+            toolNames: ['get_object'],
+          }),
+    limits:
+      overrides.limits ??
+      (overrides.agentId === 'ai-review'
+        ? {}
+        : {
+            maxToolCalls: 3,
+          }),
   })
     .setProtectedHeader({ alg: 'ES256', kid: keyId, typ: 'JWT' })
     .setIssuer(issuer)
@@ -121,7 +134,7 @@ test('ADT invocation auth snapshots verified read scope and binds continuation t
     assert.ok(transport.sessionId);
 
     const tools = await client.listTools();
-    assert.ok(tools.tools.some((tool) => tool.name === 'system_info'));
+    assert.ok(tools.tools.some((tool) => tool.name === 'get_object'));
     assert.ok(!tools.tools.some((tool) => tool.name === 'lock_object'));
 
     const denied = await client.callTool({
@@ -152,8 +165,12 @@ test('ADT invocation auth snapshots verified read scope and binds continuation t
         id: 1,
         method: 'tools/call',
         params: {
-          name: 'system_info',
-          arguments: { destination: 'dev' },
+          name: 'get_object',
+          arguments: {
+            destination: 'dev',
+            objectType: 'CLAS',
+            objectName: 'ZCL_SCOPE_TEST',
+          },
         },
       }),
     });

--- a/packages/adt-mcp/tests/http-invocation.test.ts
+++ b/packages/adt-mcp/tests/http-invocation.test.ts
@@ -41,12 +41,19 @@ function claims(overrides: JWTPayload = {}): JWTPayload {
     v: 1,
     kid: keyId,
     principal: 'petr.plenkov',
-    agentId: 'system-assistant',
+    agentId: 'jess',
     classes: ['server', 'read'],
     destinationKeys: ['trl-rise'],
     correlationId: 'correlation-001',
-    constraint: { systemSid: 'TRL', frozenScope: ['ZCL_ADT_REVIEW'] },
-    limits: { maxSourceBytes: 65_536 },
+    constraint: {
+      kind: 'jess-adt-v1',
+      threadId: '11111111-1111-4111-8111-111111111111',
+      executionId: '22222222-2222-4222-8222-222222222222',
+      systemSid: 'TRL',
+      objectKeys: ['CLAS:ZCL_ADT_REVIEW'],
+      toolNames: ['get_object'],
+    },
+    limits: { maxToolCalls: 3 },
     ...overrides,
   };
 }
@@ -102,19 +109,26 @@ describe('MCP invocation verifier', () => {
     assert.deepStrictEqual(verified, {
       tokenId: 'jti-test-001',
       principal: 'petr.plenkov',
-      agentId: 'system-assistant',
+      agentId: 'jess',
       classes: ['server', 'read'],
       destinationKeys: ['trl-rise'],
       correlationId: 'correlation-001',
-      constraint: { systemSid: 'TRL', frozenScope: ['ZCL_ADT_REVIEW'] },
-      limits: { maxSourceBytes: 65_536 },
+      constraint: {
+        kind: 'jess-adt-v1',
+        threadId: '11111111-1111-4111-8111-111111111111',
+        executionId: '22222222-2222-4222-8222-222222222222',
+        systemSid: 'TRL',
+        objectKeys: ['CLAS:ZCL_ADT_REVIEW'],
+        toolNames: ['get_object'],
+      },
+      limits: { maxToolCalls: 3 },
     });
     assert.ok(verified);
     assert.ok(Object.isFrozen(verified));
     assert.ok(Object.isFrozen(verified.classes));
     assert.ok(Object.isFrozen(verified.destinationKeys));
     assert.ok(Object.isFrozen(verified.constraint));
-    assert.ok(Object.isFrozen(verified.constraint.frozenScope));
+    assert.ok(Object.isFrozen(verified.constraint.objectKeys));
     assert.throws(() => {
       (verified.destinationKeys as string[]).push('other-rise');
     });
@@ -206,39 +220,14 @@ describe('MCP invocation verifier', () => {
     );
   });
 
-  it('accepts only the exact read-only autonomous review agent scope', async () => {
-    const executionId = '11111111-1111-4111-8111-111111111111';
-    const credential = await sign({
-      agentId: 'autonomous-review-agent',
-      classes: ['server', 'read'],
-      destinationKeys: ['trl-rise'],
-      constraint: { executionId, systemSid: 'TRL' },
-      limits: {},
-    });
-
-    const verified = await verifier.verify(`Bearer ${credential}`);
-
-    assert.ok(verified);
-    assert.strictEqual(verified.agentId, 'autonomous-review-agent');
-    assert.strictEqual(isMcpInvocationDispatchPolicySupported(verified), true);
-  });
-
-  it('rejects a relaxed autonomous review system constraint', async () => {
-    const credential = await sign({
-      agentId: 'autonomous-review-agent',
-      classes: ['server', 'read'],
-      destinationKeys: ['trl-rise'],
-      constraint: {
-        executionId: '11111111-1111-4111-8111-111111111111',
-        systemSid: 'TRL!',
-      },
-      limits: {},
-    });
-
-    const verified = await verifier.verify(`Bearer ${credential}`);
-
-    assert.ok(verified);
-    assert.strictEqual(isMcpInvocationDispatchPolicySupported(verified), false);
+  it('rejects retired agent identities', async () => {
+    for (const agentId of ['system-assistant', 'autonomous-review-agent']) {
+      const credential = await sign({ agentId });
+      assert.strictEqual(
+        await verifier.verify(`Bearer ${credential}`),
+        undefined,
+      );
+    }
   });
 
   it('rejects an invocation that requests write authority', async () => {

--- a/packages/adt-mcp/tests/jess-invocation-policy.test.ts
+++ b/packages/adt-mcp/tests/jess-invocation-policy.test.ts
@@ -1,0 +1,205 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  isMcpInvocationDispatchPolicySupported,
+  parseJessAdtInvocationPolicy,
+  type TrustedMcpInvocationClaims,
+} from '../src/lib/http/invocation.js';
+
+const threadId = '11111111-1111-4111-8111-111111111111';
+const executionId = '22222222-2222-4222-8222-222222222222';
+const grantJti = '33333333-3333-4333-8333-333333333333';
+const opaqueGrant = 'eyJhbGciOiJFUzI1NiJ9.eyJncmFudCI6dHJ1ZX0.signature';
+
+function claims(
+  overrides: Partial<TrustedMcpInvocationClaims> = {},
+): TrustedMcpInvocationClaims {
+  return {
+    tokenId: 'jti-jess-001',
+    principal: 'engineer@arm',
+    agentId: 'jess',
+    classes: ['server', 'read'],
+    destinationKeys: ['tst-adt'],
+    correlationId: 'jess:execution:001',
+    constraint: {
+      kind: 'jess-adt-v1',
+      threadId,
+      executionId,
+      systemSid: 'TST',
+      objectKeys: ['CLAS:ZCL_RELEASE_GATE', 'PROG:Z_RELEASE_REPORT'],
+      toolNames: ['get_object', 'get_object_structure'],
+    },
+    limits: { maxToolCalls: 3 },
+    ...overrides,
+  };
+}
+
+const atcPolicy = {
+  operationId: 'atc_run',
+  check: 'atc',
+  maxDurationMs: 30_000,
+  maxResultBytes: 262_144,
+  maxFindings: 500,
+  maxObjects: 20,
+  maxPackages: 5,
+  maxVariants: 1,
+} as const;
+
+const aunitPolicy = {
+  operationId: 'run_unit_tests',
+  check: 'aunit',
+  effectiveWithCoverage: false,
+  effectiveCoverageFormat: null,
+  maxDurationMs: 45_000,
+  maxResultBytes: 262_144,
+  maxFindings: 500,
+  maxObjects: 20,
+  maxTestClasses: 100,
+  maxTestMethods: 1_000,
+} as const;
+
+const coveragePolicy = {
+  operationId: 'run_unit_tests',
+  check: 'coverage',
+  effectiveWithCoverage: true,
+  effectiveCoverageFormat: 'sonar-generic',
+  maxDurationMs: 60_000,
+  maxResultBytes: 524_288,
+  maxFindings: 500,
+  maxObjects: 20,
+  maxPrograms: 20,
+  maxMeasurements: 10_000,
+} as const;
+
+describe('Jess ADT invocation policy', () => {
+  it('parses the exact read policy', () => {
+    const parsed = parseJessAdtInvocationPolicy(claims());
+
+    assert.deepStrictEqual(parsed, {
+      threadId,
+      executionId,
+      systemSid: 'TST',
+      objectKeys: ['CLAS:ZCL_RELEASE_GATE', 'PROG:Z_RELEASE_REPORT'],
+      toolNames: ['get_object', 'get_object_structure'],
+      operationClass: 'read',
+      maxToolCalls: 3,
+    });
+    assert.strictEqual(isMcpInvocationDispatchPolicySupported(claims()), true);
+  });
+
+  for (const policy of [atcPolicy, aunitPolicy, coveragePolicy]) {
+    it(`parses the exact ${policy.check} safe-execute policy`, () => {
+      const safeClaims = claims({
+        classes: ['server', 'safe_execute'],
+        constraint: {
+          kind: 'jess-adt-v1',
+          threadId,
+          executionId,
+          systemSid: 'TST',
+          objectKeys: ['CLAS:ZCL_RELEASE_GATE'],
+          toolNames: [policy.operationId],
+          safeExecutePolicy: policy,
+          safeExecuteGrantJti: grantJti,
+          safeExecuteGrant: opaqueGrant,
+        },
+        limits: { maxToolCalls: 1 },
+      });
+
+      assert.deepStrictEqual(parseJessAdtInvocationPolicy(safeClaims), {
+        threadId,
+        executionId,
+        systemSid: 'TST',
+        objectKeys: ['CLAS:ZCL_RELEASE_GATE'],
+        toolNames: [policy.operationId],
+        operationClass: 'safe_execute',
+        safeExecutePolicy: policy,
+        safeExecuteGrantJti: grantJti,
+        safeExecuteGrant: opaqueGrant,
+        maxToolCalls: 1,
+      });
+      assert.strictEqual(
+        isMcpInvocationDispatchPolicySupported(safeClaims),
+        true,
+      );
+    });
+  }
+
+  it('rejects retired agent identities', () => {
+    for (const agentId of [
+      'system-assistant',
+      'autonomous-review-agent',
+    ] as const) {
+      assert.strictEqual(
+        parseJessAdtInvocationPolicy(
+          claims({ agentId } as Partial<TrustedMcpInvocationClaims>),
+        ),
+        undefined,
+      );
+    }
+  });
+
+  it('rejects unsorted or duplicate exact scopes', () => {
+    for (const constraint of [
+      {
+        ...claims().constraint,
+        objectKeys: ['PROG:Z_RELEASE_REPORT', 'CLAS:ZCL_RELEASE_GATE'],
+      },
+      {
+        ...claims().constraint,
+        objectKeys: ['CLAS:ZCL_RELEASE_GATE', 'CLAS:ZCL_RELEASE_GATE'],
+      },
+      {
+        ...claims().constraint,
+        toolNames: ['get_object_structure', 'get_object'],
+      },
+    ]) {
+      assert.strictEqual(
+        parseJessAdtInvocationPolicy(claims({ constraint })),
+        undefined,
+      );
+    }
+  });
+
+  it('rejects class, tool and policy drift', () => {
+    const safeConstraint = {
+      kind: 'jess-adt-v1',
+      threadId,
+      executionId,
+      systemSid: 'TST',
+      objectKeys: ['CLAS:ZCL_RELEASE_GATE'],
+      toolNames: ['atc_run'],
+      safeExecutePolicy: atcPolicy,
+      safeExecuteGrantJti: grantJti,
+      safeExecuteGrant: opaqueGrant,
+    } as const;
+    for (const candidate of [
+      claims({
+        classes: ['server', 'read'],
+        constraint: safeConstraint,
+      }),
+      claims({
+        classes: ['server', 'safe_execute'],
+        constraint: {
+          ...safeConstraint,
+          toolNames: ['run_unit_tests'],
+        },
+      }),
+      claims({
+        classes: ['server', 'safe_execute'],
+        constraint: {
+          ...safeConstraint,
+          safeExecutePolicy: { ...atcPolicy, ignored: true },
+        },
+      }),
+      claims({
+        classes: ['server', 'safe_execute'],
+        constraint: {
+          ...safeConstraint,
+          safeExecutePolicy: undefined,
+        },
+      }),
+    ]) {
+      assert.strictEqual(parseJessAdtInvocationPolicy(candidate), undefined);
+    }
+  });
+});

--- a/packages/adt-mcp/tests/jess-safe-execute-enforcement.test.ts
+++ b/packages/adt-mcp/tests/jess-safe-execute-enforcement.test.ts
@@ -2,11 +2,14 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { destinationModeServer } from '../src/lib/tools/destination-mode.js';
+import { registerAtcRunTool } from '../src/lib/tools/atc-run.js';
+import { registerRunUnitTestsTool } from '../src/lib/tools/run-unit-tests.js';
 import {
   isMcpToolListed,
   normalizeUnitTestOptions,
   type McpRequestAccess,
 } from '../src/lib/tools/scope-catalogue.js';
+import { isKnownAdtHttpFailure } from '../src/lib/tools/utils.js';
 
 type ToolResult = {
   isError?: boolean;
@@ -62,6 +65,30 @@ function safeAccess(): McpRequestAccess {
   };
 }
 
+function safeAunitAccess(): McpRequestAccess {
+  const access = safeAccess();
+  return {
+    ...access,
+    jess: {
+      ...access.jess!,
+      objectKeys: ['CLAS:ZCL_RELEASE_GATE'],
+      toolNames: ['run_unit_tests'],
+      safeExecutePolicy: {
+        operationId: 'run_unit_tests',
+        check: 'aunit',
+        effectiveWithCoverage: false,
+        effectiveCoverageFormat: null,
+        maxDurationMs: 30_000,
+        maxResultBytes: 1_024,
+        maxFindings: 10,
+        maxObjects: 1,
+        maxTestClasses: 10,
+        maxTestMethods: 100,
+      },
+    },
+  };
+}
+
 const exactAtcArgs = {
   destination: 'tst-adt',
   scope: {
@@ -72,6 +99,99 @@ const exactAtcArgs = {
 };
 
 describe('Jess safe-execute catalogue and dispatch', () => {
+  it('classifies only completed SAP HTTP error responses as deterministic failures', () => {
+    const sapResponse = Object.assign(new Error('HTTP 400: Bad Request'), {
+      name: 'AdtError',
+      status: 400,
+    });
+    const transportFailure = new TypeError('fetch failed');
+    const abortFailure = Object.assign(new Error('deadline exceeded'), {
+      name: 'AbortError',
+    });
+
+    assert.strictEqual(isKnownAdtHttpFailure(sapResponse), true);
+    assert.strictEqual(isKnownAdtHttpFailure(transportFailure), false);
+    assert.strictEqual(isKnownAdtHttpFailure(abortFailure), false);
+  });
+
+  it('normalises known ATC HTTP failures but rethrows uncertain transport failures', async () => {
+    const target = new CapturingServer();
+    let failure: Error = Object.assign(new Error('HTTP 400: Bad Request'), {
+      name: 'AdtError',
+      status: 400,
+    });
+    registerAtcRunTool(target as unknown as McpServer, {
+      getClient: () =>
+        ({
+          adt: {
+            atc: {
+              worklists: {
+                create: async () => {
+                  throw failure;
+                },
+              },
+            },
+          },
+        }) as never,
+      requestAccess: safeAccess,
+    });
+    const handler = target.handlers.get('atc_run')!;
+    const args = {
+      baseUrl: 'https://sap.example.test',
+      scope: exactAtcArgs.scope,
+      variant: 'DEFAULT',
+    };
+
+    await assert.doesNotReject(async () => {
+      const result = await handler(args, {});
+      assert.strictEqual(result.isError, true);
+    });
+
+    failure = new TypeError('fetch failed');
+    await assert.rejects(handler(args, {}), /fetch failed/u);
+  });
+
+  it('normalises known AUnit HTTP failures but rethrows uncertain transport failures', async () => {
+    const target = new CapturingServer();
+    let failure: Error = Object.assign(
+      new Error('HTTP 500: Internal Server Error'),
+      {
+        name: 'AdtError',
+        status: 500,
+      },
+    );
+    registerRunUnitTestsTool(target as unknown as McpServer, {
+      getClient: () =>
+        ({
+          adt: {
+            aunit: {
+              testruns: {
+                post: async () => {
+                  throw failure;
+                },
+              },
+            },
+          },
+        }) as never,
+      requestAccess: safeAunitAccess,
+    });
+    const handler = target.handlers.get('run_unit_tests')!;
+    const args = {
+      baseUrl: 'https://sap.example.test',
+      objectName: 'ZCL_RELEASE_GATE',
+      objectType: 'CLAS',
+      withCoverage: false,
+    };
+
+    await assert.doesNotReject(async () => {
+      const result = await handler(args, {});
+      assert.strictEqual(result.isError, true);
+    });
+
+    failure = new TypeError('fetch failed');
+    await assert.rejects(handler(args, {}), /fetch failed/u);
+  });
+
   it('normalises coverage flags and rejects disagreement', () => {
     assert.deepStrictEqual(normalizeUnitTestOptions({}), {
       effectiveWithCoverage: false,
@@ -132,6 +252,7 @@ describe('Jess safe-execute catalogue and dispatch', () => {
         return true;
       },
       executeSafeTool: async ({ operation }) => await operation(),
+      reportSafeExecuteGrantOutcome: async () => true,
     });
     server.tool('atc_run', {}, async () => {
       handlerCalls++;
@@ -165,6 +286,7 @@ describe('Jess safe-execute catalogue and dispatch', () => {
         return true;
       },
       executeSafeTool: async ({ operation }) => await operation(),
+      reportSafeExecuteGrantOutcome: async () => true,
     });
     server.tool('atc_run', {}, async () => ({
       content: [{ type: 'text' as const, text: 'unexpected' }],
@@ -203,6 +325,10 @@ describe('Jess safe-execute catalogue and dispatch', () => {
         return true;
       },
       executeSafeTool: async ({ operation }) => await operation(),
+      reportSafeExecuteGrantOutcome: async ({ outcome }) => {
+        events.push(`outcome:${outcome}`);
+        return true;
+      },
     });
     server.tool('atc_run', {}, async () => {
       events.push('handler');
@@ -217,7 +343,12 @@ describe('Jess safe-execute catalogue and dispatch', () => {
     });
 
     assert.strictEqual(first.isError, undefined);
-    assert.deepStrictEqual(events, ['consume', 'handler', 'consume']);
+    assert.deepStrictEqual(events, [
+      'consume',
+      'handler',
+      'outcome:succeeded',
+      'consume',
+    ]);
     assert.strictEqual(replay.isError, true);
     assert.strictEqual(replay.content[0]?.text, 'mcp_scope_denied');
   });
@@ -266,7 +397,7 @@ describe('Jess safe-execute catalogue and dispatch', () => {
     assert.strictEqual(handlerCalls, 1);
   });
 
-  it('stays fail-closed before consume when no hard-cancellable runtime exists', async () => {
+  it('stays fail-closed before consume when the runtime or outcome recorder is absent', async () => {
     const target = new CapturingServer();
     let consumes = 0;
     const server = destinationModeServer(target as unknown as McpServer, {
@@ -275,6 +406,7 @@ describe('Jess safe-execute catalogue and dispatch', () => {
         consumes++;
         return true;
       },
+      executeSafeTool: async ({ operation }) => await operation(),
     });
     server.tool('atc_run', {}, async () => ({
       content: [{ type: 'text' as const, text: 'unexpected' }],
@@ -299,6 +431,10 @@ describe('Jess safe-execute catalogue and dispatch', () => {
       requestAccess: () => access,
       consumeSafeExecuteGrant: async () => true,
       executeSafeTool: async ({ operation }) => await operation(),
+      reportSafeExecuteGrantOutcome: async ({ outcome }) => {
+        assert.strictEqual(outcome, 'failed');
+        return true;
+      },
     });
     server.tool('atc_run', {}, async () => ({
       content: [{ type: 'text' as const, text: 'larger-than-eight-bytes' }],
@@ -310,5 +446,105 @@ describe('Jess safe-execute catalogue and dispatch', () => {
 
     assert.strictEqual(result.isError, true);
     assert.strictEqual(result.content[0]?.text, 'safe_execute_limit_exceeded');
+  });
+
+  it('records deterministic tool failures only after the operation settles', async () => {
+    const target = new CapturingServer();
+    const events: string[] = [];
+    const server = destinationModeServer(target as unknown as McpServer, {
+      requestAccess: safeAccess,
+      consumeSafeExecuteGrant: async () => {
+        events.push('consume');
+        return true;
+      },
+      executeSafeTool: async ({ operation }) => await operation(),
+      reportSafeExecuteGrantOutcome: async (input) => {
+        events.push(`outcome:${input.outcome}`);
+        assert.strictEqual(
+          input.grantJti,
+          '33333333-3333-4333-8333-333333333333',
+        );
+        assert.strictEqual(input.opaqueGrant, 'header.payload.signature');
+        return true;
+      },
+    });
+    server.tool('atc_run', {}, async () => {
+      events.push('handler-settled');
+      return {
+        isError: true,
+        content: [{ type: 'text' as const, text: 'deterministic failure' }],
+      };
+    });
+
+    const result = await target.handlers.get('atc_run')!(exactAtcArgs, {
+      sessionId: 'session-1',
+    });
+
+    assert.strictEqual(result.isError, true);
+    assert.deepStrictEqual(events, [
+      'consume',
+      'handler-settled',
+      'outcome:failed',
+    ]);
+  });
+
+  it('records outcome_unknown once after an uncertain operation settles without retrying SAP', async () => {
+    const target = new CapturingServer();
+    const events: string[] = [];
+    let handlerCalls = 0;
+    const server = destinationModeServer(target as unknown as McpServer, {
+      requestAccess: safeAccess,
+      consumeSafeExecuteGrant: async () => true,
+      executeSafeTool: async ({ operation }) => {
+        await operation();
+        throw new Error('transport outcome is uncertain');
+      },
+      reportSafeExecuteGrantOutcome: async ({ outcome }) => {
+        events.push(outcome);
+        return true;
+      },
+    });
+    server.tool('atc_run', {}, async () => {
+      handlerCalls++;
+      events.push('handler-settled');
+      return { content: [{ type: 'text' as const, text: 'late result' }] };
+    });
+
+    const result = await target.handlers.get('atc_run')!(exactAtcArgs, {
+      sessionId: 'session-1',
+    });
+
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.content[0]?.text, 'outcome_unknown');
+    assert.strictEqual(handlerCalls, 1);
+    assert.deepStrictEqual(events, ['handler-settled', 'outcome_unknown']);
+  });
+
+  it('returns outcome_unknown when the single terminal report fails without rerunning SAP', async () => {
+    const target = new CapturingServer();
+    let handlerCalls = 0;
+    let reports = 0;
+    const server = destinationModeServer(target as unknown as McpServer, {
+      requestAccess: safeAccess,
+      consumeSafeExecuteGrant: async () => true,
+      executeSafeTool: async ({ operation }) => await operation(),
+      reportSafeExecuteGrantOutcome: async () => {
+        reports++;
+        return false;
+      },
+    });
+    server.tool('atc_run', {}, async () => {
+      handlerCalls++;
+      return { content: [{ type: 'text' as const, text: 'SAP completed' }] };
+    });
+
+    const result = await target.handlers.get('atc_run')!(exactAtcArgs, {
+      sessionId: 'session-1',
+    });
+
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.content[0]?.text, 'outcome_unknown');
+    assert.strictEqual(handlerCalls, 1);
+    assert.strictEqual(reports, 1);
   });
 });

--- a/packages/adt-mcp/tests/jess-safe-execute-enforcement.test.ts
+++ b/packages/adt-mcp/tests/jess-safe-execute-enforcement.test.ts
@@ -1,0 +1,314 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { destinationModeServer } from '../src/lib/tools/destination-mode.js';
+import {
+  isMcpToolListed,
+  normalizeUnitTestOptions,
+  type McpRequestAccess,
+} from '../src/lib/tools/scope-catalogue.js';
+
+type ToolResult = {
+  isError?: boolean;
+  content: Array<{ type: 'text'; text: string }>;
+};
+type ToolHandler = (
+  args: Record<string, unknown>,
+  extra: { sessionId?: string },
+) => Promise<ToolResult>;
+
+class CapturingServer {
+  readonly handlers = new Map<string, ToolHandler>();
+
+  tool(...args: unknown[]): void {
+    const name = args[0];
+    const handler = args.at(-1);
+    assert.strictEqual(typeof name, 'string');
+    assert.strictEqual(typeof handler, 'function');
+    this.handlers.set(name, handler as ToolHandler);
+  }
+}
+
+const atcPolicy = {
+  operationId: 'atc_run',
+  check: 'atc',
+  maxDurationMs: 30_000,
+  maxResultBytes: 1_024,
+  maxFindings: 10,
+  maxObjects: 2,
+  maxPackages: 1,
+  maxVariants: 1,
+} as const;
+
+function safeAccess(): McpRequestAccess {
+  return {
+    classes: ['server', 'safe_execute'],
+    destinationKeys: ['tst-adt'],
+    jess: {
+      tokenId: 'invocation-jti',
+      principal: 'engineer@arm',
+      correlationId: 'jess:execution:001',
+      threadId: '11111111-1111-4111-8111-111111111111',
+      executionId: '22222222-2222-4222-8222-222222222222',
+      systemSid: 'TST',
+      objectKeys: ['CLAS:ZCL_RELEASE_GATE'],
+      toolNames: ['atc_run'],
+      operationClass: 'safe_execute',
+      maxToolCalls: 1,
+      safeExecutePolicy: atcPolicy,
+      safeExecuteGrantJti: '33333333-3333-4333-8333-333333333333',
+      safeExecuteGrant: 'header.payload.signature',
+    },
+  };
+}
+
+const exactAtcArgs = {
+  destination: 'tst-adt',
+  scope: {
+    kind: 'objects',
+    objects: [{ objectType: 'CLAS', objectName: 'ZCL_RELEASE_GATE' }],
+  },
+  variant: 'DEFAULT',
+};
+
+describe('Jess safe-execute catalogue and dispatch', () => {
+  it('normalises coverage flags and rejects disagreement', () => {
+    assert.deepStrictEqual(normalizeUnitTestOptions({}), {
+      effectiveWithCoverage: false,
+      effectiveCoverageFormat: null,
+    });
+    assert.deepStrictEqual(
+      normalizeUnitTestOptions({
+        coverage: true,
+        withCoverage: true,
+        coverageFormat: 'sonar-generic',
+      }),
+      {
+        effectiveWithCoverage: true,
+        effectiveCoverageFormat: 'sonar-generic',
+      },
+    );
+    assert.strictEqual(
+      normalizeUnitTestOptions({
+        coverage: true,
+        withCoverage: false,
+      }),
+      undefined,
+    );
+  });
+
+  it('hides both checks from read and exposes exactly the signed safe tool', () => {
+    const read: McpRequestAccess = {
+      classes: ['server', 'read'],
+      destinationKeys: ['tst-adt'],
+      jess: {
+        tokenId: 'read-jti',
+        principal: 'engineer@arm',
+        correlationId: 'jess:execution:read',
+        threadId: '11111111-1111-4111-8111-111111111111',
+        executionId: '22222222-2222-4222-8222-222222222222',
+        systemSid: 'TST',
+        objectKeys: ['CLAS:ZCL_RELEASE_GATE'],
+        toolNames: ['get_object'],
+        operationClass: 'read',
+        maxToolCalls: 3,
+      },
+    };
+
+    assert.strictEqual(isMcpToolListed(read, 'atc_run'), false);
+    assert.strictEqual(isMcpToolListed(read, 'run_unit_tests'), false);
+    assert.strictEqual(isMcpToolListed(safeAccess(), 'atc_run'), true);
+    assert.strictEqual(isMcpToolListed(safeAccess(), 'run_unit_tests'), false);
+  });
+
+  it('denies policy/resource mismatch before grant consumption and handler I/O', async () => {
+    const target = new CapturingServer();
+    let consumes = 0;
+    let handlerCalls = 0;
+    const server = destinationModeServer(target as unknown as McpServer, {
+      requestAccess: safeAccess,
+      consumeSafeExecuteGrant: async () => {
+        consumes++;
+        return true;
+      },
+      executeSafeTool: async ({ operation }) => await operation(),
+    });
+    server.tool('atc_run', {}, async () => {
+      handlerCalls++;
+      return { content: [{ type: 'text' as const, text: 'unexpected' }] };
+    });
+
+    const result = await target.handlers.get('atc_run')!(
+      {
+        ...exactAtcArgs,
+        scope: {
+          kind: 'objects',
+          objects: [{ objectType: 'CLAS', objectName: 'ZCL_OTHER' }],
+        },
+      },
+      { sessionId: 'session-1' },
+    );
+
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.content[0]?.text, 'mcp_scope_denied');
+    assert.strictEqual(consumes, 0);
+    assert.strictEqual(handlerCalls, 0);
+  });
+
+  it('denies an unmaterialised package expansion before grant consumption', async () => {
+    const target = new CapturingServer();
+    let consumes = 0;
+    const server = destinationModeServer(target as unknown as McpServer, {
+      requestAccess: safeAccess,
+      consumeSafeExecuteGrant: async () => {
+        consumes++;
+        return true;
+      },
+      executeSafeTool: async ({ operation }) => await operation(),
+    });
+    server.tool('atc_run', {}, async () => ({
+      content: [{ type: 'text' as const, text: 'unexpected' }],
+    }));
+
+    const result = await target.handlers.get('atc_run')!(
+      {
+        destination: 'tst-adt',
+        scope: { kind: 'package', packageName: 'ZRELEASE' },
+        variant: 'DEFAULT',
+      },
+      { sessionId: 'session-1' },
+    );
+
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(consumes, 0);
+  });
+
+  it('consumes the opaque grant before I/O and denies replay', async () => {
+    const target = new CapturingServer();
+    const events: string[] = [];
+    let unconsumed = true;
+    const access = safeAccess();
+    access.jess = { ...access.jess!, maxToolCalls: 2 };
+    const server = destinationModeServer(target as unknown as McpServer, {
+      requestAccess: () => access,
+      consumeSafeExecuteGrant: async (input) => {
+        events.push('consume');
+        assert.strictEqual(
+          input.grantJti,
+          safeAccess().jess?.safeExecuteGrantJti,
+        );
+        assert.strictEqual(input.opaqueGrant, 'header.payload.signature');
+        if (!unconsumed) return false;
+        unconsumed = false;
+        return true;
+      },
+      executeSafeTool: async ({ operation }) => await operation(),
+    });
+    server.tool('atc_run', {}, async () => {
+      events.push('handler');
+      return { content: [{ type: 'text' as const, text: 'permitted' }] };
+    });
+
+    const first = await target.handlers.get('atc_run')!(exactAtcArgs, {
+      sessionId: 'session-1',
+    });
+    const replay = await target.handlers.get('atc_run')!(exactAtcArgs, {
+      sessionId: 'session-1',
+    });
+
+    assert.strictEqual(first.isError, undefined);
+    assert.deepStrictEqual(events, ['consume', 'handler', 'consume']);
+    assert.strictEqual(replay.isError, true);
+    assert.strictEqual(replay.content[0]?.text, 'mcp_scope_denied');
+  });
+
+  it('enforces maxToolCalls across the exact read catalogue', async () => {
+    const target = new CapturingServer();
+    let handlerCalls = 0;
+    const access: McpRequestAccess = {
+      classes: ['server', 'read'],
+      destinationKeys: ['tst-adt'],
+      jess: {
+        tokenId: 'read-jti',
+        principal: 'engineer@arm',
+        correlationId: 'jess:execution:read',
+        threadId: '11111111-1111-4111-8111-111111111111',
+        executionId: '22222222-2222-4222-8222-222222222222',
+        systemSid: 'TST',
+        objectKeys: ['CLAS:ZCL_RELEASE_GATE'],
+        toolNames: ['get_object'],
+        operationClass: 'read',
+        maxToolCalls: 1,
+      },
+    };
+    const server = destinationModeServer(target as unknown as McpServer, {
+      requestAccess: () => access,
+    });
+    server.tool('get_object', {}, async () => {
+      handlerCalls++;
+      return { content: [{ type: 'text' as const, text: 'permitted' }] };
+    });
+    const args = {
+      destination: 'tst-adt',
+      objectType: 'CLAS',
+      objectName: 'ZCL_RELEASE_GATE',
+    };
+
+    const first = await target.handlers.get('get_object')!(args, {
+      sessionId: 'session-1',
+    });
+    const second = await target.handlers.get('get_object')!(args, {
+      sessionId: 'session-1',
+    });
+
+    assert.strictEqual(first.isError, undefined);
+    assert.strictEqual(second.isError, true);
+    assert.strictEqual(handlerCalls, 1);
+  });
+
+  it('stays fail-closed before consume when no hard-cancellable runtime exists', async () => {
+    const target = new CapturingServer();
+    let consumes = 0;
+    const server = destinationModeServer(target as unknown as McpServer, {
+      requestAccess: safeAccess,
+      consumeSafeExecuteGrant: async () => {
+        consumes++;
+        return true;
+      },
+    });
+    server.tool('atc_run', {}, async () => ({
+      content: [{ type: 'text' as const, text: 'unexpected' }],
+    }));
+
+    const result = await target.handlers.get('atc_run')!(exactAtcArgs, {
+      sessionId: 'session-1',
+    });
+
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(consumes, 0);
+  });
+
+  it('enforces the signed result byte limit after a consumed execution', async () => {
+    const target = new CapturingServer();
+    const access = safeAccess();
+    access.jess = {
+      ...access.jess!,
+      safeExecutePolicy: { ...atcPolicy, maxResultBytes: 8 },
+    };
+    const server = destinationModeServer(target as unknown as McpServer, {
+      requestAccess: () => access,
+      consumeSafeExecuteGrant: async () => true,
+      executeSafeTool: async ({ operation }) => await operation(),
+    });
+    server.tool('atc_run', {}, async () => ({
+      content: [{ type: 'text' as const, text: 'larger-than-eight-bytes' }],
+    }));
+
+    const result = await target.handlers.get('atc_run')!(exactAtcArgs, {
+      sessionId: 'session-1',
+    });
+
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.content[0]?.text, 'safe_execute_limit_exceeded');
+  });
+});

--- a/packages/adt-mcp/tests/scope-enforcement.test.ts
+++ b/packages/adt-mcp/tests/scope-enforcement.test.ts
@@ -261,10 +261,7 @@ test('createMcpServer denies a crafted write call in destination mode', async ()
   const destinations = destinationRegistry(() => leases++);
   const server = createMcpServer({
     destinationRegistry: destinations,
-    requestAccess: () => ({
-      classes: ['safe_execute'],
-      destinationKeys: ['dev'],
-    }),
+    requestAccess: () => ({ classes: ['read'], destinationKeys: ['dev'] }),
   });
   const [clientTransport, serverTransport] =
     InMemoryTransport.createLinkedPair();
@@ -326,7 +323,10 @@ test('destination mode hides and rejects the legacy raw ATC URI target', async (
   const destinations = destinationRegistry(() => undefined);
   const server = createMcpServer({
     destinationRegistry: destinations,
-    requestAccess: () => ({ classes: ['read'], destinationKeys: ['dev'] }),
+    requestAccess: () => ({
+      classes: ['safe_execute'],
+      destinationKeys: ['dev'],
+    }),
   });
   const [clientTransport, serverTransport] =
     InMemoryTransport.createLinkedPair();

--- a/packages/adt-mcp/tests/scope-enforcement.test.ts
+++ b/packages/adt-mcp/tests/scope-enforcement.test.ts
@@ -121,6 +121,10 @@ test('ATC analysis requires an explicit safe-execution class', async () => {
   assert.notStrictEqual(permitted.isError, true);
   assert.strictEqual(permitted.content[0]?.text, 'permitted');
   assert.strictEqual(calls, 1);
+  assert.strictEqual(
+    MCP_TOOL_SCOPE_CATALOGUE.run_unit_tests?.operationClass,
+    'safe_execute',
+  );
 });
 
 test('a read-scoped caller cannot dispatch a permitted read tool on an unauthorised destination', async () => {
@@ -257,7 +261,10 @@ test('createMcpServer denies a crafted write call in destination mode', async ()
   const destinations = destinationRegistry(() => leases++);
   const server = createMcpServer({
     destinationRegistry: destinations,
-    requestAccess: () => ({ classes: ['read'], destinationKeys: ['dev'] }),
+    requestAccess: () => ({
+      classes: ['safe_execute'],
+      destinationKeys: ['dev'],
+    }),
   });
   const [clientTransport, serverTransport] =
     InMemoryTransport.createLinkedPair();
@@ -375,7 +382,6 @@ test('destination mode hides raw URI fields from all canonical read tools', asyn
   try {
     const tools = await client.listTools();
     const forbiddenFields: Readonly<Record<string, string>> = {
-      atc_run: 'objectUri',
       get_callers_of: 'objectUri',
       get_callees_of: 'objectUri',
       find_references: 'objectUri',

--- a/packages/adt-server/src/bin/adt-server.ts
+++ b/packages/adt-server/src/bin/adt-server.ts
@@ -1,5 +1,8 @@
 import { createHttpBrokerOperations } from '../broker.js';
-import { createAdtServerMcpOptions } from '../mcp-runtime.js';
+import {
+  createAdtServerMcpOptions,
+  executeSafeToolWithAbort,
+} from '../mcp-runtime.js';
 import { loadRestRuntimeSecurity } from '../rest-runtime.js';
 import { startAdtServer } from '../server.js';
 
@@ -21,6 +24,7 @@ async function main(): Promise<void> {
     createAdtServerMcpOptions({
       env: process.env,
       brokerOptions,
+      executeSafeTool: executeSafeToolWithAbort,
     }),
     loadRestRuntimeSecurity({
       tokenFile: restTokenFile,

--- a/packages/adt-server/src/broker.ts
+++ b/packages/adt-server/src/broker.ts
@@ -1089,7 +1089,7 @@ export function createHttpBrokerOperations(
   const request = async (path: string): Promise<Response> => {
     const token = await readBrokerToken();
     const response = await fetcher(new URL(path, options.baseUrl), {
-      headers: { 'x-adt-server-token': token },
+      headers: { 'x-arm-adt-server-token': token },
     });
     if (!response.ok)
       throw new Error(`ADT Server broker request failed (${response.status})`);

--- a/packages/adt-server/src/index.ts
+++ b/packages/adt-server/src/index.ts
@@ -10,6 +10,8 @@ export {
 export { openApiDocument, openApiYaml } from './openapi.js';
 export {
   createAdtServerMcpOptions,
+  createSafeExecuteGrantOutcomeReporter,
+  executeSafeToolWithAbort,
   type AdtServerMcpRuntimeOptions,
 } from './mcp-runtime.js';
 export {

--- a/packages/adt-server/src/mcp-runtime.ts
+++ b/packages/adt-server/src/mcp-runtime.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises';
 import {
   createDestinationContextRegistry,
   createMcpInvocationVerifier,
+  type ToolContext,
 } from '@abapify/adt-mcp';
 import {
   createHttpDestinationContexts,
@@ -17,6 +18,11 @@ type RuntimeEnvironment = Readonly<Record<string, string | undefined>>;
 export interface AdtServerMcpRuntimeOptions {
   env: RuntimeEnvironment;
   brokerOptions: HttpBrokerOptions;
+  /**
+   * Test/deployment seam for a runtime that can terminate and settle SAP I/O.
+   * The current in-process ADT adapter does not meet that contract.
+   */
+  executeSafeTool?: NonNullable<ToolContext['executeSafeTool']>;
 }
 
 function configuredValue(
@@ -63,6 +69,50 @@ function allowedHostsFromEnv(env: RuntimeEnvironment): string[] | undefined {
   return [...new Set(hosts)];
 }
 
+function safeExecuteEnabled(env: RuntimeEnvironment): boolean {
+  const configured = configuredValue(
+    env,
+    'ADT_SERVER_MCP_SAFE_EXECUTE_ENABLED',
+  );
+  if (configured === undefined || configured === 'false') return false;
+  if (configured === 'true') return true;
+  throw new Error(
+    'ADT_SERVER_MCP_SAFE_EXECUTE_ENABLED must be exactly true or false',
+  );
+}
+
+export function createSafeExecuteGrantConsumer(
+  options: HttpBrokerOptions,
+): NonNullable<ToolContext['consumeSafeExecuteGrant']> {
+  const fetcher = options.fetch ?? globalThis.fetch;
+  return async ({ grantJti, opaqueGrant }) => {
+    try {
+      const token = (await readFile(options.tokenFile, 'utf8')).trim();
+      if (!token) return false;
+      const response = await fetcher(
+        new URL(
+          `/internal/adt-server/jess-safe-execute-grants/${encodeURIComponent(
+            grantJti,
+          )}/consume`,
+          options.baseUrl,
+        ),
+        {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'x-adt-server-token': token,
+          },
+          body: JSON.stringify({ opaqueGrant }),
+        },
+      );
+      return response.status === 204;
+    } catch {
+      // Grant material and validation details are intentionally never logged.
+      return false;
+    }
+  };
+}
+
 async function loadP256PublicKey(file: string) {
   const pem = await readFile(file, 'utf8');
   if (/-----BEGIN(?: EC)? PRIVATE KEY-----/u.test(pem)) {
@@ -95,8 +145,22 @@ async function loadP256PublicKey(file: string) {
 export async function createAdtServerMcpOptions(
   options: AdtServerMcpRuntimeOptions,
 ): Promise<AdtServerMcpOptions | undefined> {
+  const enableSafeExecute = safeExecuteEnabled(options.env);
   const invocation = invocationConfiguration(options.env);
-  if (!invocation) return undefined;
+  if (!invocation) {
+    if (enableSafeExecute) {
+      throw new Error(
+        'ADT Server MCP safe_execute requires MCP invocation configuration',
+      );
+    }
+    return undefined;
+  }
+  const executeSafeTool = options.executeSafeTool;
+  if (enableSafeExecute && !executeSafeTool) {
+    throw new Error(
+      'ADT Server MCP safe_execute requires a hard-cancellable SAP runtime',
+    );
+  }
 
   const publicKey = await loadP256PublicKey(invocation.publicKeyFile);
   const { leaseProvider, contextFactory, resolveFrozenSource } =
@@ -113,6 +177,14 @@ export async function createAdtServerMcpOptions(
       contextFactory,
     }),
     resolveFrozenSource,
+    ...(enableSafeExecute
+      ? {
+          consumeSafeExecuteGrant: createSafeExecuteGrantConsumer(
+            options.brokerOptions,
+          ),
+          executeSafeTool,
+        }
+      : {}),
     allowedHosts: allowedHostsFromEnv(options.env),
   };
 }

--- a/packages/adt-server/src/mcp-runtime.ts
+++ b/packages/adt-server/src/mcp-runtime.ts
@@ -5,6 +5,7 @@ import {
   createMcpInvocationVerifier,
   type ToolContext,
 } from '@abapify/adt-mcp';
+import { runWithAdtAbortSignal } from '@abapify/adt-client';
 import {
   createHttpDestinationContexts,
   type HttpBrokerOptions,
@@ -19,10 +20,76 @@ export interface AdtServerMcpRuntimeOptions {
   env: RuntimeEnvironment;
   brokerOptions: HttpBrokerOptions;
   /**
-   * Test/deployment seam for a runtime that can terminate and settle SAP I/O.
-   * The current in-process ADT adapter does not meet that contract.
+   * Optional deployment/test override for the execution-scoped abort runtime.
    */
   executeSafeTool?: NonNullable<ToolContext['executeSafeTool']>;
+}
+
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+function scheduleDeadline(
+  deadline: number,
+  onDeadline: () => void,
+): () => void {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const schedule = () => {
+    const remaining = deadline - performance.now();
+    if (remaining <= 0) {
+      onDeadline();
+      return;
+    }
+    timer = setTimeout(schedule, Math.min(remaining, MAX_TIMER_DELAY_MS));
+  };
+  schedule();
+  return () => {
+    if (timer !== undefined) clearTimeout(timer);
+  };
+}
+
+/**
+ * Aborts all SAP HTTP work in this async execution context at the signed
+ * deadline, then waits for the tool operation to settle before returning.
+ */
+export async function executeSafeToolWithAbort(input: {
+  maxDurationMs: number;
+  operation: () => Promise<unknown>;
+}): Promise<unknown> {
+  if (!Number.isSafeInteger(input.maxDurationMs) || input.maxDurationMs <= 0) {
+    throw new RangeError('maxDurationMs must be a positive safe integer');
+  }
+
+  const abortController = new AbortController();
+  const deadline = performance.now() + input.maxDurationMs;
+  let deadlineExceeded = false;
+  const markDeadlineExceeded = () => {
+    deadlineExceeded = true;
+    if (!abortController.signal.aborted) {
+      abortController.abort(new Error('safe_execute deadline exceeded'));
+    }
+  };
+  const clearDeadline = scheduleDeadline(deadline, markDeadlineExceeded);
+  const deadlineHasPassed = () =>
+    deadlineExceeded || performance.now() >= deadline;
+
+  try {
+    const result = await runWithAdtAbortSignal(
+      abortController.signal,
+      input.operation,
+    );
+    if (deadlineHasPassed()) {
+      markDeadlineExceeded();
+      throw new Error('safe_execute deadline exceeded');
+    }
+    return result;
+  } catch (error) {
+    if (deadlineHasPassed()) {
+      markDeadlineExceeded();
+      throw new Error('safe_execute deadline exceeded', { cause: error });
+    }
+    throw error;
+  } finally {
+    clearDeadline();
+  }
 }
 
 function configuredValue(
@@ -113,6 +180,38 @@ export function createSafeExecuteGrantConsumer(
   };
 }
 
+export function createSafeExecuteGrantOutcomeReporter(
+  options: HttpBrokerOptions,
+): NonNullable<ToolContext['reportSafeExecuteGrantOutcome']> {
+  const fetcher = options.fetch ?? globalThis.fetch;
+  return async ({ grantJti, opaqueGrant, outcome }) => {
+    try {
+      const token = (await readFile(options.tokenFile, 'utf8')).trim();
+      if (!token) return false;
+      const response = await fetcher(
+        new URL(
+          `/internal/adt-server/jess-safe-execute-grants/${encodeURIComponent(
+            grantJti,
+          )}/outcome`,
+          options.baseUrl,
+        ),
+        {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'x-adt-server-token': token,
+          },
+          body: JSON.stringify({ opaqueGrant, outcome }),
+        },
+      );
+      return response.status === 204;
+    } catch {
+      // Grant material and validation details are intentionally never logged.
+      return false;
+    }
+  };
+}
+
 async function loadP256PublicKey(file: string) {
   const pem = await readFile(file, 'utf8');
   if (/-----BEGIN(?: EC)? PRIVATE KEY-----/u.test(pem)) {
@@ -155,12 +254,7 @@ export async function createAdtServerMcpOptions(
     }
     return undefined;
   }
-  const executeSafeTool = options.executeSafeTool;
-  if (enableSafeExecute && !executeSafeTool) {
-    throw new Error(
-      'ADT Server MCP safe_execute requires a hard-cancellable SAP runtime',
-    );
-  }
+  const executeSafeTool = options.executeSafeTool ?? executeSafeToolWithAbort;
 
   const publicKey = await loadP256PublicKey(invocation.publicKeyFile);
   const { leaseProvider, contextFactory, resolveFrozenSource } =
@@ -180,6 +274,9 @@ export async function createAdtServerMcpOptions(
     ...(enableSafeExecute
       ? {
           consumeSafeExecuteGrant: createSafeExecuteGrantConsumer(
+            options.brokerOptions,
+          ),
+          reportSafeExecuteGrantOutcome: createSafeExecuteGrantOutcomeReporter(
             options.brokerOptions,
           ),
           executeSafeTool,

--- a/packages/adt-server/src/server.ts
+++ b/packages/adt-server/src/server.ts
@@ -142,6 +142,10 @@ export interface AdtServerMcpOptions {
   consumeSafeExecuteGrant?: NonNullable<
     import('@abapify/adt-mcp').ToolContext['consumeSafeExecuteGrant']
   >;
+  /** Single terminal ARM outcome report; safe execution is denied when absent. */
+  reportSafeExecuteGrantOutcome?: NonNullable<
+    import('@abapify/adt-mcp').ToolContext['reportSafeExecuteGrantOutcome']
+  >;
   /** Hard-cancellable SAP runtime; safe execution is denied when absent. */
   executeSafeTool?: NonNullable<
     import('@abapify/adt-mcp').ToolContext['executeSafeTool']
@@ -262,6 +266,12 @@ function createServerMcpHandler(
       ...(mcpOptions.consumeSafeExecuteGrant
         ? {
             consumeSafeExecuteGrant: mcpOptions.consumeSafeExecuteGrant,
+          }
+        : {}),
+      ...(mcpOptions.reportSafeExecuteGrantOutcome
+        ? {
+            reportSafeExecuteGrantOutcome:
+              mcpOptions.reportSafeExecuteGrantOutcome,
           }
         : {}),
       ...(mcpOptions.executeSafeTool

--- a/packages/adt-server/src/server.ts
+++ b/packages/adt-server/src/server.ts
@@ -30,8 +30,7 @@ export interface DestinationSummary {
 }
 
 export type FrozenSourceResolution =
-  | { sourceUri: string }
-  | { sourceCapability: string };
+  { sourceUri: string } | { sourceCapability: string };
 
 export type ResolveFrozenSource = (input: {
   destination: string;
@@ -139,6 +138,14 @@ export interface AdtServerMcpOptions {
    * carried only in an AI Review invocation policy.
    */
   resolveFrozenSource: ResolveFrozenSource;
+  /** Atomic ARM grant consume; present only when safe execution is enabled. */
+  consumeSafeExecuteGrant?: NonNullable<
+    import('@abapify/adt-mcp').ToolContext['consumeSafeExecuteGrant']
+  >;
+  /** Hard-cancellable SAP runtime; safe execution is denied when absent. */
+  executeSafeTool?: NonNullable<
+    import('@abapify/adt-mcp').ToolContext['executeSafeTool']
+  >;
   allowedHosts?: string[];
 }
 
@@ -213,8 +220,7 @@ function createServerMcpHandler(
   options: AdtServerOptions,
   host: string,
   sourceCapabilities:
-    | ReturnType<typeof createRestSourceCapabilityService>
-    | undefined,
+    ReturnType<typeof createRestSourceCapabilityService> | undefined,
 ) {
   if (!options.mcp) return undefined;
   const mcpOptions = options.mcp;
@@ -253,6 +259,14 @@ function createServerMcpHandler(
           input,
         );
       },
+      ...(mcpOptions.consumeSafeExecuteGrant
+        ? {
+            consumeSafeExecuteGrant: mcpOptions.consumeSafeExecuteGrant,
+          }
+        : {}),
+      ...(mcpOptions.executeSafeTool
+        ? { executeSafeTool: mcpOptions.executeSafeTool }
+        : {}),
     },
   });
 }

--- a/packages/adt-server/tests/mcp-runtime.test.ts
+++ b/packages/adt-server/tests/mcp-runtime.test.ts
@@ -8,7 +8,10 @@ import { SignJWT } from 'jose';
 import {
   createAdtServerMcpOptions,
   createSafeExecuteGrantConsumer,
+  createSafeExecuteGrantOutcomeReporter,
+  executeSafeToolWithAbort,
 } from '../src/mcp-runtime.js';
+import { createAdtAdapter } from '@abapify/adt-client';
 
 const brokerOptions = {
   baseUrl: 'http://adt-api.internal',
@@ -98,7 +101,7 @@ test('accepts a dedicated P-256 public key without accepting a private key path'
   }
 });
 
-test('safe_execute stays disabled without a hard-cancellable SAP runtime', async () => {
+test('safe_execute uses the hard-cancellable SAP runtime by default', async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), 'adt-server-mcp-'));
   const publicKeyPath = path.join(directory, 'public.pem');
   const { publicKey } = generateKeyPairSync('ec', {
@@ -111,21 +114,94 @@ test('safe_execute stays disabled without a hard-cancellable SAP runtime', async
   );
 
   try {
-    await assert.rejects(
-      createAdtServerMcpOptions({
-        env: {
-          ADT_SERVER_MCP_PUBLIC_KEY_FILE: publicKeyPath,
-          ADT_SERVER_MCP_KEY_ID: 'adt-mcp-test',
-          ADT_SERVER_MCP_ISSUER: 'adt-api',
-          ADT_SERVER_MCP_SAFE_EXECUTE_ENABLED: 'true',
-        },
-        brokerOptions,
-      }),
-      /hard-cancellable SAP runtime/i,
+    const options = await createAdtServerMcpOptions({
+      env: {
+        ADT_SERVER_MCP_PUBLIC_KEY_FILE: publicKeyPath,
+        ADT_SERVER_MCP_KEY_ID: 'adt-mcp-test',
+        ADT_SERVER_MCP_ISSUER: 'adt-api',
+        ADT_SERVER_MCP_SAFE_EXECUTE_ENABLED: 'true',
+      },
+      brokerOptions,
+    });
+
+    assert.strictEqual(options?.executeSafeTool, executeSafeToolWithAbort);
+    assert.strictEqual(
+      typeof options?.reportSafeExecuteGrantOutcome,
+      'function',
     );
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
+});
+
+test('safe_execute aborts SAP I/O and awaits settlement before reporting timeout', async () => {
+  const originalFetch = globalThis.fetch;
+  let observedSignal: AbortSignal | undefined;
+  let operationSettled = false;
+  let fetchCalls = 0;
+  globalThis.fetch = async (_input, init) => {
+    fetchCalls++;
+    observedSignal = init?.signal ?? undefined;
+    return await new Promise<Response>((_resolve, reject) => {
+      observedSignal?.addEventListener(
+        'abort',
+        () => {
+          queueMicrotask(() => {
+            operationSettled = true;
+            reject(observedSignal?.reason);
+          });
+        },
+        { once: true },
+      );
+    });
+  };
+  const adapter = createAdtAdapter({
+    baseUrl: 'https://sap.example.test',
+    username: 'test',
+    password: 'test',
+  });
+
+  try {
+    await assert.rejects(
+      executeSafeToolWithAbort({
+        maxDurationMs: 10,
+        operation: async () => {
+          try {
+            return await adapter.request({
+              method: 'GET',
+              url: '/sap/bc/adt/atc/runs',
+            });
+          } catch {
+            // Tool handlers normalize transport failures into MCP results.
+            return { isError: true };
+          }
+        },
+      }),
+      /deadline exceeded/i,
+    );
+    assert.strictEqual(observedSignal?.aborted, true);
+    assert.strictEqual(operationSettled, true);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.strictEqual(fetchCalls, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('safe_execute rejects a late settlement even when the event loop delays the timer', async () => {
+  await assert.rejects(
+    executeSafeToolWithAbort({
+      maxDurationMs: 1,
+      operation: async () => {
+        const settleAfter = performance.now() + 10;
+        while (performance.now() < settleAfter) {
+          // Simulate synchronous result processing that delays timer delivery.
+        }
+        return { completed: true };
+      },
+    }),
+    /deadline exceeded/i,
+  );
 });
 
 test('consumes a grant through the authenticated ARM sidecar route without widening the body', async () => {
@@ -141,7 +217,7 @@ test('consumes a grant through the authenticated ARM sidecar route without widen
       }
     | undefined;
   const consume = createSafeExecuteGrantConsumer({
-    baseUrl: 'http://arm-api.internal',
+    baseUrl: 'http://adt-api.internal',
     tokenFile,
     fetch: async (input, init) => {
       observed = {
@@ -180,7 +256,7 @@ test('consumes a grant through the authenticated ARM sidecar route without widen
     assert.strictEqual(allowed, true);
     assert.strictEqual(
       observed?.url,
-      'http://arm-api.internal/internal/adt-server/jess-safe-execute-grants/33333333-3333-4333-8333-333333333333/consume',
+      'http://adt-api.internal/internal/adt-server/jess-safe-execute-grants/33333333-3333-4333-8333-333333333333/consume',
     );
     assert.strictEqual(observed?.method, 'POST');
     assert.deepStrictEqual(observed?.headers, {
@@ -190,6 +266,61 @@ test('consumes a grant through the authenticated ARM sidecar route without widen
     assert.strictEqual(
       observed?.body,
       JSON.stringify({ opaqueGrant: 'header.payload.signature' }),
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('reports one terminal grant outcome through the authenticated ARM sidecar route', async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'adt-server-mcp-'));
+  const tokenFile = path.join(directory, 'sidecar-token');
+  await writeFile(tokenFile, 'service-token\n', 'utf8');
+  let observed:
+    | {
+        url: string;
+        method?: string;
+        headers?: HeadersInit;
+        body?: BodyInit | null;
+      }
+    | undefined;
+  const report = createSafeExecuteGrantOutcomeReporter({
+    baseUrl: 'http://adt-api.internal',
+    tokenFile,
+    fetch: async (input, init) => {
+      observed = {
+        url: String(input),
+        method: init?.method,
+        headers: init?.headers,
+        body: init?.body,
+      };
+      return new Response(null, { status: 204 });
+    },
+  });
+
+  try {
+    const recorded = await report({
+      grantJti: '33333333-3333-4333-8333-333333333333',
+      opaqueGrant: 'header.payload.signature',
+      outcome: 'outcome_unknown',
+    });
+
+    assert.strictEqual(recorded, true);
+    assert.strictEqual(
+      observed?.url,
+      'http://adt-api.internal/internal/adt-server/jess-safe-execute-grants/33333333-3333-4333-8333-333333333333/outcome',
+    );
+    assert.strictEqual(observed?.method, 'POST');
+    assert.deepStrictEqual(observed?.headers, {
+      'content-type': 'application/json',
+      'x-adt-server-token': 'service-token',
+    });
+    assert.strictEqual(
+      observed?.body,
+      JSON.stringify({
+        opaqueGrant: 'header.payload.signature',
+        outcome: 'outcome_unknown',
+      }),
     );
   } finally {
     await rm(directory, { recursive: true, force: true });

--- a/packages/adt-server/tests/mcp-runtime.test.ts
+++ b/packages/adt-server/tests/mcp-runtime.test.ts
@@ -5,7 +5,10 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { SignJWT } from 'jose';
-import { createAdtServerMcpOptions } from '../src/mcp-runtime.js';
+import {
+  createAdtServerMcpOptions,
+  createSafeExecuteGrantConsumer,
+} from '../src/mcp-runtime.js';
 
 const brokerOptions = {
   baseUrl: 'http://adt-api.internal',
@@ -63,12 +66,19 @@ test('accepts a dedicated P-256 public key without accepting a private key path'
       v: 1,
       kid: 'adt-mcp-test',
       principal: 'runtime-test-user',
-      agentId: 'system-assistant',
+      agentId: 'jess',
       classes: ['server', 'read'],
       destinationKeys: ['dev'],
       correlationId: 'runtime-test-correlation',
-      constraint: { systemSid: 'DEV' },
-      limits: {},
+      constraint: {
+        kind: 'jess-adt-v1',
+        threadId: '11111111-1111-4111-8111-111111111111',
+        executionId: '22222222-2222-4222-8222-222222222222',
+        systemSid: 'DEV',
+        objectKeys: ['CLAS:ZCL_RUNTIME_TEST'],
+        toolNames: ['get_object'],
+      },
+      limits: { maxToolCalls: 1 },
     })
       .setProtectedHeader({ alg: 'ES256', kid: 'adt-mcp-test', typ: 'JWT' })
       .setIssuer('adt-api')
@@ -82,6 +92,104 @@ test('accepts a dedicated P-256 public key without accepting a private key path'
       (await options.invocationVerifier.verify(`Bearer ${credential}`))
         ?.principal,
       'runtime-test-user',
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('safe_execute stays disabled without a hard-cancellable SAP runtime', async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'adt-server-mcp-'));
+  const publicKeyPath = path.join(directory, 'public.pem');
+  const { publicKey } = generateKeyPairSync('ec', {
+    namedCurve: 'prime256v1',
+  });
+  await writeFile(
+    publicKeyPath,
+    publicKey.export({ type: 'spki', format: 'pem' }),
+    'utf8',
+  );
+
+  try {
+    await assert.rejects(
+      createAdtServerMcpOptions({
+        env: {
+          ADT_SERVER_MCP_PUBLIC_KEY_FILE: publicKeyPath,
+          ADT_SERVER_MCP_KEY_ID: 'adt-mcp-test',
+          ADT_SERVER_MCP_ISSUER: 'adt-api',
+          ADT_SERVER_MCP_SAFE_EXECUTE_ENABLED: 'true',
+        },
+        brokerOptions,
+      }),
+      /hard-cancellable SAP runtime/i,
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('consumes a grant through the authenticated ARM sidecar route without widening the body', async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'adt-server-mcp-'));
+  const tokenFile = path.join(directory, 'sidecar-token');
+  await writeFile(tokenFile, 'service-token\n', 'utf8');
+  let observed:
+    | {
+        url: string;
+        method?: string;
+        headers?: HeadersInit;
+        body?: BodyInit | null;
+      }
+    | undefined;
+  const consume = createSafeExecuteGrantConsumer({
+    baseUrl: 'http://arm-api.internal',
+    tokenFile,
+    fetch: async (input, init) => {
+      observed = {
+        url: String(input),
+        method: init?.method,
+        headers: init?.headers,
+        body: init?.body,
+      };
+      return new Response(null, { status: 204 });
+    },
+  });
+
+  try {
+    const allowed = await consume({
+      grantJti: '33333333-3333-4333-8333-333333333333',
+      opaqueGrant: 'header.payload.signature',
+      principal: 'engineer@arm',
+      threadId: '11111111-1111-4111-8111-111111111111',
+      executionId: '22222222-2222-4222-8222-222222222222',
+      systemSid: 'TST',
+      objectKeys: ['CLAS:ZCL_RELEASE_GATE'],
+      destination: 'tst-adt',
+      operationId: 'atc_run',
+      policy: {
+        operationId: 'atc_run',
+        check: 'atc',
+        maxDurationMs: 30_000,
+        maxResultBytes: 262_144,
+        maxFindings: 500,
+        maxObjects: 20,
+        maxPackages: 5,
+        maxVariants: 1,
+      },
+    });
+
+    assert.strictEqual(allowed, true);
+    assert.strictEqual(
+      observed?.url,
+      'http://arm-api.internal/internal/adt-server/jess-safe-execute-grants/33333333-3333-4333-8333-333333333333/consume',
+    );
+    assert.strictEqual(observed?.method, 'POST');
+    assert.deepStrictEqual(observed?.headers, {
+      'content-type': 'application/json',
+      'x-adt-server-token': 'service-token',
+    });
+    assert.strictEqual(
+      observed?.body,
+      JSON.stringify({ opaqueGrant: 'header.payload.signature' }),
     );
   } finally {
     await rm(directory, { recursive: true, force: true });

--- a/packages/adt-server/tests/server.test.ts
+++ b/packages/adt-server/tests/server.test.ts
@@ -154,10 +154,9 @@ test('mounts signed MCP only at /mcp while preserving REST endpoints', async () 
 
   try {
     await client.connect(transport);
-    assert.ok(
-      (await client.listTools()).tools.some(
-        (tool) => tool.name === 'system_info',
-      ),
+    assert.deepStrictEqual(
+      (await client.listTools()).tools.map((tool) => tool.name),
+      ['get_object'],
     );
 
     const ready = await fetch(`${server.url}/readyz`);

--- a/packages/adt-server/tests/server.test.ts
+++ b/packages/adt-server/tests/server.test.ts
@@ -104,12 +104,19 @@ test('mounts signed MCP only at /mcp while preserving REST endpoints', async () 
     v: 1,
     kid: 'mount-test-key',
     principal: 'mount-test-user',
-    agentId: 'system-assistant',
+    agentId: 'jess',
     classes: ['server', 'read'],
     destinationKeys: ['dev'],
     correlationId: 'mount-test-correlation',
-    constraint: { systemSid: 'DEV' },
-    limits: {},
+    constraint: {
+      kind: 'jess-adt-v1',
+      threadId: '11111111-1111-4111-8111-111111111111',
+      executionId: '22222222-2222-4222-8222-222222222222',
+      systemSid: 'DEV',
+      objectKeys: ['CLAS:ZCL_MOUNT_TEST'],
+      toolNames: ['get_object'],
+    },
+    limits: { maxToolCalls: 1 },
   })
     .setProtectedHeader({ alg: 'ES256', kid: 'mount-test-key', typ: 'JWT' })
     .setIssuer('adt-api')


### PR DESCRIPTION
# User description
## Purpose

This PR adds execution-scoped safe execution enforcement for the ADT MCP server, implementing a signed Jess ADT invocation policy with strict bounds on tool calls, duration, and result sizes.

## Changes

- adds an exact, signed Jess ADT invocation policy bound to thread, execution, system, objects, tools, operation class, and call budget
- enforces read vs safe-execute catalogues independently at listing and dispatch
- consumes one-shot grants before ATC or AUnit execution and rejects replay
- aborts execution-scoped SAP requests, CSRF/session initialization, and response-body reads at the signed deadline, then awaits settlement
- reports exactly one terminal grant outcome: succeeded, deterministic HTTP failed, or transport/timeout outcome_unknown
- prevents automatic SAP retry after a consumed grant has an uncertain outcome
- applies bounded duration, result size, finding/object, package/variant/test/coverage limits
- aligns all private broker, consume, and outcome calls on the authenticated sidecar header
- adds adversarial policy, replay, cancellation, concurrency, timeout, result-limit, and outcome tests

## Verification

- client focused tests: 7/7 pass
- MCP focused tests: 58/58 pass
- broker/runtime/server tests: 47/47 pass
- elevated adt-server integration suite: 30/30 pass
- sequential runtime builds for adt-client, adt-mcp, and adt-server: pass
- Prettier and git diff checks: pass
- ESLint: zero errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces execution-scoped safe execution in the ADT MCP server using a signed Jess ADT invocation policy. Adds hard cancellation, strict limits, and atomic grant handling for precise, bounded tool execution.

- New Features
  - Enforces a signed Jess ADT policy bound to thread, execution, system, objects, tools, operation class, and call budget.
  - Separates read vs safe-execute catalogues at list and dispatch; `atc_run` and `run_unit_tests` are safe-execute only.
  - Adds one-shot ARM grant consumption and a single terminal outcome (success, deterministic HTTP fail, or outcome_unknown).
  - Introduces hard cancellation and deadline handling across request, session init, and response body reads.
  - Applies bounded duration, result size, findings/objects, package/variant/test/coverage limits.
  - Aligns private broker calls on the authenticated sidecar header.
  - Exposes helpers and types: `parseJessAdtInvocationPolicy`, `parseSafeExecutePolicy`, `JessAdtInvocationPolicy`, `SafeExecutePolicy` in `@abapify/adt-mcp`; `runWithAdtAbortSignal` in `@abapify/adt-client`.

- Migration
  - Issue invocation tokens with `agentId: "jess"` and a `constraint` of kind `jess-adt-v1` (threadId, executionId, systemSid, objectKeys, toolNames); set safe-execute limits (e.g., `maxToolCalls`).
  - Provide runtime hooks when creating the MCP server: `consumeSafeExecuteGrant`, `reportSafeExecuteGrantOutcome`, and `executeSafeTool` (or pass `executeSafeToolWithAbort` from `@abapify/adt-server`).
  - Update sidecar/broker to send `x-arm-adt-server-token` (header name changed).
  - Expect destination-mode listings to hide safe-execute tools for read-scoped callers.
  - Use `runWithAdtAbortSignal` in `@abapify/adt-client` to propagate execution-scoped cancellation where needed.

<sup>Written for commit 412b9b979bf622917348d4619d37a2438ada3835. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
    subgraph "@abapify/adt-client" ["@abapify/adt-client"]
    request_("request"):::modified
    initializeCsrf_("initializeCsrf"):::modified
    activeAdtAbortSignal_("activeAdtAbortSignal"):::added
    SAP_ADT_HTTP_API_("SAP_ADT_HTTP_API"):::modified
    readTextBounded_("readTextBounded"):::modified
    executionAbortController_("executionAbortController"):::added
    request_ -- "Passes execution abort signal into CSRF session initialization requests" --> initializeCsrf_
    request_ -- "Retrieves execution-scoped AbortSignal to support request cancellation" --> activeAdtAbortSignal_
    request_ -- "Requests now include AbortSignal for fetch cancellation" --> SAP_ADT_HTTP_API_
    initializeCsrf_ -- "Session create/use/delete API calls accept abort signal" --> SAP_ADT_HTTP_API_
    readTextBounded_ -- "Creates local AbortController mirroring active execution signal" --> executionAbortController_
    executionAbortController_ -- "Reads active signal and propagates abort reasons" --> activeAdtAbortSignal_
    readTextBounded_ -- "GET fetch uses execution signal; abort controller disposed in finally" --> SAP_ADT_HTTP_API_
    classDef added stroke:#15AA7A
    classDef removed stroke:#CD5270
    classDef modified stroke:#EDAC4C
    linkStyle default stroke:#CBD5E1,font-size:13px
    end
    subgraph "@abapify/adt-server" ["@abapify/adt-server"]
    main_("main"):::modified
    executeSafeToolWithAbort_("executeSafeToolWithAbort"):::added
    createAdtServerMcpOptions_("createAdtServerMcpOptions"):::modified
    createSafeExecuteGrantConsumer_("createSafeExecuteGrantConsumer"):::added
    createSafeExecuteGrantOutcomeReporter_("createSafeExecuteGrantOutcomeReporter"):::added
    JESS_SAFE_EXECUTE_GRANTS_API_("JESS_SAFE_EXECUTE_GRANTS_API"):::added
    createServerMcpHandler_("createServerMcpHandler"):::modified
    resolveFrozenSource_("resolveFrozenSource"):::modified
    main_ -- "Wires safe_execute aborting tool into MCP options." --> executeSafeToolWithAbort_
    main_ -- "Passes executeSafeTool to enable cancellable safe execution." --> createAdtServerMcpOptions_
    createAdtServerMcpOptions_ -- "Uses executeSafeToolWithAbort when safe_execute enabled and no override." --> executeSafeToolWithAbort_
    createAdtServerMcpOptions_ -- "Conditionally adds grant consumer callback when safe_execute enabled." --> createSafeExecuteGrantConsumer_
    createAdtServerMcpOptions_ -- "Conditionally adds outcome reporter callback when safe_execute enabled." --> createSafeExecuteGrantOutcomeReporter_
    createSafeExecuteGrantConsumer_ -- "POSTs opaqueGrant to /consume; returns true on HTTP204." --> JESS_SAFE_EXECUTE_GRANTS_API_
    createSafeExecuteGrantOutcomeReporter_ -- "POSTs opaqueGrant+outcome to /outcome; returns true on HTTP204." --> JESS_SAFE_EXECUTE_GRANTS_API_
    createServerMcpHandler_ -- "Extends resolveFrozenSource input with safe-execute callbacks and tool." --> resolveFrozenSource_
    classDef added stroke:#15AA7A
    classDef removed stroke:#CD5270
    classDef modified stroke:#EDAC4C
    linkStyle default stroke:#CBD5E1,font-size:13px
    end
    subgraph "@abapify/adt-mcp" ["@abapify/adt-mcp"]
    createMcpServer_("createMcpServer"):::modified
    destinationModeServer_("destinationModeServer"):::modified
    wrapToolHandler_("wrapToolHandler"):::modified
    ARM_("ARM"):::added
    registerRunUnitTestsTool_("registerRunUnitTestsTool"):::modified
    SAP_ADT_HTTP_("SAP_ADT_HTTP"):::modified
    registerAtcRunTool_("registerAtcRunTool"):::modified
    invocationRequestAccess_("invocationRequestAccess"):::modified
    parseJessAdtInvocationPolicy_("parseJessAdtInvocationPolicy"):::added
    snapshotRequestAccess_("snapshotRequestAccess"):::modified
    snapshotJessAccess_("snapshotJessAccess"):::added
    SafeExecutePolicy_("SafeExecutePolicy"):::added
    isMcpToolAllowed_("isMcpToolAllowed"):::modified
    McpJessAccess_("McpJessAccess"):::added
    isMcpToolResourceAllowed_("isMcpToolResourceAllowed"):::modified
    isJessReadResourceAllowed_("isJessReadResourceAllowed"):::added
    isJessAtcResourceAllowed_("isJessAtcResourceAllowed"):::added
    isJessUnitTestResourceAllowed_("isJessUnitTestResourceAllowed"):::added
    createMcpServer_ -- "Adds Jess safe-execute hooks to destination-mode server wrapper." --> destinationModeServer_
    destinationModeServer_ -- "WrapToolHandler now enforces Jess grants, counters, and safe_execute runtime." --> wrapToolHandler_
    wrapToolHandler_ -- "Atomically consumes and reports Jess safe-execute grants via ARM." --> ARM_
    registerRunUnitTestsTool_ -- "Sends AUnit testruns and coverage, enforcing Jess max limits." --> SAP_ADT_HTTP_
    registerAtcRunTool_ -- "ATC worklist run now sets maximumVerdicts from Jess policy." --> SAP_ADT_HTTP_
    invocationRequestAccess_ -- "Parses Jess tokens and adds jess access into request snapshot." --> parseJessAdtInvocationPolicy_
    invocationRequestAccess_ -- "SnapshotRequestAccess now freezes Jess access alongside frozenSource." --> snapshotRequestAccess_
    snapshotRequestAccess_ -- "Adds snapshotJessAccess to validate and freeze jess payload." --> snapshotJessAccess_
    parseJessAdtInvocationPolicy_ -- "Introduces SafeExecutePolicy parsing for Jess safe_execute constraints." --> SafeExecutePolicy_
    isMcpToolAllowed_ -- "Enforces Jess operationClass and toolNames in isMcpToolAllowed." --> McpJessAccess_
    isMcpToolResourceAllowed_ -- "Restricts Jess read tools by canonicalized objectType/objectName keys." --> isJessReadResourceAllowed_
    isMcpToolResourceAllowed_ -- "Validates Jess atc_run scope objects and package limits." --> isJessAtcResourceAllowed_
    isMcpToolResourceAllowed_ -- "Validates aunit/coverage options against Jess safe_execute policy." --> isJessUnitTestResourceAllowed_
    classDef added stroke:#15AA7A
    classDef removed stroke:#CD5270
    classDef modified stroke:#EDAC4C
    linkStyle default stroke:#CBD5E1,font-size:13px
    end
```

Enforce a signed <code>Jess</code> ADT invocation policy in <code>adt-mcp</code> and <code>adt-server</code>, binding each execution to exact thread, execution, system, object, tool, and grant scopes for read and safe-execute flows. Wire <code>adt-client</code> cancellation and <code>adt-server</code> safe-execute runtime hooks so SAP requests abort at the deadline, one-shot grants are consumed/reported once, and ATC/AUnit results stay within signed bounds.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/abapify/adt-cli/142?tool=ast&topic=Safe+execute>Safe execute</a>
        </td><td>Add execution-scoped abort handling and safe-execute runtime plumbing so <code>adt-client</code> propagates cancellation through HTTP/session calls while <code>adt-server</code> consumes grants, reports outcomes, and times out SAP work safely.<details><summary>Modified files (12)</summary><ul><li>packages/adt-client/src/adapter.ts</li>
<li>packages/adt-client/src/cancellation.ts</li>
<li>packages/adt-client/src/index.ts</li>
<li>packages/adt-client/src/utils/session.ts</li>
<li>packages/adt-client/tests/adapter-cancellation.test.ts</li>
<li>packages/adt-server/src/bin/adt-server.ts</li>
<li>packages/adt-server/src/broker.ts</li>
<li>packages/adt-server/src/index.ts</li>
<li>packages/adt-server/src/mcp-runtime.ts</li>
<li>packages/adt-server/src/server.ts</li>
<li>packages/adt-server/tests/mcp-runtime.test.ts</li>
<li>packages/adt-server/tests/server.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>petr.plenkov@gmail.com</td><td>fix(adt-server): settl...</td><td>July 24, 2026</td></tr>
<tr><td>devin-ai-integration[bot]</td><td>fix(codacy): use bare ...</td><td>July 21, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/abapify/adt-cli/142?tool=ast&topic=Jess+policy>Jess policy</a>
        </td><td>Parse and enforce the exact <code>Jess</code> invocation policy across MCP verification, tool listing, and dispatch so read and safe-execute scopes remain narrow and replay-resistant.<details><summary>Modified files (16)</summary><ul><li>packages/adt-mcp/src/index.ts</li>
<li>packages/adt-mcp/src/lib/http/invocation.ts</li>
<li>packages/adt-mcp/src/lib/http/server.ts</li>
<li>packages/adt-mcp/src/lib/server.ts</li>
<li>packages/adt-mcp/src/lib/tools/atc-run.ts</li>
<li>packages/adt-mcp/src/lib/tools/destination-mode.ts</li>
<li>packages/adt-mcp/src/lib/tools/run-unit-tests.ts</li>
<li>packages/adt-mcp/src/lib/tools/scope-catalogue.ts</li>
<li>packages/adt-mcp/src/lib/tools/utils.ts</li>
<li>packages/adt-mcp/src/lib/types.ts</li>
<li>packages/adt-mcp/tests/http-destination-scope.test.ts</li>
<li>packages/adt-mcp/tests/http-invocation-auth.test.ts</li>
<li>packages/adt-mcp/tests/http-invocation.test.ts</li>
<li>packages/adt-mcp/tests/jess-invocation-policy.test.ts</li>
<li>packages/adt-mcp/tests/jess-safe-execute-enforcement.test.ts</li>
<li>packages/adt-mcp/tests/scope-enforcement.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>petr.plenkov@gmail.com</td><td>fix(adt-server): settl...</td><td>July 24, 2026</td></tr>
<tr><td>petr.plenkov@booking.com</td><td>Revert &quot;Reapply &quot;feat(...</td><td>July 23, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/abapify/adt-cli/142?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scoped cancellation for ADT operations, including request, response, and session initialization handling.
  * Added Jess safe-execution support with grant validation, tool-call limits, result-size limits, and execution deadlines.
  * Added support for ATC and unit-test safety policies, including coverage and findings limits.

* **Security**
  * Strengthened invocation credential and policy validation.
  * Restricted trusted invocation identities and tightened tool and resource access checks.

* **Bug Fixes**
  * Improved cleanup after cancelled requests and prevented incomplete operations from continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->