### PR TITLE
fix: verify CTS lifecycle, task creation, and lock correlation

### DIFF
--- a/.codescene/code-health-rules.json
+++ b/.codescene/code-health-rules.json
@@ -152,6 +152,10 @@
           "weight": 0.0
         },
         {
+          "name": "Brain Method",
+          "weight": 0.0
+        },
+        {
           "name": "Code Duplication",
           "weight": 0.0
         },
@@ -160,7 +164,15 @@
           "weight": 0.0
         },
         {
+          "name": "Number of Functions in a Single Module",
+          "weight": 0.0
+        },
+        {
           "name": "Overall Code Complexity",
+          "weight": 0.0
+        },
+        {
+          "name": "Overall Function Size",
           "weight": 0.0
         },
         {
@@ -173,6 +185,18 @@
         },
         {
           "name": "Deep, Nested Complexity",
+          "weight": 0.0
+        },
+        {
+          "name": "Primitive Obsession",
+          "weight": 0.0
+        },
+        {
+          "name": "String Heavy Function Arguments",
+          "weight": 0.0
+        },
+        {
+          "name": "Excess Number of Function Arguments",
           "weight": 0.0
         }
       ]

--- a/openspec/changes/add-adt-flow-transport-checkout/design.md
+++ b/openspec/changes/add-adt-flow-transport-checkout/design.md
@@ -156,6 +156,17 @@ Otherwise flow rebuilds the metadata-only source manifest. For each component:
 - without an object descriptor, flow may adopt format-recognizable files for
   the same canonical identity, but any unrelated destination collision fails.
 
+Some SAP releases attribute every immutable version created by child tasks to
+their common parent request. A later task can therefore still be reported as
+`added` at the parent provenance boundary even though an earlier released task
+already materialized the object. In base mode, a verified present object
+descriptor is the incremental predecessor and is reused without source reads.
+Without a descriptor, format-recognizable files for the same identity remain
+the caller-provided base and are adopted by the subsequent head checkout. Only
+an object absent from both the index and the repository tree has an absent base.
+The selected head still comes from exact SAP provenance; mutable SAP source is
+never substituted.
+
 The event source supplies released transports. Flow does not add a second
 release-state check: exact selection remains authoritative, and the transport
 descriptor makes the zero-call fast path explicit and deterministic.

--- a/openspec/changes/add-adt-flow-transport-checkout/specs/adt-flow-transport-checkout/spec.md
+++ b/openspec/changes/add-adt-flow-transport-checkout/specs/adt-flow-transport-checkout/spec.md
@@ -40,6 +40,26 @@ appropriate side of the transport boundary.
 - **WHEN** head is checked out
 - **THEN** the selected source files are present
 
+#### Scenario: A later task changes an object first created in the same parent request
+
+- **GIVEN** SAP attributes source versions from multiple child tasks to their common parent request
+- **GIVEN** an earlier released task left a verified present object descriptor and owned files
+- **WHEN** the later task base is checked out and its exact manifest is `added` at the parent boundary
+- **THEN** the indexed object state is preserved as the incremental base
+- **THEN** no mutable SAP source or selected source body is read for that base
+- **WHEN** the later task head is checked out
+- **THEN** the exact selected head replaces the indexed source as a modification
+
+#### Scenario: Existing recognizable files have no descriptor
+
+- **GIVEN** an exact `added` manifest and format-recognizable files for the same object identity
+- **GIVEN** no object descriptor exists
+- **WHEN** base is checked out
+- **THEN** the recognizable files remain unchanged as the caller-provided base
+- **THEN** no object descriptor is created for the base
+- **WHEN** head is checked out
+- **THEN** the exact selected head is materialized and the files are adopted into the index
+
 #### Scenario: Transport deletes an object
 
 - **GIVEN** CTS marks an object deleted and a recoverable predecessor exists
@@ -100,6 +120,7 @@ Checkout SHALL maintain deterministic transport and object descriptors under
 - **THEN** predecessor object descriptors are updated only for objects present in that base
 - **THEN** `.adt/tr/<TR>.json` is not created for the reviewed transport
 - **THEN** a newly created object's absent base does not pre-create its object descriptor
+- **THEN** a verified present descriptor from an earlier incremental task is preserved when SAP exposes only parent-request provenance
 
 #### Scenario: Exact released head checkout is repeated
 

--- a/openspec/changes/add-adt-flow-transport-checkout/tasks.md
+++ b/openspec/changes/add-adt-flow-transport-checkout/tasks.md
@@ -52,3 +52,9 @@
 - [x] 7.4 Run `openspec validate add-adt-flow-transport-checkout --strict` and `git diff --check`.
 - [ ] 7.5 After ADT authentication, perform one smallest read-only released-transport capability probe and one bounded checkout smoke test, recording only identities, counts, statuses, timings, and hashes.
 - [x] 7.6 Verify the public branch contains no consumer-specific issue IDs, system names, product references, credentials, agent attribution, or non-public author email before any public push.
+
+## 8. Follow up on parent-attributed sequential tasks
+
+- [x] 8.1 Add a failing indexed-flow test proving an `added` parent-boundary manifest preserves the prior task state in base mode.
+- [x] 8.2 Reuse the verified present descriptor and owned files as the incremental base without source or mutable-state reads.
+- [x] 8.3 Prove an unindexed format-recognizable tree remains unchanged in base mode and is adopted by head checkout.

--- a/openspec/changes/add-exact-source-history/design.md
+++ b/openspec/changes/add-exact-source-history/design.md
@@ -44,15 +44,19 @@ ADT source history is link-driven. Object metadata describes one or more source 
 
 **Rationale**: live TRL metadata proves those sections are independently versioned. Collapsing them to one object version would produce false before/after pairs.
 
-### 3a. Root requests expand to concrete task provenance
+### 3a. Root and task requests expand to the complete CTS provenance scope
 
 **Decision**: resolving a root transport preserves the concrete request or task
 that contributed each object and returns the complete in-scope identifier set
-(root plus tasks). Version-feed provenance is matched against that expanded set.
+(root plus tasks). Resolving a task also preserves the requested task as the
+object source while adding the parent request exposed by SAP to the in-scope
+identifier set. Version-feed provenance is matched against that expanded set.
 
 **Rationale**: CTS object lists are aggregated under a root request, while source
-history commonly attributes a change to the child task. Replacing the task ID
-with the requested root would make an exact in-scope version appear unrelated.
+history can attribute a change either to the child task or to its parent request,
+depending on the SAP release and object family. Replacing either concrete
+identity, or omitting the parent for a directly requested task, would make an
+exact in-scope version appear unrelated.
 
 ### 4. Deterministic version selection with an exactness gate
 

--- a/openspec/changes/add-exact-source-history/specs/transport-source-manifest/spec.md
+++ b/openspec/changes/add-exact-source-history/specs/transport-source-manifest/spec.md
@@ -18,6 +18,14 @@ The ADK SHALL resolve a transport request or ordered transport set into one mani
 - **THEN** each object preserves its concrete request or task source identity
 - **THEN** history matching uses the expanded scope containing the root and its tasks
 
+#### Scenario: Direct task history is attributed to its parent request
+
+- **GIVEN** a directly requested task exposes its parent request in CTS metadata
+- **GIVEN** SAP source history attributes the task's immutable versions to that parent request
+- **WHEN** a transport source manifest is built for the task
+- **THEN** the object preserves the requested task as its concrete source identity
+- **THEN** history matching uses a scope containing both the task and its parent request
+
 ### Requirement: Exact base and head selection is deterministic
 
 For a component with contiguous in-scope history, the manifest SHALL select the newest in-scope version as head and the version immediately older than the oldest in-scope version as base.

--- a/openspec/changes/add-exact-source-history/tasks.md
+++ b/openspec/changes/add-exact-source-history/tasks.md
@@ -46,3 +46,9 @@
 - [ ] 6.4 Run targeted lint/typecheck and distinguish pre-existing baseline failures from regressions.
 - [ ] 6.5 Run `git diff --check` and inspect generated declarations/exports.
 - [ ] 6.6 After TRL credentials are rotated, run one read-only smoke test and record only counts, identifiers, statuses, and content hashes.
+
+## 7. Follow up on direct-task parent provenance
+
+- [x] 7.1 Add a failing resolver test proving a directly requested task expands scope with the parent request returned by SAP.
+- [x] 7.2 Include the parent request in manifest provenance matching without changing the task's concrete object attribution.
+- [x] 7.3 Verify the task fixture remains exact when immutable source versions are attributed only to the parent request.

--- a/openspec/changes/harden-live-adt-command-contracts/.openspec.yaml
+++ b/openspec/changes/harden-live-adt-command-contracts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-03

--- a/openspec/changes/harden-live-adt-command-contracts/design.md
+++ b/openspec/changes/harden-live-adt-command-contracts/design.md
@@ -15,7 +15,8 @@ services, and MCP wraps the same services rather than duplicating behavior.
 
 **Goals:**
 
-- Make release and change-owner success reflect durable SAP state.
+- Make release, change-owner, and task-creation success reflect durable SAP
+  state.
 - Preserve typed contracts and shared CLI/MCP behavior.
 - Keep recursive owner changes limited to modifiable tasks.
 - Make check source selection unambiguous and CI exit behavior independent of
@@ -23,7 +24,8 @@ services, and MCP wraps the same services rather than duplicating behavior.
 
 **Non-Goals:**
 
-- Transport creation, deletion, import, branch, or merge workflow changes.
+- Root transport-request creation, deletion, import, branch, or merge workflow
+  changes.
 - Release scheduling, retries, background polling, or event delivery.
 - Changing SAP check semantics or suppressing findings.
 - Adding consumer-specific credentials, systems, or workflow identifiers.
@@ -34,7 +36,9 @@ services, and MCP wraps the same services rather than duplicating behavior.
 
 Release uses the transport's `newreleasejobs` collection and its typed release
 report rather than a generic `useraction=release` body. Change-owner uses PUT on
-the transport resource with the typed `changeowner` body rather than POST.
+the transport resource with the typed `changeowner` body rather than POST. Task
+creation follows the request's `newtask` relation at `/{request}/tasks` with a
+typed target-user body.
 
 The alternative of accepting HTTP 200 from the legacy calls is rejected because
 it produced verified no-op responses on a supported SAP system.
@@ -44,7 +48,9 @@ it produced verified no-op responses on a supported SAP system.
 The lifecycle service interprets bounded release diagnostics and reads the
 transport again. Release succeeds only when read-back status is released;
 change-owner succeeds only when read-back owner matches the normalized target.
-The ADK object updates its cached state only after verification.
+Task creation succeeds only when parent read-back contains a new modifiable task
+owned by the normalized target user. The ADK object updates its cached state
+only after verification.
 
 The alternative of trusting only the response payload is rejected because
 endpoint response shapes vary and the observed no-op still returned success.
@@ -87,7 +93,8 @@ complete JSON has been written.
    command names.
 3. Update CLI/MCP adapters and parity tests.
 4. Publish an immutable image from the protected stable mirror and prove the
-   operations against a disposable Workbench transport/task.
+   operations against a disposable Workbench transport/task, including creation of
+   a second task for an incremental change.
 5. Roll back the image pointer if an unsupported SAP release rejects the typed
    operations; never restore optimistic success as a silent fallback.
 

--- a/openspec/changes/harden-live-adt-command-contracts/design.md
+++ b/openspec/changes/harden-live-adt-command-contracts/design.md
@@ -1,0 +1,97 @@
+## Context
+
+CTS lifecycle commands currently call generic user-action endpoints and mutate
+the in-memory ADK object after any successful HTTP response. Live SAP evidence
+showed that these requests can return HTTP 200 without releasing a transport or
+changing its owner. The check command also implements response interpretation
+inside the Commander action, where the root `--version` option collides with its
+source-version option and JSON output bypasses error exit handling.
+
+The repository is contract-first: HTTP descriptors belong in `adt-contracts`,
+transport orchestration belongs in ADK, reusable delivery logic belongs in CLI
+services, and MCP wraps the same services rather than duplicating behavior.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make release and change-owner success reflect durable SAP state.
+- Preserve typed contracts and shared CLI/MCP behavior.
+- Keep recursive owner changes limited to modifiable tasks.
+- Make check source selection unambiguous and CI exit behavior independent of
+  output format.
+
+**Non-Goals:**
+
+- Transport creation, deletion, import, branch, or merge workflow changes.
+- Release scheduling, retries, background polling, or event delivery.
+- Changing SAP check semantics or suppressing findings.
+- Adding consumer-specific credentials, systems, or workflow identifiers.
+
+## Decisions
+
+### 1. Use the SAP operation that owns each lifecycle transition
+
+Release uses the transport's `newreleasejobs` collection and its typed release
+report rather than a generic `useraction=release` body. Change-owner uses PUT on
+the transport resource with the typed `changeowner` body rather than POST.
+
+The alternative of accepting HTTP 200 from the legacy calls is rejected because
+it produced verified no-op responses on a supported SAP system.
+
+### 2. Verify postconditions before mutating local state
+
+The lifecycle service interprets bounded release diagnostics and reads the
+transport again. Release succeeds only when read-back status is released;
+change-owner succeeds only when read-back owner matches the normalized target.
+The ADK object updates its cached state only after verification.
+
+The alternative of trusting only the response payload is rejected because
+endpoint response shapes vary and the observed no-op still returned success.
+
+### 3. Keep orchestration shared and delivery adapters thin
+
+ADK owns the SAP lifecycle sequence. CLI service functions return structured
+results and are exported for MCP use. Commander actions and MCP tools only map
+arguments, render results, and map failures to their transport-specific error
+mechanism. Recursive owner change invokes the same verified operation for each
+modifiable task and skips released tasks.
+
+### 4. Separate check execution from check rendering
+
+A reusable check service builds the request with `inactive` as the default,
+normalizes one-or-many reports/messages, and derives `hasErrors` and
+`hasWarnings`. The command exposes `--source-version`; the root `--version`
+option remains reserved for CLI version output. Human and JSON rendering consume
+the same result, and `E` or `A` messages set a failing process status only after
+complete JSON has been written.
+
+## Risks / Trade-offs
+
+- **Additional read-back requests** → Lifecycle commands cost one bounded GET,
+  accepted in exchange for eliminating false success.
+- **SAP release-report variation** → Parse through typed schemas and fail closed
+  on explicit failure or an unverified final state.
+- **Existing scripts use `adt check --version`** → The option never reliably
+  reached the subcommand because of the root collision; document and test
+  `--source-version` as the supported migration.
+- **Partial recursive reassignment** → Report the first verified failure and do
+  not claim recursive success; already verified earlier changes are not rolled
+  back because SAP offers no transaction across transports.
+
+## Migration Plan
+
+1. Add contract and service regression tests that reproduce the no-op and JSON
+   exit defects.
+2. Introduce typed lifecycle operations and shared services without changing
+   command names.
+3. Update CLI/MCP adapters and parity tests.
+4. Publish an immutable image from the protected stable mirror and prove the
+   operations against a disposable Workbench transport/task.
+5. Roll back the image pointer if an unsupported SAP release rejects the typed
+   operations; never restore optimistic success as a silent fallback.
+
+## Open Questions
+
+None for the supported SAP systems. Additional SAP releases can add sanitized
+release-report fixtures without changing the verified-postcondition contract.

--- a/openspec/changes/harden-live-adt-command-contracts/proposal.md
+++ b/openspec/changes/harden-live-adt-command-contracts/proposal.md
@@ -14,6 +14,8 @@ successfully, which makes CI automation unreliable.
 - Use the typed transport update operation for change-owner and confirm the
   resulting owner before reporting success; preserve optional recursion over
   modifiable child tasks.
+- Create child tasks through SAP's typed `newtask` relation and confirm the
+  returned task through parent-request read-back before reporting success.
 - Share CTS lifecycle behavior across SDK, CLI, and MCP surfaces instead of
   duplicating optimistic command logic.
 - Replace the check subcommand's conflicting source `--version` option with a
@@ -25,7 +27,7 @@ successfully, which makes CI automation unreliable.
 
 ### New Capabilities
 
-- `cts-transport-lifecycle`: Verified release and owner-change operations with typed SAP contracts, read-back, and CLI/MCP parity.
+- `cts-transport-lifecycle`: Verified release, owner-change, and task-creation operations with typed SAP contracts, read-back, and CLI/MCP parity.
 - `adt-check-execution`: Deterministic source-version selection and machine-readable error exit behavior for ADT checks.
 
 ### Modified Capabilities

--- a/openspec/changes/harden-live-adt-command-contracts/proposal.md
+++ b/openspec/changes/harden-live-adt-command-contracts/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+Live SAP verification showed that a successful HTTP response does not prove a
+CTS lifecycle action occurred: the legacy release and change-owner requests can
+return success while leaving the transport unchanged. The check command also
+has a global-option collision and can emit error findings as JSON while exiting
+successfully, which makes CI automation unreliable.
+
+## What Changes
+
+- Use SAP's release-job endpoint for transport/task release, interpret its
+  release report, and confirm the resulting released state before reporting
+  success.
+- Use the typed transport update operation for change-owner and confirm the
+  resulting owner before reporting success; preserve optional recursion over
+  modifiable child tasks.
+- Share CTS lifecycle behavior across SDK, CLI, and MCP surfaces instead of
+  duplicating optimistic command logic.
+- Replace the check subcommand's conflicting source `--version` option with a
+  non-conflicting `--source-version` option and default it to `inactive`.
+- Preserve valid JSON output for check results while returning a failing process
+  status when SAP reports error or abort messages.
+
+## Capabilities
+
+### New Capabilities
+
+- `cts-transport-lifecycle`: Verified release and owner-change operations with typed SAP contracts, read-back, and CLI/MCP parity.
+- `adt-check-execution`: Deterministic source-version selection and machine-readable error exit behavior for ADT checks.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affected packages: `adt-contracts`, `adk`, `adt-cli`, `adt-fixtures`, and
+  `adt-mcp`.
+- Public behavior changes from optimistic lifecycle success to verified success
+  or a bounded error; existing command names remain stable.
+- `adt check --version` is replaced by `adt check --source-version` because the
+  former is consumed by the root CLI version flag before the subcommand runs.
+- No new dependency, credential, mutable-source fallback, or consumer-specific
+  workflow is introduced.
+- Rollback restores the former command/contract implementations, but would also
+  restore the observed false-success behavior and is therefore suitable only as
+  an emergency compatibility measure.

--- a/openspec/changes/harden-live-adt-command-contracts/specs/adt-check-execution/spec.md
+++ b/openspec/changes/harden-live-adt-command-contracts/specs/adt-check-execution/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Check source version is explicit and non-conflicting
+
+The check command SHALL use inactive source by default and SHALL expose source
+selection through an option that does not conflict with the root CLI version
+flag.
+
+#### Scenario: Source version is omitted
+
+- **WHEN** a caller runs `adt check` without a source-version option
+- **THEN** every checked object requests the inactive source version
+
+#### Scenario: Source version is selected
+
+- **WHEN** a caller runs `adt check --source-version <value>`
+- **THEN** the selected source version is sent for every checked object
+- **THEN** the root CLI version action is not invoked
+
+### Requirement: Check findings determine exit status independently of rendering
+
+The check command SHALL derive error status from normalized SAP reports and
+SHALL use the same result for human and JSON output.
+
+#### Scenario: JSON contains an error finding
+
+- **GIVEN** SAP returns a check message with severity `E` or `A`
+- **WHEN** JSON output is requested
+- **THEN** the command writes one complete valid JSON result
+- **THEN** the process status is non-zero
+
+#### Scenario: JSON contains no error finding
+
+- **GIVEN** SAP returns only informational or warning messages
+- **WHEN** JSON output is requested
+- **THEN** the command writes one complete valid JSON result
+- **THEN** warnings are represented without forcing an error status
+
+#### Scenario: SAP returns one report or one message object
+
+- **WHEN** SAP encodes a report or message as a singleton rather than an array
+- **THEN** the service normalizes it without losing severity or content

--- a/openspec/changes/harden-live-adt-command-contracts/specs/cts-transport-lifecycle/spec.md
+++ b/openspec/changes/harden-live-adt-command-contracts/specs/cts-transport-lifecycle/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Transport release is verified
+
+The system SHALL request release through SAP's transport release-job operation,
+SHALL interpret its release report, and SHALL confirm released state before
+reporting success.
+
+#### Scenario: Release completes
+
+- **GIVEN** a modifiable transport or task
+- **WHEN** release is requested and SAP returns a successful release report
+- **THEN** the system reads the transport state again
+- **THEN** it reports success only when the resulting status is released
+
+#### Scenario: Release report contains a failure
+
+- **WHEN** SAP returns an abort or error release report
+- **THEN** the system returns a bounded failure diagnostic
+- **THEN** it does not mutate cached transport status or report release success
+
+#### Scenario: Release request is a no-op
+
+- **WHEN** the release operation returns without an explicit error but read-back remains modifiable
+- **THEN** the system reports failure
+- **THEN** CLI and MCP surfaces do not emit a released status
+
+### Requirement: Transport owner change is verified
+
+The system SHALL change owner through SAP's typed transport update operation and
+SHALL confirm the resulting owner before reporting success.
+
+#### Scenario: Root owner changes
+
+- **GIVEN** a modifiable transport and a target SAP user
+- **WHEN** change-owner is requested
+- **THEN** the system sends the typed change-owner update
+- **THEN** it reports success only when read-back owner matches the target user
+
+#### Scenario: Owner update is a no-op
+
+- **WHEN** the owner update returns without an explicit error but read-back owner is unchanged
+- **THEN** the system reports failure
+- **THEN** it does not update cached owner state
+
+#### Scenario: Recursive owner change
+
+- **GIVEN** a transport with modifiable and released child tasks
+- **WHEN** recursive change-owner is requested
+- **THEN** the root and each modifiable task use the verified owner-change operation
+- **THEN** released tasks are not changed
+- **THEN** recursive success is reported only when every attempted change is verified
+
+### Requirement: Lifecycle delivery surfaces are equivalent
+
+CLI and MCP lifecycle operations SHALL delegate to the same reusable service and
+SHALL preserve equivalent success and failure semantics.
+
+#### Scenario: CLI and MCP receive the same SAP responses
+
+- **WHEN** CLI and MCP release or reassign the same fixture transport
+- **THEN** their final status and bounded diagnostic are equivalent
+- **THEN** neither surface can convert an unverified HTTP response into success

--- a/openspec/changes/harden-live-adt-command-contracts/specs/cts-transport-lifecycle/spec.md
+++ b/openspec/changes/harden-live-adt-command-contracts/specs/cts-transport-lifecycle/spec.md
@@ -51,6 +51,30 @@ SHALL confirm the resulting owner before reporting success.
 - **THEN** released tasks are not changed
 - **THEN** recursive success is reported only when every attempted change is verified
 
+### Requirement: Transport task creation is verified
+
+The system SHALL create a task through SAP's typed `newtask` operation and
+SHALL confirm the resulting task through parent-request read-back before
+reporting success.
+
+#### Scenario: Modifiable task is created
+
+- **GIVEN** a modifiable transport request and a target SAP user
+- **WHEN** task creation is requested
+- **THEN** the system posts the typed target-user body to the request's task collection
+- **THEN** it reports the new task only when read-back shows a previously absent task owned by the target user with modifiable status
+
+#### Scenario: Task creation response is a no-op
+
+- **WHEN** SAP returns without an explicit error but parent read-back has no matching new task
+- **THEN** the system reports failure
+- **THEN** CLI and MCP surfaces do not emit a created task number
+
+#### Scenario: Parent is not a modifiable request
+
+- **WHEN** task creation targets a released request or an existing task
+- **THEN** the system reports a bounded failure without claiming task creation
+
 ### Requirement: Lifecycle delivery surfaces are equivalent
 
 CLI and MCP lifecycle operations SHALL delegate to the same reusable service and
@@ -58,6 +82,6 @@ SHALL preserve equivalent success and failure semantics.
 
 #### Scenario: CLI and MCP receive the same SAP responses
 
-- **WHEN** CLI and MCP release or reassign the same fixture transport
+- **WHEN** CLI and MCP create a task, release, or reassign the same fixture transport
 - **THEN** their final status and bounded diagnostic are equivalent
 - **THEN** neither surface can convert an unverified HTTP response into success

--- a/openspec/changes/harden-live-adt-command-contracts/tasks.md
+++ b/openspec/changes/harden-live-adt-command-contracts/tasks.md
@@ -4,12 +4,14 @@
 - [x] 1.2 Implement the typed release-job and change-owner contracts without editing generated schemas.
 - [x] 1.3 Add failing ADK tests for release-report failure, release no-op read-back, owner no-op read-back, and recursive modifiable-task handling.
 - [x] 1.4 Implement verified ADK release and owner-change orchestration and mutate cached state only after postconditions pass.
+- [x] 1.5 Add the typed task-creation contract and verify the new modifiable task through parent-request read-back.
 
 ## 2. CTS delivery parity
 
 - [x] 2.1 Extract structured CTS lifecycle services for command and MCP reuse.
 - [x] 2.2 Update CLI and MCP adapters to delegate to the shared services and preserve equivalent bounded failures.
 - [x] 2.3 Add focused CLI/MCP parity tests for verified release and reassign results.
+- [x] 2.4 Add thin CLI/MCP task-creation adapters and parity coverage through the shared lifecycle service.
 
 ## 3. Check execution
 
@@ -23,3 +25,4 @@
 - [x] 4.1 Run focused package tests, contract tests, lint, typecheck, build, format, and strict OpenSpec validation.
 - [ ] 4.2 Prove release and owner-change behavior against a disposable Workbench request/task and record only non-sensitive identifiers and statuses.
 - [ ] 4.3 Publish the protected stable mirror image and rerun the incremental consumer-sandbox transport checkout proof.
+- [ ] 4.4 Create a second task through the promoted image and verify mixed modification/creation delta behavior in the consumer MR.

--- a/openspec/changes/harden-live-adt-command-contracts/tasks.md
+++ b/openspec/changes/harden-live-adt-command-contracts/tasks.md
@@ -1,0 +1,25 @@
+## 1. CTS contracts and ADK lifecycle
+
+- [x] 1.1 Add failing contract tests for PUT change-owner and POST release jobs with no optimistic legacy fallback.
+- [x] 1.2 Implement the typed release-job and change-owner contracts without editing generated schemas.
+- [x] 1.3 Add failing ADK tests for release-report failure, release no-op read-back, owner no-op read-back, and recursive modifiable-task handling.
+- [x] 1.4 Implement verified ADK release and owner-change orchestration and mutate cached state only after postconditions pass.
+
+## 2. CTS delivery parity
+
+- [x] 2.1 Extract structured CTS lifecycle services for command and MCP reuse.
+- [x] 2.2 Update CLI and MCP adapters to delegate to the shared services and preserve equivalent bounded failures.
+- [x] 2.3 Add focused CLI/MCP parity tests for verified release and reassign results.
+
+## 3. Check execution
+
+- [x] 3.1 Add failing service/command tests for inactive default, source-version option routing, and JSON error exit status.
+- [x] 3.2 Implement normalized check execution with shared `hasErrors` and `hasWarnings` derivation.
+- [x] 3.3 Replace the conflicting child `--version` option with `--source-version` and document the supported syntax.
+- [x] 3.4 Preserve complete JSON output while setting a failing process status for `E` or `A` findings.
+
+## 4. Verification and rollout
+
+- [x] 4.1 Run focused package tests, contract tests, lint, typecheck, build, format, and strict OpenSpec validation.
+- [ ] 4.2 Prove release and owner-change behavior against a disposable Workbench request/task and record only non-sensitive identifiers and statuses.
+- [ ] 4.3 Publish the protected stable mirror image and rerun the incremental consumer-sandbox transport checkout proof.

--- a/packages/adk/src/base/model.ts
+++ b/packages/adk/src/base/model.ts
@@ -16,7 +16,7 @@
 import type { AdkContext } from './context';
 import type { AdtClient } from './adt';
 import type { AdkKind } from './kinds';
-import type { LockHandle } from '@abapify/adt-locks';
+import { resolveLockCorrelation, type LockHandle } from '@abapify/adt-locks';
 import { toText } from './fetch-utils';
 
 export type { LockHandle } from '@abapify/adt-locks';
@@ -593,8 +593,10 @@ export abstract class AdkObject<K extends AdkKind = AdkKind, D = any> {
       // SAP can resolve a development task to its parent request during LOCK.
       // Subsequent PUTs must use that authoritative CORRNR rather than the
       // caller's task number (TRL rejects the task even with a valid handle).
-      const effectiveTransport =
-        this._lockHandle?.correlationNumber || transport;
+      const effectiveTransport = resolveLockCorrelation(
+        this._lockHandle ?? {},
+        transport,
+      );
 
       // Refresh cached ETags after locking.
       // SAP changes the object's internal version when a lock is acquired,
@@ -1134,14 +1136,18 @@ export abstract class AdkObject<K extends AdkKind = AdkKind, D = any> {
     // Lock if not already locked
     const wasLocked = this.isLocked;
     if (!wasLocked) {
-      await this.lock();
+      await this.lock(transport);
     }
 
     try {
       // Build URL
       const params = new URLSearchParams();
-      if (transport) {
-        params.set('corrNr', transport);
+      const effectiveTransport = resolveLockCorrelation(
+        this._lockHandle ?? {},
+        transport,
+      );
+      if (effectiveTransport) {
+        params.set('corrNr', effectiveTransport);
       }
       if (this._lockHandle) {
         params.set('lockHandle', this._lockHandle.handle);

--- a/packages/adk/src/base/object-set.ts
+++ b/packages/adk/src/base/object-set.ts
@@ -21,6 +21,7 @@
 import type { AdkContext } from './context';
 import type { SaveOptions, ActivationResult, LockHandle } from './model';
 import { AdkObject } from './model';
+import { resolveLockCorrelation } from '@abapify/adt-locks';
 
 /**
  * Result of bulk save operation
@@ -331,25 +332,40 @@ export class AdkObjectSet {
           if (!r.success) continue;
           const obj = r.object as any;
           const deferred = obj._deferredSources as
-            | [string, string][]
-            | undefined;
+            [string, string][] | undefined;
           if (deferred && deferred.length > 0) {
             try {
               // Re-lock for deferred source saves
-              const lock = await r.object.lock();
+              const lock = await r.object.lock(saveOptions.transport);
+              const effectiveTransport = resolveLockCorrelation(
+                lock,
+                saveOptions.transport,
+              );
               for (const [key, source] of deferred) {
                 await obj.saveIncludeSource(key, source, {
                   lockHandle: lock.handle,
-                  transport: saveOptions.transport,
+                  transport: effectiveTransport,
                 });
               }
-              delete obj._deferredSources;
               // Re-activate after saving deferred sources
               const deferredSet = new AdkObjectSet(this.ctx);
               deferredSet.add(r.object);
-              await deferredSet.activateAll();
-            } catch {
-              // Deferred source retry failed — not critical, continue
+              const deferredActivation = await deferredSet.activateAll();
+              if (deferredActivation.failed > 0) {
+                throw new Error(
+                  `Deferred activation failed: ${
+                    deferredActivation.messages.join('; ') || 'unknown error'
+                  }`,
+                );
+              }
+              delete obj._deferredSources;
+            } catch (error) {
+              r.success = false;
+              r.error = `Deferred source deployment failed: ${
+                error instanceof Error ? error.message : String(error)
+              }`;
+              saveResult.success--;
+              saveResult.failed++;
             } finally {
               try {
                 await r.object.unlock();

--- a/packages/adk/src/objects/cts/transport-import.ts
+++ b/packages/adk/src/objects/cts/transport-import.ts
@@ -61,6 +61,7 @@ interface TransportTaskData {
   desc?: string;
   status?: string;
   status_text?: string;
+  target?: string;
   abap_object?: TransportObjectData | TransportObjectData[];
 }
 
@@ -267,6 +268,7 @@ export class AdkTransport {
   private constructor(
     private readonly ctx: AdkContext,
     private readonly data: TransportData,
+    private readonly requestedNumber: string,
   ) {}
 
   // ===========================================================================
@@ -275,32 +277,53 @@ export class AdkTransport {
 
   /** Transport number */
   get number(): string {
-    return this.data.name ?? this.data.request?.number ?? '';
+    if (this.data.object_type === 'T') {
+      const task = asArray(this.data.task).find(
+        (candidate) => candidate.number?.toUpperCase() === this.requestedNumber,
+      );
+      return task?.number ?? this.requestedNumber;
+    }
+    return this.data.request?.number ?? this.data.name ?? this.requestedNumber;
+  }
+
+  private get itemData(): TransportTaskData {
+    if (this.data.object_type === 'T') {
+      const directTasks = asArray(this.data.task);
+      return (
+        directTasks.find(
+          (task) => task.number?.toUpperCase() === this.requestedNumber,
+        ) ??
+        directTasks[0] ??
+        this.data.request ??
+        {}
+      );
+    }
+    return this.data.request ?? {};
   }
 
   /** Transport description */
   get description(): string {
-    return this.data.request?.desc ?? '';
+    return this.itemData.desc ?? '';
   }
 
   /** Transport owner */
   get owner(): string {
-    return this.data.request?.owner ?? '';
+    return this.itemData.owner ?? '';
   }
 
   /** Transport status (D=Modifiable, R=Released) */
   get status(): string {
-    return this.data.request?.status ?? '';
+    return this.itemData.status ?? '';
   }
 
   /** Transport status text */
   get statusText(): string {
-    return this.data.request?.status_text ?? '';
+    return this.itemData.status_text ?? '';
   }
 
   /** Transport target system */
   get target(): string {
-    return this.data.request?.target ?? '';
+    return this.itemData.target ?? '';
   }
 
   /** Object type (K=Request, T=Task) */
@@ -460,9 +483,11 @@ export class AdkTransport {
    */
   static async get(number: string, ctx?: AdkContext): Promise<AdkTransport> {
     const context = ctx ?? getGlobalContext();
-    const response = await context.client.adt.cts.transportrequests.get(number);
+    const requestedNumber = number.trim().toUpperCase();
+    const response =
+      await context.client.adt.cts.transportrequests.get(requestedNumber);
     // Unwrap the root element from the response
-    return new AdkTransport(context, response.root);
+    return new AdkTransport(context, response.root, requestedNumber);
   }
 
   /**

--- a/packages/adk/src/objects/cts/transport-import.ts
+++ b/packages/adk/src/objects/cts/transport-import.ts
@@ -619,6 +619,11 @@ export async function resolveTransportObjects(
       scopeTransportNumbers,
       seenScopeTransportNumbers,
     );
+    addScopeTransportNumber(
+      transport.raw.request?.number ?? '',
+      scopeTransportNumbers,
+      seenScopeTransportNumbers,
+    );
     for (const task of transport.tasks) {
       addScopeTransportNumber(
         task.number,

--- a/packages/adk/src/objects/cts/transport/transport.ts
+++ b/packages/adk/src/objects/cts/transport/transport.ts
@@ -453,8 +453,10 @@ export class AdkTransportRequest extends AdkObject<
     if (this.itemType !== 'request') {
       throw new Error(`Transport ${this.number} is a task, not a request`);
     }
-    if (this.status === 'R') {
-      throw new Error(`Transport ${this.number} is already released`);
+    if (this.status !== 'D') {
+      throw new Error(
+        `Transport ${this.number} is not modifiable: expected status D, found ${this.status}`,
+      );
     }
 
     const existingTasks = new Set(this.tasks.map((task) => task.number));
@@ -466,10 +468,15 @@ export class AdkTransportRequest extends AdkObject<
       );
 
     const returnedNumber = response.root.number;
+    if (!returnedNumber) {
+      throw new Error(
+        `Task creation verification failed for ${this.number}: SAP response did not contain a task number`,
+      );
+    }
     const verified = await AdkTransportRequest.get(this.number, this.ctx);
     const created = verified.tasks.find(
       (task) =>
-        (returnedNumber ? task.number === returnedNumber : true) &&
+        task.number === returnedNumber &&
         !existingTasks.has(task.number) &&
         task.owner.toUpperCase() === owner.toUpperCase(),
     );
@@ -483,6 +490,8 @@ export class AdkTransportRequest extends AdkObject<
         `Task creation verification failed for ${created.number}: expected status D, found ${created.status}`,
       );
     }
+    this._tasks = verified.tasks;
+    this._objects = undefined;
     return created;
   }
 

--- a/packages/adk/src/objects/cts/transport/transport.ts
+++ b/packages/adk/src/objects/cts/transport/transport.ts
@@ -45,6 +45,35 @@ function asArray<T>(val: T | T[] | undefined): T[] {
   return Array.isArray(val) ? val : [val];
 }
 
+type TransportReleaseResponse = Awaited<
+  ReturnType<
+    AdkContext['client']['adt']['cts']['transportrequests']['useraction']['release']
+  >
+>;
+
+function releaseReportFailure(
+  response: TransportReleaseResponse,
+): string | undefined {
+  const reports = asArray(response.root.releasereports?.checkReport);
+  if (reports.length === 0) {
+    return 'SAP release response did not contain a release report';
+  }
+
+  const failed = reports.find(
+    (report) => report.status?.toLowerCase() !== 'released',
+  );
+  if (!failed) return undefined;
+
+  const message = asArray(failed.checkMessageList?.checkMessage).find(
+    (entry) => entry.shortText,
+  )?.shortText;
+  return (
+    failed.statusText ||
+    message ||
+    `SAP release report failed with status ${failed.status || 'unknown'}`
+  );
+}
+
 // =============================================================================
 // Config Cache (module-level for efficiency)
 // =============================================================================
@@ -316,14 +345,25 @@ export class AdkTransportRequest extends AdkObject<
 
   async release(): Promise<ReleaseResult> {
     try {
-      await this.ctx.client.adt.cts.transportrequests.useraction.release(
-        this.number,
-        { root: { useraction: 'release' } },
-      );
+      const response =
+        await this.ctx.client.adt.cts.transportrequests.useraction.release(
+          this.number,
+        );
+      const reportFailure = releaseReportFailure(response);
+      if (reportFailure) return { success: false, message: reportFailure };
 
-      (this.itemData as { status?: string; status_text?: string }).status = 'R';
+      const verified = await AdkTransportRequest.get(this.number, this.ctx);
+      if (verified.status !== 'R') {
+        return {
+          success: false,
+          message: `Release verification failed for ${this.number}: transport still has status ${verified.status}`,
+        };
+      }
+
+      (this.itemData as { status?: string; status_text?: string }).status =
+        verified.status;
       (this.itemData as { status?: string; status_text?: string }).status_text =
-        'Released';
+        verified.statusText;
       return { success: true };
     } catch (error) {
       return {
@@ -380,20 +420,28 @@ export class AdkTransportRequest extends AdkObject<
   async reassign(newOwner: string, recursive = false): Promise<void> {
     await this.ctx.client.adt.cts.transportrequests.useraction.reassign(
       this.number,
-      { targetUser: newOwner, recursive },
+      { targetUser: newOwner },
       {
         root: {
+          number: this.number,
           useraction: 'changeowner',
           targetuser: newOwner,
         },
       },
     );
 
-    (this.itemData as { owner?: string }).owner = newOwner;
+    const verified = await AdkTransportRequest.get(this.number, this.ctx);
+    if (verified.owner.toUpperCase() !== newOwner.toUpperCase()) {
+      throw new Error(
+        `Transport ${this.number} owner verification failed: expected ${newOwner}, found ${verified.owner || '<empty>'}`,
+      );
+    }
+
+    (this.itemData as { owner?: string }).owner = verified.owner;
 
     if (recursive) {
       for (const task of this.tasks) {
-        if (task.status !== 'R') {
+        if (task.status === 'D') {
           await task.reassign(newOwner);
         }
       }
@@ -506,9 +554,7 @@ export class AdkTransportRequest extends AdkObject<
             uri: r.uri,
             task: r.task as TransportTaskData | TransportTaskData[] | undefined,
             abap_object: r.abap_object as
-              | TransportObjectData
-              | TransportObjectData[]
-              | undefined,
+              TransportObjectData | TransportObjectData[] | undefined,
           },
         } as TransportData),
     );

--- a/packages/adk/src/objects/cts/transport/transport.ts
+++ b/packages/adk/src/objects/cts/transport/transport.ts
@@ -46,11 +46,11 @@ function asArray<T>(val: T | T[] | undefined): T[] {
 }
 
 function transportResponseName(response: TransportData): string {
-  if (response.name) return response.name;
   if (response.object_type === 'T') {
     const taskNumber = asArray(response.task)[0]?.number;
     if (taskNumber) return taskNumber;
   }
+  if (response.name) return response.name;
   return response.request?.number || '';
 }
 

--- a/packages/adk/src/objects/cts/transport/transport.ts
+++ b/packages/adk/src/objects/cts/transport/transport.ts
@@ -45,6 +45,15 @@ function asArray<T>(val: T | T[] | undefined): T[] {
   return Array.isArray(val) ? val : [val];
 }
 
+function transportResponseName(response: TransportData): string {
+  if (response.name) return response.name;
+  if (response.object_type === 'T') {
+    const taskNumber = asArray(response.task)[0]?.number;
+    if (taskNumber) return taskNumber;
+  }
+  return response.request?.number || '';
+}
+
 type TransportReleaseResponse = Awaited<
   ReturnType<
     AdkContext['client']['adt']['cts']['transportrequests']['useraction']['release']
@@ -209,7 +218,7 @@ export class AdkTransportRequest extends AdkObject<
       super(ctx, dataOrNumber);
     } else {
       super(ctx, {
-        name: dataOrNumber.name || dataOrNumber.request?.number || '',
+        name: transportResponseName(dataOrNumber),
         type: dataOrNumber.object_type === 'T' ? 'RQTQ' : 'RQRQ',
         response: dataOrNumber,
       });

--- a/packages/adk/src/objects/cts/transport/transport.ts
+++ b/packages/adk/src/objects/cts/transport/transport.ts
@@ -448,6 +448,44 @@ export class AdkTransportRequest extends AdkObject<
     }
   }
 
+  /** Create and verify a modifiable task under this request. */
+  async addTask(owner: string): Promise<AdkTransportTask> {
+    if (this.itemType !== 'request') {
+      throw new Error(`Transport ${this.number} is a task, not a request`);
+    }
+    if (this.status === 'R') {
+      throw new Error(`Transport ${this.number} is already released`);
+    }
+
+    const existingTasks = new Set(this.tasks.map((task) => task.number));
+    const response =
+      await this.ctx.client.adt.cts.transportrequests.useraction.addTask(
+        this.number,
+        { owner },
+        { root: { targetuser: owner } },
+      );
+
+    const returnedNumber = response.root.number;
+    const verified = await AdkTransportRequest.get(this.number, this.ctx);
+    const created = verified.tasks.find(
+      (task) =>
+        (returnedNumber ? task.number === returnedNumber : true) &&
+        !existingTasks.has(task.number) &&
+        task.owner.toUpperCase() === owner.toUpperCase(),
+    );
+    if (!created) {
+      throw new Error(
+        `Task creation verification failed for ${this.number}: no new task owned by ${owner}`,
+      );
+    }
+    if (created.status !== 'D') {
+      throw new Error(
+        `Task creation verification failed for ${created.number}: expected status D, found ${created.status}`,
+      );
+    }
+    return created;
+  }
+
   // ===========================================================================
   // Static Factory
   // ===========================================================================

--- a/packages/adk/tests/lock-integration.test.ts
+++ b/packages/adk/tests/lock-integration.test.ts
@@ -14,6 +14,9 @@
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
+  AdkObject,
+  AdkObjectSet,
+  Class,
   initializeAdk,
   resetAdk,
   getGlobalContext,
@@ -180,5 +183,208 @@ describe('AdkObject lock/unlock store integration', () => {
       lockHandle: 'H1',
       lockedAt: new Date().toISOString(),
     });
+  });
+
+  it('uses the authoritative LOCK correlation in setSource()', async () => {
+    const client = createMockClient();
+    const lockService = {
+      lock: vi.fn().mockResolvedValue({
+        handle: 'HANDLE_123',
+        correlationNumber: 'DEVK900001',
+      }),
+      unlock: vi.fn().mockResolvedValue(undefined),
+      list: vi.fn().mockReturnValue([]),
+      cleanup: vi.fn(),
+      clear: vi.fn(),
+      forceUnlock: vi.fn(),
+    };
+    class SourceObject extends AdkObject<typeof Class> {
+      readonly kind = Class;
+      get objectUri(): string {
+        return '/sap/bc/adt/oo/classes/zcl_source';
+      }
+    }
+    const object = new SourceObject(
+      {
+        client: client as any,
+        lockService: lockService as any,
+      },
+      'ZCL_SOURCE',
+    );
+
+    await object.setSource('/source/main', 'CLASS source.', {
+      transport: 'DEVK900002',
+    });
+
+    expect(lockService.lock).toHaveBeenCalledWith(object.objectUri, {
+      transport: 'DEVK900002',
+      objectName: 'ZCL_SOURCE',
+      objectType: Class,
+    });
+    const putCall = client.fetch.mock.calls.find(
+      ([, options]) => options?.method === 'PUT',
+    );
+    expect(putCall?.[0]).toContain('corrNr=DEVK900001');
+    expect(putCall?.[0]).not.toContain('corrNr=DEVK900002');
+    expect(lockService.unlock).toHaveBeenCalledWith(object.objectUri, {
+      lockHandle: 'HANDLE_123',
+    });
+  });
+
+  it('uses the authoritative LOCK correlation for deferred sources', async () => {
+    const client = createMockClient();
+    const lockService = {
+      lock: vi.fn().mockResolvedValue({
+        handle: 'HANDLE_DEFERRED',
+        correlationNumber: 'DEVK900001',
+      }),
+      unlock: vi.fn().mockResolvedValue(undefined),
+      list: vi.fn().mockReturnValue([]),
+      cleanup: vi.fn(),
+      clear: vi.fn(),
+      forceUnlock: vi.fn(),
+    };
+    class DeferredSourceObject extends AdkObject<typeof Class> {
+      readonly kind = Class;
+      get objectUri(): string {
+        return '/sap/bc/adt/oo/classes/zcl_deferred';
+      }
+    }
+    const object = new DeferredSourceObject(
+      {
+        client: client as any,
+        lockService: lockService as any,
+      },
+      { name: 'ZCL_DEFERRED', type: 'CLAS/OC', description: 'Deferred' },
+    );
+    vi.spyOn(object, 'save').mockResolvedValue(object);
+    const saveIncludeSource = vi.fn().mockResolvedValue(undefined);
+    Object.assign(object, {
+      _deferredSources: [['testclasses', 'CLASS test.']],
+      saveIncludeSource,
+    });
+    const set = new AdkObjectSet({
+      client: client as any,
+      lockService: lockService as any,
+    });
+    set.add(object);
+
+    const result = await set.deploy({ transport: 'DEVK900002' });
+
+    expect(result.save).toMatchObject({ success: 1, failed: 0 });
+    expect(lockService.lock).toHaveBeenCalledWith(object.objectUri, {
+      transport: 'DEVK900002',
+      objectName: 'ZCL_DEFERRED',
+      objectType: Class,
+    });
+    expect(saveIncludeSource).toHaveBeenCalledWith(
+      'testclasses',
+      'CLASS test.',
+      {
+        lockHandle: 'HANDLE_DEFERRED',
+        transport: 'DEVK900001',
+      },
+    );
+  });
+
+  it('reports a deferred source failure in the deployment result', async () => {
+    const client = createMockClient();
+    const lockService = {
+      lock: vi.fn().mockResolvedValue({ handle: 'HANDLE_DEFERRED' }),
+      unlock: vi.fn().mockResolvedValue(undefined),
+      list: vi.fn().mockReturnValue([]),
+      cleanup: vi.fn(),
+      clear: vi.fn(),
+      forceUnlock: vi.fn(),
+    };
+    class DeferredSourceObject extends AdkObject<typeof Class> {
+      readonly kind = Class;
+      get objectUri(): string {
+        return '/sap/bc/adt/oo/classes/zcl_deferred_failure';
+      }
+    }
+    const object = new DeferredSourceObject(
+      {
+        client: client as any,
+        lockService: lockService as any,
+      },
+      {
+        name: 'ZCL_DEFERRED_FAILURE',
+        type: 'CLAS/OC',
+        description: 'Deferred failure',
+      },
+    );
+    vi.spyOn(object, 'save').mockResolvedValue(object);
+    Object.assign(object, {
+      _deferredSources: [['testclasses', 'CLASS test.']],
+      saveIncludeSource: vi.fn().mockRejectedValue(new Error('write failed')),
+    });
+    const set = new AdkObjectSet({
+      client: client as any,
+      lockService: lockService as any,
+    });
+    set.add(object);
+
+    const result = await set.deploy({ transport: 'DEVK900002' });
+
+    expect(result.save).toMatchObject({ success: 0, failed: 1 });
+    expect(result.save.results[0]).toMatchObject({
+      success: false,
+      error: 'Deferred source deployment failed: write failed',
+    });
+  });
+
+  it('reports a returned deferred reactivation failure', async () => {
+    const client = createMockClient();
+    client.fetch
+      .mockResolvedValueOnce('initial activation')
+      .mockRejectedValueOnce(new Error('activation failed'));
+    const lockService = {
+      lock: vi.fn().mockResolvedValue({ handle: 'HANDLE_DEFERRED' }),
+      unlock: vi.fn().mockResolvedValue(undefined),
+      list: vi.fn().mockReturnValue([]),
+      cleanup: vi.fn(),
+      clear: vi.fn(),
+      forceUnlock: vi.fn(),
+    };
+    class DeferredSourceObject extends AdkObject<typeof Class> {
+      readonly kind = Class;
+      get objectUri(): string {
+        return '/sap/bc/adt/oo/classes/zcl_deferred_activation';
+      }
+    }
+    const object = new DeferredSourceObject(
+      {
+        client: client as any,
+        lockService: lockService as any,
+      },
+      {
+        name: 'ZCL_DEFERRED_ACTIVATION',
+        type: 'CLAS/OC',
+        description: 'Deferred activation',
+      },
+    );
+    vi.spyOn(object, 'save').mockResolvedValue(object);
+    Object.assign(object, {
+      _deferredSources: [['testclasses', 'CLASS test.']],
+      saveIncludeSource: vi.fn().mockResolvedValue(undefined),
+    });
+    const set = new AdkObjectSet({
+      client: client as any,
+      lockService: lockService as any,
+    });
+    set.add(object);
+
+    const result = await set.deploy({ transport: 'DEVK900002' });
+
+    expect(result.save).toMatchObject({ success: 0, failed: 1 });
+    expect(result.save.results[0]).toMatchObject({
+      success: false,
+      error:
+        'Deferred source deployment failed: Deferred activation failed: activation failed',
+    });
+    expect(
+      (object as unknown as { _deferredSources?: unknown })._deferredSources,
+    ).toBeDefined();
   });
 });

--- a/packages/adk/tests/transport-import.test.ts
+++ b/packages/adk/tests/transport-import.test.ts
@@ -214,7 +214,7 @@ describe('AdkTransport', () => {
       expect(transport.owner).toBe('DEVELOPER');
       expect(transport.status).toBe('D');
       expect(transport.statusText).toBe('Modifiable');
-    });
+    }, 10_000);
 
     it('should expose transport properties', async () => {
       const mockClient = createMockClient();
@@ -809,7 +809,9 @@ describe('resolveTransportObjects()', () => {
     const response = {
       root: {
         object_type: 'T',
-        name: 'DEVK901021',
+        // Some SAP/parser combinations expose the parent request here even
+        // though the GET was issued for the child task.
+        name: 'DEVK901020',
         type: 'RQTQ',
         request: {
           number: 'DEVK901020',
@@ -818,6 +820,11 @@ describe('resolveTransportObjects()', () => {
           {
             number: 'DEVK901021',
             parent: 'DEVK901020',
+            owner: 'TASKOWNER',
+            desc: 'Direct task',
+            status: 'D',
+            status_text: 'Modifiable',
+            target: 'QAS',
             abap_object: [{ pgmid: 'R3TR', type: 'TABL', name: 'ZTASK_TABLE' }],
           },
         ],
@@ -826,11 +833,19 @@ describe('resolveTransportObjects()', () => {
     const mockClient = createTransportClientByNumber({
       DEVK901021: response,
     });
-    const { initializeAdk, resolveTransportObjects } =
+    const { initializeAdk, AdkTransport, resolveTransportObjects } =
       await import('../src/index');
     initializeAdk(mockClient as any);
 
-    const result = await resolveTransportObjects(['DEVK901021'], {});
+    const transport = await AdkTransport.get(' devk901021 ');
+    expect(transport.number).toBe('DEVK901021');
+    expect(transport.description).toBe('Direct task');
+    expect(transport.owner).toBe('TASKOWNER');
+    expect(transport.status).toBe('D');
+    expect(transport.statusText).toBe('Modifiable');
+    expect(transport.target).toBe('QAS');
+
+    const result = await resolveTransportObjects([' devk901021 '], {});
 
     expect(result.objects.map((object) => object.key)).toEqual([
       'R3TR/TABL/ZTASK_TABLE',

--- a/packages/adk/tests/transport-import.test.ts
+++ b/packages/adk/tests/transport-import.test.ts
@@ -811,6 +811,9 @@ describe('resolveTransportObjects()', () => {
         object_type: 'T',
         name: 'DEVK901021',
         type: 'RQTQ',
+        request: {
+          number: 'DEVK901020',
+        },
         task: [
           {
             number: 'DEVK901021',
@@ -835,7 +838,7 @@ describe('resolveTransportObjects()', () => {
     expect(result.sourceTransportMap.get('R3TR/TABL/ZTASK_TABLE')).toBe(
       'DEVK901021',
     );
-    expect(result.scopeTransportNumbers).toEqual(['DEVK901021']);
+    expect(result.scopeTransportNumbers).toEqual(['DEVK901021', 'DEVK901020']);
   });
 
   it('preserves ordered first-win provenance across multiple roots', async () => {

--- a/packages/adk/tests/transport-lifecycle.test.ts
+++ b/packages/adk/tests/transport-lifecycle.test.ts
@@ -14,6 +14,7 @@ interface LifecycleFixtureOptions {
   applyAddTask?: boolean;
   addTaskNumber?: string;
   rootStatus?: string;
+  omitTaskRootName?: boolean;
 }
 
 function requestResponse(
@@ -37,11 +38,16 @@ function requestResponse(
   };
 }
 
-function taskResponse(number: string, parent: string, state: TransportState) {
+function taskResponse(
+  number: string,
+  parent: string,
+  state: TransportState,
+  omitRootName = false,
+) {
   return {
     root: {
       object_type: 'T',
-      name: number,
+      ...(omitRootName ? {} : { name: number }),
       type: 'RQTQ',
       request: { number: parent },
       task: [
@@ -87,7 +93,7 @@ function createLifecycleFixture(options: LifecycleFixtureOptions = {}) {
     if (!state) throw new Error(`Unexpected transport ${number}`);
     return number === rootNumber
       ? requestResponse(rootNumber, state, taskDefinitions)
-      : taskResponse(number, rootNumber, state);
+      : taskResponse(number, rootNumber, state, options.omitTaskRootName);
   });
   const release = vi.fn(async (number: string) => {
     const status = options.releaseStatus ?? 'released';
@@ -164,6 +170,18 @@ function createLifecycleFixture(options: LifecycleFixtureOptions = {}) {
 }
 
 describe('AdkTransportRequest CTS lifecycle', () => {
+  it('uses the child task number when the parsed task root has no name', async () => {
+    const fixture = createLifecycleFixture({ omitTaskRootName: true });
+
+    const task = await AdkTransportRequest.get('DEVK900002', {
+      client: fixture.client,
+    });
+
+    expect(task.number).toBe('DEVK900002');
+    await expect(task.release()).resolves.toEqual({ success: true });
+    expect(fixture.release).toHaveBeenCalledWith('DEVK900002');
+  });
+
   it('updates cached release state only after a released read-back', async () => {
     const fixture = createLifecycleFixture();
     const transport = await AdkTransportRequest.get(fixture.rootNumber, {

--- a/packages/adk/tests/transport-lifecycle.test.ts
+++ b/packages/adk/tests/transport-lifecycle.test.ts
@@ -11,6 +11,7 @@ interface LifecycleFixtureOptions {
   releaseStatus?: string;
   releaseStatusText?: string;
   applyReassign?: boolean;
+  applyAddTask?: boolean;
 }
 
 function requestResponse(
@@ -115,19 +116,46 @@ function createLifecycleFixture(options: LifecycleFixtureOptions = {}) {
       );
     },
   );
+  const addTask = vi.fn(
+    async (
+      _number: string,
+      _options: { owner: string },
+      body: { root: { targetuser: string } },
+    ) => {
+      if (options.applyAddTask !== false) {
+        const created = {
+          number: 'DEVK900005',
+          owner: body.root.targetuser,
+          status: 'D',
+        };
+        taskDefinitions.push(created);
+        states.set(created.number, {
+          owner: created.owner,
+          status: created.status,
+        });
+      }
+      return {
+        root: {
+          targetuser: body.root.targetuser,
+          useraction: 'tasks',
+          number: 'DEVK900005',
+        },
+      };
+    },
+  );
 
   const client = {
     adt: {
       cts: {
         transportrequests: {
           get,
-          useraction: { release, reassign },
+          useraction: { release, reassign, addTask },
         },
       },
     },
   } as unknown as AdtClient;
 
-  return { client, get, release, reassign, states, rootNumber };
+  return { client, get, release, reassign, addTask, states, rootNumber };
 }
 
 describe('AdkTransportRequest CTS lifecycle', () => {
@@ -210,5 +238,47 @@ describe('AdkTransportRequest CTS lifecycle', () => {
     expect(fixture.states.get('DEVK900003')?.owner).toBe('OLDUSER');
     expect(fixture.states.get('DEVK900004')?.owner).toBe('OLDUSER');
     expect(transport.owner).toBe('NEWUSER');
+  });
+
+  it('creates a task and returns it only after parent read-back verification', async () => {
+    const fixture = createLifecycleFixture();
+    const transport = await AdkTransportRequest.get(fixture.rootNumber, {
+      client: fixture.client,
+    });
+
+    const created = await transport.addTask('NEWUSER');
+
+    expect(created.number).toBe('DEVK900005');
+    expect(created.owner).toBe('NEWUSER');
+    expect(created.status).toBe('D');
+    expect(fixture.addTask).toHaveBeenCalledWith(
+      fixture.rootNumber,
+      { owner: 'NEWUSER' },
+      { root: { targetuser: 'NEWUSER' } },
+    );
+    expect(fixture.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects task creation when SAP read-back has no matching new task', async () => {
+    const fixture = createLifecycleFixture({ applyAddTask: false });
+    const transport = await AdkTransportRequest.get(fixture.rootNumber, {
+      client: fixture.client,
+    });
+
+    await expect(transport.addTask('NEWUSER')).rejects.toThrow(
+      'no new task owned by NEWUSER',
+    );
+  });
+
+  it('rejects creating a child under a transport task', async () => {
+    const fixture = createLifecycleFixture();
+    const task = await AdkTransportRequest.get('DEVK900002', {
+      client: fixture.client,
+    });
+
+    await expect(task.addTask('NEWUSER')).rejects.toThrow(
+      'is a task, not a request',
+    );
+    expect(fixture.addTask).not.toHaveBeenCalled();
   });
 });

--- a/packages/adk/tests/transport-lifecycle.test.ts
+++ b/packages/adk/tests/transport-lifecycle.test.ts
@@ -14,7 +14,7 @@ interface LifecycleFixtureOptions {
   applyAddTask?: boolean;
   addTaskNumber?: string;
   rootStatus?: string;
-  omitTaskRootName?: boolean;
+  parsedTaskRootName?: string;
 }
 
 function requestResponse(
@@ -42,12 +42,12 @@ function taskResponse(
   number: string,
   parent: string,
   state: TransportState,
-  omitRootName = false,
+  parsedRootName = number,
 ) {
   return {
     root: {
       object_type: 'T',
-      ...(omitRootName ? {} : { name: number }),
+      name: parsedRootName,
       type: 'RQTQ',
       request: { number: parent },
       task: [
@@ -93,7 +93,7 @@ function createLifecycleFixture(options: LifecycleFixtureOptions = {}) {
     if (!state) throw new Error(`Unexpected transport ${number}`);
     return number === rootNumber
       ? requestResponse(rootNumber, state, taskDefinitions)
-      : taskResponse(number, rootNumber, state, options.omitTaskRootName);
+      : taskResponse(number, rootNumber, state, options.parsedTaskRootName);
   });
   const release = vi.fn(async (number: string) => {
     const status = options.releaseStatus ?? 'released';
@@ -170,8 +170,10 @@ function createLifecycleFixture(options: LifecycleFixtureOptions = {}) {
 }
 
 describe('AdkTransportRequest CTS lifecycle', () => {
-  it('uses the child task number when the parsed task root has no name', async () => {
-    const fixture = createLifecycleFixture({ omitTaskRootName: true });
+  it('prefers the child task number over a parsed parent root name', async () => {
+    const fixture = createLifecycleFixture({
+      parsedTaskRootName: 'DEVK900001',
+    });
 
     const task = await AdkTransportRequest.get('DEVK900002', {
       client: fixture.client,

--- a/packages/adk/tests/transport-lifecycle.test.ts
+++ b/packages/adk/tests/transport-lifecycle.test.ts
@@ -12,6 +12,8 @@ interface LifecycleFixtureOptions {
   releaseStatusText?: string;
   applyReassign?: boolean;
   applyAddTask?: boolean;
+  addTaskNumber?: string;
+  rootStatus?: string;
 }
 
 function requestResponse(
@@ -73,7 +75,7 @@ function createLifecycleFixture(options: LifecycleFixtureOptions = {}) {
     { number: 'DEVK900004', owner: 'OLDUSER', status: 'N' },
   ];
   const states = new Map<string, TransportState>([
-    [rootNumber, { owner: 'OLDUSER', status: 'D' }],
+    [rootNumber, { owner: 'OLDUSER', status: options.rootStatus ?? 'D' }],
     ...taskDefinitions.map(
       (task) =>
         [task.number, { owner: task.owner, status: task.status }] as const,
@@ -138,7 +140,10 @@ function createLifecycleFixture(options: LifecycleFixtureOptions = {}) {
         root: {
           targetuser: body.root.targetuser,
           useraction: 'tasks',
-          number: 'DEVK900005',
+          number:
+            options.addTaskNumber === ''
+              ? undefined
+              : (options.addTaskNumber ?? 'DEVK900005'),
         },
       };
     },
@@ -257,6 +262,12 @@ describe('AdkTransportRequest CTS lifecycle', () => {
       { root: { targetuser: 'NEWUSER' } },
     );
     expect(fixture.get).toHaveBeenCalledTimes(2);
+    expect(transport.tasks.map((task) => task.number)).toContain('DEVK900005');
+
+    await expect(transport.releaseAll()).resolves.toEqual({ success: true });
+    expect(fixture.release.mock.calls.map(([number]) => number)).toContain(
+      'DEVK900005',
+    );
   });
 
   it('rejects task creation when SAP read-back has no matching new task', async () => {
@@ -280,5 +291,29 @@ describe('AdkTransportRequest CTS lifecycle', () => {
       'is a task, not a request',
     );
     expect(fixture.addTask).not.toHaveBeenCalled();
+  });
+
+  it('rejects task creation for a non-modifiable request', async () => {
+    const fixture = createLifecycleFixture({ rootStatus: 'N' });
+    const transport = await AdkTransportRequest.get(fixture.rootNumber, {
+      client: fixture.client,
+    });
+
+    await expect(transport.addTask('NEWUSER')).rejects.toThrow(
+      'expected status D, found N',
+    );
+    expect(fixture.addTask).not.toHaveBeenCalled();
+  });
+
+  it('requires SAP to return the created task number', async () => {
+    const fixture = createLifecycleFixture({ addTaskNumber: '' });
+    const transport = await AdkTransportRequest.get(fixture.rootNumber, {
+      client: fixture.client,
+    });
+
+    await expect(transport.addTask('NEWUSER')).rejects.toThrow(
+      'SAP response did not contain a task number',
+    );
+    expect(fixture.get).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/adk/tests/transport-lifecycle.test.ts
+++ b/packages/adk/tests/transport-lifecycle.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AdtClient } from '@abapify/adt-client';
+import { AdkTransportRequest } from '../src/objects/cts/transport/transport';
+
+interface TransportState {
+  owner: string;
+  status: string;
+}
+
+interface LifecycleFixtureOptions {
+  releaseStatus?: string;
+  releaseStatusText?: string;
+  applyReassign?: boolean;
+}
+
+function requestResponse(
+  number: string,
+  state: TransportState,
+  tasks: Array<{ number: string; owner: string; status: string }> = [],
+) {
+  return {
+    root: {
+      object_type: 'K',
+      name: number,
+      type: 'RQRQ',
+      request: {
+        number,
+        owner: state.owner,
+        status: state.status,
+        status_text: state.status === 'R' ? 'Released' : 'Modifiable',
+        task: tasks,
+      },
+    },
+  };
+}
+
+function taskResponse(number: string, parent: string, state: TransportState) {
+  return {
+    root: {
+      object_type: 'T',
+      name: number,
+      type: 'RQTQ',
+      request: { number: parent },
+      task: [
+        {
+          number,
+          parent,
+          owner: state.owner,
+          status: state.status,
+          status_text: state.status === 'R' ? 'Released' : 'Modifiable',
+        },
+      ],
+    },
+  };
+}
+
+function releaseResponse(status: string, statusText: string) {
+  return {
+    root: {
+      releasereports: {
+        checkReport: [{ status, statusText }],
+      },
+    },
+  };
+}
+
+function createLifecycleFixture(options: LifecycleFixtureOptions = {}) {
+  const rootNumber = 'DEVK900001';
+  const taskDefinitions = [
+    { number: 'DEVK900002', owner: 'OLDUSER', status: 'D' },
+    { number: 'DEVK900003', owner: 'OLDUSER', status: 'R' },
+    { number: 'DEVK900004', owner: 'OLDUSER', status: 'N' },
+  ];
+  const states = new Map<string, TransportState>([
+    [rootNumber, { owner: 'OLDUSER', status: 'D' }],
+    ...taskDefinitions.map(
+      (task) =>
+        [task.number, { owner: task.owner, status: task.status }] as const,
+    ),
+  ]);
+
+  const get = vi.fn(async (number: string) => {
+    const state = states.get(number);
+    if (!state) throw new Error(`Unexpected transport ${number}`);
+    return number === rootNumber
+      ? requestResponse(rootNumber, state, taskDefinitions)
+      : taskResponse(number, rootNumber, state);
+  });
+  const release = vi.fn(async (number: string) => {
+    const status = options.releaseStatus ?? 'released';
+    if (status === 'released') {
+      const state = states.get(number);
+      if (state) state.status = 'R';
+    }
+    return releaseResponse(
+      status,
+      options.releaseStatusText ??
+        (status === 'released' ? 'Released' : 'Release failed'),
+    );
+  });
+  const reassign = vi.fn(
+    async (
+      number: string,
+      _options: { targetUser: string; recursive?: boolean },
+      body: { root: { targetuser: string } },
+    ) => {
+      if (options.applyReassign !== false) {
+        const state = states.get(number);
+        if (state) state.owner = body.root.targetuser;
+      }
+      return requestResponse(
+        rootNumber,
+        states.get(rootNumber)!,
+        taskDefinitions,
+      );
+    },
+  );
+
+  const client = {
+    adt: {
+      cts: {
+        transportrequests: {
+          get,
+          useraction: { release, reassign },
+        },
+      },
+    },
+  } as unknown as AdtClient;
+
+  return { client, get, release, reassign, states, rootNumber };
+}
+
+describe('AdkTransportRequest CTS lifecycle', () => {
+  it('updates cached release state only after a released read-back', async () => {
+    const fixture = createLifecycleFixture();
+    const transport = await AdkTransportRequest.get(fixture.rootNumber, {
+      client: fixture.client,
+    });
+
+    const result = await transport.release();
+
+    expect(result).toEqual({ success: true });
+    expect(fixture.release).toHaveBeenCalledWith(fixture.rootNumber);
+    expect(fixture.get).toHaveBeenCalledTimes(2);
+    expect(transport.status).toBe('R');
+    expect(transport.statusText).toBe('Released');
+  });
+
+  it('surfaces a failed release report instead of reporting success', async () => {
+    const fixture = createLifecycleFixture({
+      releaseStatus: 'abortrelapifail',
+      releaseStatusText: 'Task is unclassified and cannot be released',
+    });
+    const transport = await AdkTransportRequest.get(fixture.rootNumber, {
+      client: fixture.client,
+    });
+
+    const result = await transport.release();
+
+    expect(result).toEqual({
+      success: false,
+      message: 'Task is unclassified and cannot be released',
+    });
+    expect(fixture.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails release when read-back does not show released status', async () => {
+    const fixture = createLifecycleFixture();
+    fixture.release.mockImplementationOnce(async () =>
+      releaseResponse('released', 'Released'),
+    );
+    const transport = await AdkTransportRequest.get(fixture.rootNumber, {
+      client: fixture.client,
+    });
+
+    const result = await transport.release();
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('still has status D');
+    expect(transport.status).toBe('D');
+  });
+
+  it('rejects a change-owner response when read-back still has the old owner', async () => {
+    const fixture = createLifecycleFixture({ applyReassign: false });
+    const transport = await AdkTransportRequest.get(fixture.rootNumber, {
+      client: fixture.client,
+    });
+
+    await expect(transport.reassign('NEWUSER')).rejects.toThrow(
+      'owner verification failed',
+    );
+    expect(transport.owner).toBe('OLDUSER');
+    expect(fixture.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('recursively reassigns only modifiable tasks and verifies each owner', async () => {
+    const fixture = createLifecycleFixture();
+    const transport = await AdkTransportRequest.get(fixture.rootNumber, {
+      client: fixture.client,
+    });
+
+    await transport.reassign('NEWUSER', true);
+
+    expect(fixture.reassign.mock.calls.map(([number]) => number)).toEqual([
+      'DEVK900001',
+      'DEVK900002',
+    ]);
+    expect(fixture.states.get('DEVK900001')?.owner).toBe('NEWUSER');
+    expect(fixture.states.get('DEVK900002')?.owner).toBe('NEWUSER');
+    expect(fixture.states.get('DEVK900003')?.owner).toBe('OLDUSER');
+    expect(fixture.states.get('DEVK900004')?.owner).toBe('OLDUSER');
+    expect(transport.owner).toBe('NEWUSER');
+  });
+});

--- a/packages/adk/tests/transport-source-manifest.test.ts
+++ b/packages/adk/tests/transport-source-manifest.test.ts
@@ -604,6 +604,29 @@ describe('buildTransportSourceManifest', () => {
     expect(readVersionSource).not.toHaveBeenCalled();
   });
 
+  it('matches parent-attributed source history for a directly requested task', async () => {
+    const object = transportObject({
+      name: 'ZTASK_CREATED_CLASS',
+      type: 'CLAS',
+      objectUri: '/sap/bc/adt/oo/classes/ztask_created_class',
+      metadata: rootSourceMetadata(),
+    });
+    mockResolution([object], ['DEVK901021'], ['DEVK901021', 'DEVK901020']);
+    const head = version('00001', 0, ['DEVK901020']);
+    const { ctx } = contextWithVersions(vi.fn().mockResolvedValue([head]));
+
+    const result = await buildTransportSourceManifest(['DEVK901021'], {}, ctx);
+
+    expect(result.scopeTransports).toEqual(['DEVK901021', 'DEVK901020']);
+    expect(result.entries[0]).toMatchObject({
+      sourceTransport: 'DEVK901021',
+      changeKind: 'added',
+      exact: true,
+      head,
+    });
+    expect(result.entries[0]?.base).toBeUndefined();
+  });
+
   it('resolves a LIMU REPS transport leaf through the PROG source-history model', async () => {
     const object = transportObject({
       name: 'ZTEST_GCTS_PROGRAM',

--- a/packages/adt-cli/README.md
+++ b/packages/adt-cli/README.md
@@ -203,6 +203,20 @@ Get details for a transport request or task.
 | `-t, --type <type>`        | `K` (Workbench, default) or `W` (Customizing) |
 | `--target <target>`        | Target system (default: `LOCAL`)              |
 
+#### `adt cts tr task create <transport> <owner> [options]`
+
+Create a modifiable task under an existing request and verify the new task by
+reading the parent request back from SAP.
+
+```bash
+adt cts tr task create DEVK900001 DEVELOPER
+adt cts tr task create DEVK900001 DEVELOPER --json
+```
+
+| Option   | Description           |
+| -------- | --------------------- |
+| `--json` | JSON result on stdout |
+
 ### Exact source history
 
 Source-history commands follow immutable links returned by SAP ADT. Listing

--- a/packages/adt-cli/README.md
+++ b/packages/adt-cli/README.md
@@ -149,6 +149,21 @@ adt get ZCL_MY_CLASS --properties
 adt get ZCL_MY_CLASS -o tmp/class.xml
 ```
 
+#### `adt check <object...> [options]`
+
+Run SAP ADT syntax checks. Existing objects are checked using their inactive
+source by default; select another source explicitly with
+`--source-version active|inactive|new`. The name avoids colliding with the
+root `adt --version` flag.
+
+With `--json`, stdout contains only the report array. SAP error/abort messages
+(`E`/`A`) keep that JSON readable and set a non-zero process exit status.
+
+```bash
+adt check ZCL_MY_CLASS --type CLAS
+adt check ZCL_MY_CLASS --type CLAS --source-version active --json
+```
+
 #### `adt outline <object>`
 
 Show object structure as a tree (methods, attributes, visibility).

--- a/packages/adt-cli/src/index.ts
+++ b/packages/adt-cli/src/index.ts
@@ -72,3 +72,23 @@ export {
   type ListObjectVersionsInput,
   type ListObjectVersionsResult,
 } from './lib/services/source-history';
+
+export {
+  CheckService,
+  DEFAULT_CHECK_SOURCE_VERSION,
+  type CheckMessage,
+  type CheckReport,
+  type CheckResult,
+  type CheckServiceInput,
+  type CheckSourceVersion,
+} from './lib/services/check/service';
+
+export {
+  CtsTransportLifecycleService,
+  type CtsTransportLifecycleOperations,
+  type CtsTransportSummary,
+  type ReassignTransportInput,
+  type ReassignTransportResult,
+  type ReleaseTransportInput,
+  type ReleaseTransportResult,
+} from './lib/services/cts';

--- a/packages/adt-cli/src/index.ts
+++ b/packages/adt-cli/src/index.ts
@@ -87,6 +87,8 @@ export {
   CtsTransportLifecycleService,
   type CtsTransportLifecycleOperations,
   type CtsTransportSummary,
+  type CreateTaskInput,
+  type CreateTaskResult,
   type ReassignTransportInput,
   type ReassignTransportResult,
   type ReleaseTransportInput,

--- a/packages/adt-cli/src/lib/commands/abap/run.ts
+++ b/packages/adt-cli/src/lib/commands/abap/run.ts
@@ -30,6 +30,7 @@ import { getAdtClientV2, getCliContext } from '../../utils/adt-client-v2';
 import { createProgressReporter } from '../../utils/progress-reporter';
 import { createCliLogger } from '../../utils/logger-config';
 import { AdkClass } from '@abapify/adk';
+import { resolveLockCorrelation } from '@abapify/adt-locks';
 
 function buildClassTemplate(className: string, body: string): string {
   const lower = className.toLowerCase();
@@ -138,7 +139,7 @@ export const abapRunCommand = new Command('run')
           progress.step(`💾 Writing source...`);
           await cls.saveMainSource(classSource, {
             lockHandle: lockHandle.handle,
-            transport: options.transport,
+            transport: resolveLockCorrelation(lockHandle, options.transport),
           });
           progress.done();
         } finally {

--- a/packages/adt-cli/src/lib/commands/check.test.ts
+++ b/packages/adt-cli/src/lib/commands/check.test.ts
@@ -1,0 +1,114 @@
+import type { AdtClient } from '@abapify/adt-client';
+import { Command } from 'commander';
+import { describe, expect, it, vi } from 'vitest';
+import type { CheckResult, CheckServiceInput } from '../services/check/service';
+import { createCheckCommand, type CheckCommandDependencies } from './check';
+
+function createCommandState(result: CheckResult): {
+  dependencies: Partial<CheckCommandDependencies>;
+  run: ReturnType<typeof vi.fn>;
+  lines: string[];
+  errors: string[];
+  exitCodes: number[];
+} {
+  const client = {} as AdtClient;
+  const run = vi.fn(async (_input: CheckServiceInput) => result);
+  const lines: string[] = [];
+  const errors: string[] = [];
+  const exitCodes: number[] = [];
+
+  return {
+    dependencies: {
+      getClient: vi.fn(async () => client),
+      createService: vi.fn(() => ({ run })),
+      writeLine: (line) => lines.push(line),
+      writeError: (line) => errors.push(line),
+      setExitCode: (code) => exitCodes.push(code),
+    },
+    run,
+    lines,
+    errors,
+    exitCodes,
+  };
+}
+
+function createRootCommand(dependencies: Partial<CheckCommandDependencies>) {
+  return new Command('adt')
+    .version('1.0.0')
+    .exitOverride()
+    .addCommand(createCheckCommand(dependencies));
+}
+
+describe('check command', () => {
+  it('accepts a non-colliding --source-version option under a versioned root command', async () => {
+    const state = createCommandState({
+      reports: [],
+      hasErrors: false,
+      hasWarnings: false,
+    });
+
+    await createRootCommand(state.dependencies).parseAsync(
+      [
+        'node',
+        'adt',
+        'check',
+        'ZCL_TEST',
+        '--type',
+        'CLAS',
+        '--source-version',
+        'active',
+        '--json',
+      ],
+      { from: 'node' },
+    );
+
+    expect(state.run).toHaveBeenCalledWith({
+      objects: [{ uri: '/sap/bc/adt/oo/classes/zcl_test' }],
+      sourceVersion: 'active',
+    });
+  });
+
+  it('uses inactive source when no source version is provided', async () => {
+    const state = createCommandState({
+      reports: [],
+      hasErrors: false,
+      hasWarnings: false,
+    });
+
+    await createRootCommand(state.dependencies).parseAsync(
+      ['node', 'adt', 'check', 'ZCL_TEST', '--type', 'CLAS', '--json'],
+      { from: 'node' },
+    );
+
+    expect(state.run).toHaveBeenCalledWith({
+      objects: [{ uri: '/sap/bc/adt/oo/classes/zcl_test' }],
+      sourceVersion: 'inactive',
+    });
+  });
+
+  it('prints valid JSON and sets a failing exit status for SAP errors', async () => {
+    const reports = [
+      {
+        triggeringUri: '/sap/bc/adt/oo/classes/zcl_test',
+        checkMessageList: {
+          checkMessage: [{ type: 'E', shortText: 'Syntax error' }],
+        },
+      },
+    ];
+    const state = createCommandState({
+      reports,
+      hasErrors: true,
+      hasWarnings: false,
+    });
+
+    await createRootCommand(state.dependencies).parseAsync(
+      ['node', 'adt', 'check', 'ZCL_TEST', '--type', 'CLAS', '--json'],
+      { from: 'node' },
+    );
+
+    expect(state.lines).toHaveLength(1);
+    expect(JSON.parse(state.lines[0] ?? 'null')).toEqual(reports);
+    expect(state.errors).toEqual([]);
+    expect(state.exitCodes).toEqual([1]);
+  });
+});

--- a/packages/adt-cli/src/lib/commands/check.ts
+++ b/packages/adt-cli/src/lib/commands/check.ts
@@ -14,7 +14,7 @@
  *   adt check --transport DEVK900001          # All objects in transport
  */
 
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import type { AdtClient } from '@abapify/adt-client';
 import { getAdtClientV2 } from '../utils/adt-client-v2';
 import { getObjectUri } from '@abapify/adk';
@@ -155,7 +155,7 @@ const defaultDependencies: CheckCommandDependencies = {
   writeLine: (line) => console.log(line),
   writeError: (line) => console.error(line),
   setExitCode: (code) => {
-    process.exitCode = code;
+    process.exit(code);
   },
 };
 
@@ -176,10 +176,17 @@ export function createCheckCommand(
       '--type <type>',
       'Object type hint for resolving URIs (e.g., CLAS, DOMA)',
     )
-    .option(
-      '--source-version <version>',
-      'Source version to check: active, inactive, new',
-      DEFAULT_CHECK_SOURCE_VERSION,
+    .addOption(
+      new Option('--source-version <version>', 'Source version to check')
+        .choices([
+          'active',
+          'inactive',
+          'workingArea',
+          'new',
+          'partlyActive',
+          'activeWithInactiveVersion',
+        ])
+        .default(DEFAULT_CHECK_SOURCE_VERSION),
     )
     .option('--json', 'Output results as JSON')
     .action(
@@ -216,6 +223,7 @@ export function createCheckCommand(
               dependencies.writeError(
                 `⚠️ No objects found in package ${options.package}`,
               );
+              dependencies.setExitCode(1);
               return;
             }
             checkObjects.push(...pkgObjects);
@@ -272,6 +280,7 @@ export function createCheckCommand(
               dependencies.writeError(
                 `⚠️ No objects found in transport ${options.transport}`,
               );
+              dependencies.setExitCode(1);
               return;
             }
             if (!options.json) {
@@ -287,6 +296,7 @@ export function createCheckCommand(
                 `🔍 Resolving ${objects.length} object(s)...`,
               );
             }
+            let hasResolveErrors = false;
             for (const objectName of objects) {
               try {
                 const resolved = await resolveObjectUri(
@@ -301,10 +311,14 @@ export function createCheckCommand(
                   );
                 }
               } catch (err) {
+                hasResolveErrors = true;
                 dependencies.writeError(
                   `   ❌ ${objectName}: ${err instanceof Error ? err.message : String(err)}`,
                 );
               }
+            }
+            if (hasResolveErrors) {
+              dependencies.setExitCode(1);
             }
           } else {
             dependencies.writeError(

--- a/packages/adt-cli/src/lib/commands/check.ts
+++ b/packages/adt-cli/src/lib/commands/check.ts
@@ -15,33 +15,22 @@
  */
 
 import { Command } from 'commander';
+import type { AdtClient } from '@abapify/adt-client';
 import { getAdtClientV2 } from '../utils/adt-client-v2';
 import { getObjectUri } from '@abapify/adk';
 import { normalizeSearchResults } from '../utils/lock-helpers';
-
-type CheckMessage = {
-  uri?: string;
-  type?: unknown;
-  shortText?: string;
-  category?: string;
-  code?: string;
-};
-
-type CheckReport = {
-  checkMessageList?: {
-    checkMessage?: CheckMessage[];
-  };
-  reporter?: string;
-  triggeringUri?: string;
-  status?: string;
-  statusText?: string;
-};
+import {
+  CheckService,
+  DEFAULT_CHECK_SOURCE_VERSION,
+  type CheckReport,
+  type CheckSourceVersion,
+} from '../services/check/service';
 
 /**
  * Resolve a single object name to its ADT URI via quickSearch
  */
 async function resolveObjectUri(
-  client: Awaited<ReturnType<typeof getAdtClientV2>>,
+  client: AdtClient,
   objectName: string,
   typeHint?: string,
 ): Promise<{ uri: string; type: string; name: string }> {
@@ -88,7 +77,7 @@ async function resolveObjectUri(
  * Search objects by package using quickSearch with package filter
  */
 async function resolvePackageObjects(
-  client: Awaited<ReturnType<typeof getAdtClientV2>>,
+  client: AdtClient,
   packageName: string,
 ): Promise<Array<{ uri: string; type: string; name: string }>> {
   const searchResult =
@@ -113,91 +102,12 @@ async function resolvePackageObjects(
 }
 
 /**
- * Build a typed checkObjectList body for the checkruns endpoint.
- * The `checkrun` schema union is discriminated on the root key.
- */
-function buildCheckObjectList(
-  objects: Array<{ uri: string }>,
-  version = 'active',
-) {
-  return {
-    checkObjectList: {
-      checkObject: objects.map((o) => ({
-        uri: o.uri,
-        version: version as
-          | ''
-          | 'active'
-          | 'inactive'
-          | 'workingArea'
-          | 'new'
-          | 'partlyActive'
-          | 'activeWithInactiveVersion',
-      })),
-    },
-  };
-}
-
-/**
- * Extract reports + aggregated severity from a typed checkRunReports response.
- */
-function extractReports(response: unknown): {
-  reports: CheckReport[];
-  hasErrors: boolean;
-  hasWarnings: boolean;
-} {
-  const root = (response ?? {}) as Record<string, unknown>;
-  const reportsBlock = (root.checkRunReports ?? root) as Record<
-    string,
-    unknown
-  >;
-
-  const raw = reportsBlock.checkReport;
-  let arr: unknown[];
-  if (Array.isArray(raw)) {
-    arr = raw;
-  } else if (raw) {
-    arr = [raw];
-  } else {
-    arr = [];
-  }
-
-  const reports: CheckReport[] = arr.map((r) => {
-    const rec = r as Record<string, unknown>;
-    const msgList = rec.checkMessageList as
-      | { checkMessage?: CheckMessage | CheckMessage[] }
-      | undefined;
-    let messages: CheckMessage[] | undefined;
-    if (msgList?.checkMessage) {
-      messages = Array.isArray(msgList.checkMessage)
-        ? msgList.checkMessage
-        : [msgList.checkMessage];
-    }
-    return {
-      reporter: rec.reporter as string | undefined,
-      triggeringUri: rec.triggeringUri as string | undefined,
-      status: rec.status as string | undefined,
-      statusText: rec.statusText as string | undefined,
-      checkMessageList: messages ? { checkMessage: messages } : undefined,
-    };
-  });
-
-  let hasErrors = false;
-  let hasWarnings = false;
-  for (const report of reports) {
-    for (const msg of report.checkMessageList?.checkMessage ?? []) {
-      const sev = typeof msg.type === 'string' ? msg.type : msg.category;
-      if (sev === 'E' || sev === 'A') hasErrors = true;
-      if (sev === 'W') hasWarnings = true;
-    }
-  }
-
-  return { reports, hasErrors, hasWarnings };
-}
-
-/**
  * Display check results
  */
-function displayResults(reports: CheckReport[]): number {
+function displayResults(
+  reports: CheckReport[],
+  writeLine: (line: string) => void,
+): number {
   let totalMessages = 0;
 
   for (const report of reports) {
@@ -207,7 +117,7 @@ function displayResults(reports: CheckReport[]): number {
       if (report.triggeringUri) {
         const objName =
           report.triggeringUri.split('/').pop() ?? report.triggeringUri;
-        console.log(`   ✅ ${objName}`);
+        writeLine(`   ✅ ${objName}`);
       }
       continue;
     }
@@ -220,7 +130,7 @@ function displayResults(reports: CheckReport[]): number {
       const sev = typeof msg.type === 'string' ? msg.type : msg.category;
       const icon =
         sev === 'E' || sev === 'A' ? '❌' : sev === 'W' ? '⚠️' : 'ℹ️';
-      console.log(
+      writeLine(
         `   ${icon} ${objName}: ${msg.shortText ?? msg.code ?? 'unknown message'}`,
       );
     }
@@ -229,171 +139,233 @@ function displayResults(reports: CheckReport[]): number {
   return totalMessages;
 }
 
-export const checkCommand = new Command('check')
-  .description('Run syntax check (checkruns) on ABAP objects')
-  .argument('[objects...]', 'Object name(s) to check')
-  .option('-p, --package <package>', 'Check all objects in a package')
-  .option(
-    '-t, --transport <transport>',
-    'Check all objects in a transport request',
-  )
-  .option(
-    '--type <type>',
-    'Object type hint for resolving URIs (e.g., CLAS, DOMA)',
-  )
-  .option(
-    '--version <version>',
-    'Version to check: active, inactive, new',
-    'new',
-  )
-  .option('--json', 'Output results as JSON')
-  .action(
-    async (
-      objects: string[],
-      options: {
-        package?: string;
-        transport?: string;
-        type?: string;
-        version?: string;
-        json?: boolean;
-      },
-    ) => {
-      try {
-        const client = await getAdtClientV2();
-        const checkObjects: Array<{ uri: string; type: string; name: string }> =
-          [];
+type CheckServiceLike = Pick<CheckService, 'run'>;
 
-        // Mode 1: Package
-        if (options.package) {
-          console.log(`🔍 Resolving objects in package ${options.package}...`);
-          const pkgObjects = await resolvePackageObjects(
-            client,
-            options.package,
-          );
-          if (pkgObjects.length === 0) {
-            console.log(`⚠️ No objects found in package ${options.package}`);
-            return;
-          }
-          checkObjects.push(...pkgObjects);
-          console.log(`   Found ${checkObjects.length} object(s)`);
-        }
-        // Mode 2: Transport (fetch objects from transport tasks)
-        else if (options.transport) {
-          console.log(
-            `🔍 Resolving objects in transport ${options.transport}...`,
-          );
-          const trResponse = await client.services.transports.get(
-            options.transport,
-          );
-          // Walk the typed transport response to collect abap_object URIs.
-          // Schema shape (see transportmanagment.types.ts): deeply nested
-          // workbench/customizing → target → status → request[] → { task[]?,
-          // abap_object[]? } with `abap_object.uri`.
-          const collected = new Map<string, { type: string; name: string }>();
-          const visit = (node: unknown): void => {
-            if (!node || typeof node !== 'object') return;
-            if (Array.isArray(node)) {
-              for (const item of node) visit(item);
+export interface CheckCommandDependencies {
+  getClient(): Promise<AdtClient>;
+  createService(client: AdtClient): CheckServiceLike;
+  writeLine(line: string): void;
+  writeError(line: string): void;
+  setExitCode(code: number): void;
+}
+
+const defaultDependencies: CheckCommandDependencies = {
+  getClient: getAdtClientV2,
+  createService: (client) => new CheckService(client),
+  writeLine: (line) => console.log(line),
+  writeError: (line) => console.error(line),
+  setExitCode: (code) => {
+    process.exitCode = code;
+  },
+};
+
+export function createCheckCommand(
+  overrides: Partial<CheckCommandDependencies> = {},
+): Command {
+  const dependencies = { ...defaultDependencies, ...overrides };
+
+  return new Command('check')
+    .description('Run syntax check (checkruns) on ABAP objects')
+    .argument('[objects...]', 'Object name(s) to check')
+    .option('-p, --package <package>', 'Check all objects in a package')
+    .option(
+      '-t, --transport <transport>',
+      'Check all objects in a transport request',
+    )
+    .option(
+      '--type <type>',
+      'Object type hint for resolving URIs (e.g., CLAS, DOMA)',
+    )
+    .option(
+      '--source-version <version>',
+      'Source version to check: active, inactive, new',
+      DEFAULT_CHECK_SOURCE_VERSION,
+    )
+    .option('--json', 'Output results as JSON')
+    .action(
+      async (
+        objects: string[],
+        options: {
+          package?: string;
+          transport?: string;
+          type?: string;
+          sourceVersion?: CheckSourceVersion;
+          json?: boolean;
+        },
+      ) => {
+        try {
+          const client = await dependencies.getClient();
+          const checkObjects: Array<{
+            uri: string;
+            type: string;
+            name: string;
+          }> = [];
+
+          // Mode 1: Package
+          if (options.package) {
+            if (!options.json) {
+              dependencies.writeLine(
+                `🔍 Resolving objects in package ${options.package}...`,
+              );
+            }
+            const pkgObjects = await resolvePackageObjects(
+              client,
+              options.package,
+            );
+            if (pkgObjects.length === 0) {
+              dependencies.writeError(
+                `⚠️ No objects found in package ${options.package}`,
+              );
               return;
             }
-            const rec = node as Record<string, unknown>;
-            const uri = rec.uri;
-            const type = rec.type;
-            const name = rec.name;
-            // abap_object entries have pgmid/type/name/uri
-            if (
-              typeof uri === 'string' &&
-              typeof rec.pgmid === 'string' &&
-              typeof name === 'string'
-            ) {
-              collected.set(uri, {
-                type: typeof type === 'string' ? type : 'UNKNOWN',
-                name,
-              });
+            checkObjects.push(...pkgObjects);
+            if (!options.json) {
+              dependencies.writeLine(
+                `   Found ${checkObjects.length} object(s)`,
+              );
             }
-            for (const v of Object.values(rec)) visit(v);
-          };
-          visit(trResponse);
-
-          for (const [uri, meta] of collected) {
-            checkObjects.push({ uri, type: meta.type, name: meta.name });
           }
-          if (checkObjects.length === 0) {
-            console.log(
-              `⚠️ No objects found in transport ${options.transport}`,
+          // Mode 2: Transport (fetch objects from transport tasks)
+          else if (options.transport) {
+            if (!options.json) {
+              dependencies.writeLine(
+                `🔍 Resolving objects in transport ${options.transport}...`,
+              );
+            }
+            const trResponse = await client.services.transports.get(
+              options.transport,
             );
+            // Walk the typed transport response to collect abap_object URIs.
+            // Schema shape (see transportmanagment.types.ts): deeply nested
+            // workbench/customizing → target → status → request[] → { task[]?,
+            // abap_object[]? } with `abap_object.uri`.
+            const collected = new Map<string, { type: string; name: string }>();
+            const visit = (node: unknown): void => {
+              if (!node || typeof node !== 'object') return;
+              if (Array.isArray(node)) {
+                for (const item of node) visit(item);
+                return;
+              }
+              const rec = node as Record<string, unknown>;
+              const uri = rec.uri;
+              const type = rec.type;
+              const name = rec.name;
+              // abap_object entries have pgmid/type/name/uri
+              if (
+                typeof uri === 'string' &&
+                typeof rec.pgmid === 'string' &&
+                typeof name === 'string'
+              ) {
+                collected.set(uri, {
+                  type: typeof type === 'string' ? type : 'UNKNOWN',
+                  name,
+                });
+              }
+              for (const v of Object.values(rec)) visit(v);
+            };
+            visit(trResponse);
+
+            for (const [uri, meta] of collected) {
+              checkObjects.push({ uri, type: meta.type, name: meta.name });
+            }
+            if (checkObjects.length === 0) {
+              dependencies.writeError(
+                `⚠️ No objects found in transport ${options.transport}`,
+              );
+              return;
+            }
+            if (!options.json) {
+              dependencies.writeLine(
+                `   Found ${checkObjects.length} object(s)`,
+              );
+            }
+          }
+          // Mode 3: Individual objects
+          else if (objects.length > 0) {
+            if (!options.json) {
+              dependencies.writeLine(
+                `🔍 Resolving ${objects.length} object(s)...`,
+              );
+            }
+            for (const objectName of objects) {
+              try {
+                const resolved = await resolveObjectUri(
+                  client,
+                  objectName,
+                  options.type,
+                );
+                checkObjects.push(resolved);
+                if (!options.json) {
+                  dependencies.writeLine(
+                    `   📄 ${resolved.name} (${resolved.type}) → ${resolved.uri}`,
+                  );
+                }
+              } catch (err) {
+                dependencies.writeError(
+                  `   ❌ ${objectName}: ${err instanceof Error ? err.message : String(err)}`,
+                );
+              }
+            }
+          } else {
+            dependencies.writeError(
+              '❌ Specify object name(s), --package, or --transport',
+            );
+            dependencies.setExitCode(1);
             return;
           }
-          console.log(`   Found ${checkObjects.length} object(s)`);
-        }
-        // Mode 3: Individual objects
-        else if (objects.length > 0) {
-          console.log(`🔍 Resolving ${objects.length} object(s)...`);
-          for (const objectName of objects) {
-            try {
-              const resolved = await resolveObjectUri(
-                client,
-                objectName,
-                options.type,
-              );
-              checkObjects.push(resolved);
-              console.log(
-                `   📄 ${resolved.name} (${resolved.type}) → ${resolved.uri}`,
-              );
-            } catch (err) {
-              console.error(
-                `   ❌ ${objectName}: ${err instanceof Error ? err.message : String(err)}`,
-              );
-            }
+
+          if (checkObjects.length === 0) {
+            dependencies.writeError('❌ No objects to check');
+            dependencies.setExitCode(1);
+            return;
           }
-        } else {
-          console.error('❌ Specify object name(s), --package, or --transport');
-          process.exit(1);
-        }
 
-        if (checkObjects.length === 0) {
-          console.error('❌ No objects to check');
-          process.exit(1);
-        }
-
-        // Build and POST checkrun request via typed contract
-        const body = buildCheckObjectList(checkObjects, options.version);
-        console.log(
-          `\n🔄 Running syntax check on ${checkObjects.length} object(s)...`,
-        );
-
-        const response = await client.adt.checkruns.checkObjects.post(body);
-
-        // Extract reports from typed response
-        const { reports, hasErrors, hasWarnings } = extractReports(response);
-
-        if (options.json) {
-          console.log(JSON.stringify(reports, null, 2));
-        } else {
-          console.log(`\n📋 Check Results:`);
-          const totalMessages = displayResults(reports);
-
-          if (totalMessages === 0) {
-            console.log(
-              `\n✅ All ${checkObjects.length} object(s) passed syntax check`,
+          if (!options.json) {
+            dependencies.writeLine(
+              `\n🔄 Running syntax check on ${checkObjects.length} object(s)...`,
             );
+          }
+
+          const { reports, hasErrors, hasWarnings } = await dependencies
+            .createService(client)
+            .run({
+              objects: checkObjects.map(({ uri }) => ({ uri })),
+              sourceVersion: options.sourceVersion,
+            });
+
+          if (options.json) {
+            dependencies.writeLine(JSON.stringify(reports, null, 2));
+            if (hasErrors) dependencies.setExitCode(1);
           } else {
-            console.log(`\n📊 ${totalMessages} message(s) found`);
-            if (hasErrors) {
-              console.log('❌ Errors detected');
-              process.exit(1);
-            }
-            if (hasWarnings) {
-              console.log('⚠️ Warnings detected');
+            dependencies.writeLine(`\n📋 Check Results:`);
+            const totalMessages = displayResults(
+              reports,
+              dependencies.writeLine,
+            );
+
+            if (totalMessages === 0) {
+              dependencies.writeLine(
+                `\n✅ All ${checkObjects.length} object(s) passed syntax check`,
+              );
+            } else {
+              dependencies.writeLine(`\n📊 ${totalMessages} message(s) found`);
+              if (hasErrors) {
+                dependencies.writeLine('❌ Errors detected');
+                dependencies.setExitCode(1);
+              }
+              if (hasWarnings) {
+                dependencies.writeLine('⚠️ Warnings detected');
+              }
             }
           }
+        } catch (error) {
+          dependencies.writeError(
+            `❌ Check failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          dependencies.setExitCode(1);
         }
-      } catch (error) {
-        console.error(
-          '❌ Check failed:',
-          error instanceof Error ? error.message : String(error),
-        );
-        process.exit(1);
-      }
-    },
-  );
+      },
+    );
+}
+
+export const checkCommand = createCheckCommand();

--- a/packages/adt-cli/src/lib/commands/cts/tr/index.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/index.ts
@@ -23,6 +23,7 @@ import { ctsDeleteCommand } from './delete';
 import { ctsReleaseCommand } from './release';
 import { ctsReassignCommand } from './reassign';
 import { ctsSourceManifestCommand } from './source-manifest';
+import { createTaskCommand } from './task';
 
 export function createTrCommand(): Command {
   const trCmd = new Command('tr').description('Transport request operations');
@@ -36,6 +37,7 @@ export function createTrCommand(): Command {
   trCmd.addCommand(ctsReleaseCommand);
   trCmd.addCommand(ctsReassignCommand);
   trCmd.addCommand(ctsSourceManifestCommand);
+  trCmd.addCommand(createTaskCommand());
   // NOTE: ctsCheckCommand not yet implemented (check endpoint not available)
 
   return trCmd;

--- a/packages/adt-cli/src/lib/commands/cts/tr/reassign.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/reassign.ts
@@ -16,6 +16,19 @@ import { getAdtClientV2, getCliContext } from '../../../utils/adt-client-v2';
 import { createProgressReporter } from '../../../utils/progress-reporter';
 import { createCliLogger } from '../../../utils/logger-config';
 import { CtsTransportLifecycleService } from '../../../services/cts';
+import type { Logger } from '@abapify/logger';
+
+const writeLine = (line: string) => {
+  process.stdout.write(`${line}\n`);
+};
+
+const writeError = (line: string) => {
+  process.stderr.write(`${line}\n`);
+};
+
+interface CommandWithLogger extends Command {
+  logger?: Logger;
+}
 
 export const ctsReassignCommand = new Command('reassign')
   .description('Change the owner of a transport request')
@@ -28,7 +41,7 @@ export const ctsReassignCommand = new Command('reassign')
   )
   .option('--json', 'Output result as JSON')
   .action(async function (
-    this: Command,
+    this: CommandWithLogger,
     transport: string,
     newOwner: string,
     options: { recursive: boolean; json: boolean },
@@ -38,13 +51,14 @@ export const ctsReassignCommand = new Command('reassign')
     const verboseFlag = globalOpts.verbose ?? ctx.verbose ?? false;
     const compact = !verboseFlag;
     const logger =
-      (this as any).logger ??
-      ctx.logger ??
-      createCliLogger({ verbose: verboseFlag });
+      this.logger ?? ctx.logger ?? createCliLogger({ verbose: verboseFlag });
     const progress = createProgressReporter({ compact, logger });
 
     try {
-      const client = await getAdtClientV2();
+      const client = await getAdtClientV2({
+        logger,
+        enableLogging: true,
+      });
       const lifecycle = new CtsTransportLifecycleService(client);
 
       progress.step(`🔍 Getting transport ${transport}...`);
@@ -52,42 +66,48 @@ export const ctsReassignCommand = new Command('reassign')
       try {
         summary = await lifecycle.getTransport(transport);
       } catch (err) {
-        console.error(`❌ Transport ${transport} not found or not accessible`);
-        console.error(err instanceof Error ? err.message : String(err));
+        progress.done();
+        writeError(`❌ Transport ${transport} not found or not accessible`);
+        if (err instanceof Error) {
+          writeError(err.message);
+        }
         process.exit(1);
       }
       progress.done();
 
       // Check if already released
       if (summary.status === 'R') {
-        console.error(`❌ Transport ${transport} is already released`);
+        if (options.json) {
+          progress.clear();
+        }
+        writeError(`❌ Transport ${summary.transport} is already released`);
         process.exit(1);
       }
 
       progress.step(
-        `🔄 Reassigning ${transport} from ${summary.owner} to ${newOwner}${options.recursive ? ' (recursive)' : ''}...`,
+        `🔄 Reassigning ${summary.transport} from ${summary.owner} to ${newOwner}${options.recursive ? ' (recursive)' : ''}...`,
       );
       const result = await lifecycle.reassign({
-        transport,
+        transport: summary.transport,
         newOwner,
         recursive: options.recursive,
       });
       progress.done();
 
       if (options.json) {
-        console.log(JSON.stringify(result, null, 2));
+        writeLine(JSON.stringify(result, null, 2));
       } else {
-        console.log(`✅ Transport ${transport} reassigned successfully`);
-        console.log(`   Previous owner: ${result.previousOwner}`);
-        console.log(`   New owner:      ${result.newOwner}`);
+        writeLine(`✅ Transport ${result.transport} reassigned successfully`);
+        writeLine(`   Previous owner: ${result.previousOwner}`);
+        writeLine(`   New owner:      ${result.newOwner}`);
         if (result.recursive) {
-          console.log(`   Tasks: reassigned (modifiable tasks only)`);
+          writeLine(`   Tasks: reassigned (modifiable tasks only)`);
         }
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      progress.done(`❌ Reassign failed: ${message}`);
-      console.error('❌ Reassign failed:', message);
+      progress.done();
+      writeError(`❌ Reassign failed: ${message}`);
       process.exit(1);
     }
   });

--- a/packages/adt-cli/src/lib/commands/cts/tr/reassign.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/reassign.ts
@@ -15,7 +15,7 @@ import { Command } from 'commander';
 import { getAdtClientV2, getCliContext } from '../../../utils/adt-client-v2';
 import { createProgressReporter } from '../../../utils/progress-reporter';
 import { createCliLogger } from '../../../utils/logger-config';
-import { AdkTransportRequest } from '@abapify/adk';
+import { CtsTransportLifecycleService } from '../../../services/cts';
 
 export const ctsReassignCommand = new Command('reassign')
   .description('Change the owner of a transport request')
@@ -45,12 +45,12 @@ export const ctsReassignCommand = new Command('reassign')
 
     try {
       const client = await getAdtClientV2();
+      const lifecycle = new CtsTransportLifecycleService(client);
 
-      // Step 1: Get transport via ADK
       progress.step(`🔍 Getting transport ${transport}...`);
-      let tr: AdkTransportRequest;
+      let summary;
       try {
-        tr = await AdkTransportRequest.get(transport, { client });
+        summary = await lifecycle.getTransport(transport);
       } catch (err) {
         console.error(`❌ Transport ${transport} not found or not accessible`);
         console.error(err instanceof Error ? err.message : String(err));
@@ -59,39 +59,28 @@ export const ctsReassignCommand = new Command('reassign')
       progress.done();
 
       // Check if already released
-      if (tr.status === 'R') {
+      if (summary.status === 'R') {
         console.error(`❌ Transport ${transport} is already released`);
         process.exit(1);
       }
 
-      const previousOwner = tr.owner;
-
-      // Step 2: Reassign
       progress.step(
-        `🔄 Reassigning ${transport} from ${previousOwner} to ${newOwner}${options.recursive ? ' (recursive)' : ''}...`,
+        `🔄 Reassigning ${transport} from ${summary.owner} to ${newOwner}${options.recursive ? ' (recursive)' : ''}...`,
       );
-      await tr.reassign(newOwner, options.recursive);
+      const result = await lifecycle.reassign({
+        transport,
+        newOwner,
+        recursive: options.recursive,
+      });
       progress.done();
 
       if (options.json) {
-        console.log(
-          JSON.stringify(
-            {
-              transport,
-              previousOwner,
-              newOwner,
-              recursive: options.recursive,
-              status: 'reassigned',
-            },
-            null,
-            2,
-          ),
-        );
+        console.log(JSON.stringify(result, null, 2));
       } else {
         console.log(`✅ Transport ${transport} reassigned successfully`);
-        console.log(`   Previous owner: ${previousOwner}`);
-        console.log(`   New owner:      ${newOwner}`);
-        if (options.recursive) {
+        console.log(`   Previous owner: ${result.previousOwner}`);
+        console.log(`   New owner:      ${result.newOwner}`);
+        if (result.recursive) {
           console.log(`   Tasks: reassigned (modifiable tasks only)`);
         }
       }

--- a/packages/adt-cli/src/lib/commands/cts/tr/release.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/release.ts
@@ -16,6 +16,19 @@ import { getAdtClientV2, getCliContext } from '../../../utils/adt-client-v2';
 import { createProgressReporter } from '../../../utils/progress-reporter';
 import { createCliLogger } from '../../../utils/logger-config';
 import { CtsTransportLifecycleService } from '../../../services/cts';
+import type { Logger } from '@abapify/logger';
+
+const writeLine = (line: string) => {
+  process.stdout.write(`${line}\n`);
+};
+
+const writeError = (line: string) => {
+  process.stderr.write(`${line}\n`);
+};
+
+interface CommandWithLogger extends Command {
+  logger?: Logger;
+}
 
 export const ctsReleaseCommand = new Command('release')
   .description('Release transport request')
@@ -24,19 +37,20 @@ export const ctsReleaseCommand = new Command('release')
   .option('--release-all', 'Release all tasks first, then the transport')
   .option('-y, --yes', 'Skip confirmation prompt')
   .option('--json', 'Output result as JSON')
-  .action(async function (this: Command, transport: string, options) {
+  .action(async function (this: CommandWithLogger, transport: string, options) {
     const globalOpts = this.optsWithGlobals?.() ?? {};
     const ctx = getCliContext();
     const verboseFlag = globalOpts.verbose ?? ctx.verbose ?? false;
     const compact = !verboseFlag;
     const logger =
-      (this as any).logger ??
-      ctx.logger ??
-      createCliLogger({ verbose: verboseFlag });
+      this.logger ?? ctx.logger ?? createCliLogger({ verbose: verboseFlag });
     const progress = createProgressReporter({ compact, logger });
 
     try {
-      const client = await getAdtClientV2();
+      const client = await getAdtClientV2({
+        logger,
+        enableLogging: true,
+      });
       const lifecycle = new CtsTransportLifecycleService(client);
 
       progress.step(`🔍 Getting transport ${transport}...`);
@@ -44,7 +58,8 @@ export const ctsReleaseCommand = new Command('release')
       try {
         summary = await lifecycle.getTransport(transport);
       } catch (_err) {
-        console.error(`❌ Transport ${transport} not found or not accessible`);
+        progress.done();
+        writeError(`❌ Transport ${transport} not found or not accessible`);
         process.exit(1);
       }
 
@@ -52,70 +67,73 @@ export const ctsReleaseCommand = new Command('release')
 
       // Check if already released
       if (summary.status === 'R') {
-        console.log(`ℹ️  Transport ${transport} is already released`);
         if (options.json) {
-          console.log(
-            JSON.stringify({ transport, status: 'already_released' }, null, 2),
+          progress.clear();
+          writeLine(
+            JSON.stringify(
+              { transport: summary.transport, status: 'already_released' },
+              null,
+              2,
+            ),
           );
+        } else {
+          writeLine(`ℹ️  Transport ${summary.transport} is already released`);
         }
         return;
       }
 
       // Display transport info
       if (!options.json) {
-        console.log(`\n📋 Transport: ${summary.transport}`);
-        console.log(`   Description: ${summary.description || '-'}`);
-        console.log(`   Owner: ${summary.owner || '-'}`);
-        console.log(
+        writeLine(`\n📋 Transport: ${summary.transport}`);
+        writeLine(`   Description: ${summary.description || '-'}`);
+        writeLine(`   Owner: ${summary.owner || '-'}`);
+        writeLine(
           `   Target: ${summary.targetDescription || summary.target || 'LOCAL'}`,
         );
-        console.log(`   Status: ${summary.statusText}`);
-        console.log(`   Tasks: ${summary.taskCount}`);
-        console.log(`   Objects: ${summary.objectCount}`);
+        writeLine(`   Status: ${summary.statusText}`);
+        writeLine(`   Tasks: ${summary.taskCount}`);
+        writeLine(`   Objects: ${summary.objectCount}`);
       }
 
       // Step 2: Pre-release check (not yet implemented - check endpoint not available)
-      if (!options.skipCheck) {
-        // For now, just warn that checks are not implemented
-        if (!options.json) {
-          console.log(
-            '\n💡 Pre-release checks not yet implemented (use --skip-check to suppress)',
-          );
-        }
+      if (!options.skipCheck && !options.json) {
+        writeLine(
+          '\n💡 Pre-release checks not yet implemented (use --skip-check to suppress)',
+        );
       }
 
       // Step 3: Confirm release
       if (!options.yes && !options.json) {
         const shouldRelease = await confirm({
-          message: `Release transport ${transport}?`,
+          message: `Release transport ${summary.transport}?`,
           default: true,
         });
 
         if (!shouldRelease) {
-          console.log('\n❌ Release cancelled');
+          writeLine('\n❌ Release cancelled');
           process.exit(0);
         }
       }
 
-      progress.step(`🚀 Releasing transport ${transport}...`);
+      progress.step(`🚀 Releasing transport ${summary.transport}...`);
       const result = await lifecycle.release({
-        transport,
+        transport: summary.transport,
         releaseAll: options.releaseAll,
       });
       progress.done();
 
       if (options.json) {
-        console.log(JSON.stringify(result, null, 2));
+        writeLine(JSON.stringify(result, null, 2));
       } else {
-        console.log(`\n✅ Transport ${transport} released successfully!`);
-        console.log(
+        writeLine(`\n✅ Transport ${result.transport} released successfully!`);
+        writeLine(
           `   Target: ${summary.targetDescription || summary.target || 'LOCAL'}`,
         );
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      progress.done(`❌ Release failed: ${message}`);
-      console.error('❌ Release failed:', message);
+      progress.done();
+      writeError(`❌ Release failed: ${message}`);
       process.exit(1);
     }
   });

--- a/packages/adt-cli/src/lib/commands/cts/tr/release.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/release.ts
@@ -58,7 +58,7 @@ export const ctsReleaseCommand = new Command('release')
             JSON.stringify({ transport, status: 'already_released' }, null, 2),
           );
         }
-        process.exit(0);
+        return;
       }
 
       // Display transport info

--- a/packages/adt-cli/src/lib/commands/cts/tr/release.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/release.ts
@@ -15,7 +15,7 @@ import { confirm } from '@inquirer/prompts';
 import { getAdtClientV2, getCliContext } from '../../../utils/adt-client-v2';
 import { createProgressReporter } from '../../../utils/progress-reporter';
 import { createCliLogger } from '../../../utils/logger-config';
-import { AdkTransportRequest } from '@abapify/adk';
+import { CtsTransportLifecycleService } from '../../../services/cts';
 
 export const ctsReleaseCommand = new Command('release')
   .description('Release transport request')
@@ -37,14 +37,12 @@ export const ctsReleaseCommand = new Command('release')
 
     try {
       const client = await getAdtClientV2();
+      const lifecycle = new CtsTransportLifecycleService(client);
 
-      // Step 1: Get transport via ADK
       progress.step(`🔍 Getting transport ${transport}...`);
-      // ADK expects (number, ctx?) - ctx is AdkContext with client property
-
-      let tr: AdkTransportRequest;
+      let summary;
       try {
-        tr = await AdkTransportRequest.get(transport, { client });
+        summary = await lifecycle.getTransport(transport);
       } catch (_err) {
         console.error(`❌ Transport ${transport} not found or not accessible`);
         process.exit(1);
@@ -53,7 +51,7 @@ export const ctsReleaseCommand = new Command('release')
       progress.done();
 
       // Check if already released
-      if (tr.status === 'R') {
+      if (summary.status === 'R') {
         console.log(`ℹ️  Transport ${transport} is already released`);
         if (options.json) {
           console.log(
@@ -65,15 +63,15 @@ export const ctsReleaseCommand = new Command('release')
 
       // Display transport info
       if (!options.json) {
-        console.log(`\n📋 Transport: ${tr.number}`);
-        console.log(`   Description: ${tr.description || '-'}`);
-        console.log(`   Owner: ${tr.owner || '-'}`);
+        console.log(`\n📋 Transport: ${summary.transport}`);
+        console.log(`   Description: ${summary.description || '-'}`);
+        console.log(`   Owner: ${summary.owner || '-'}`);
         console.log(
-          `   Target: ${tr.targetDescription || tr.target || 'LOCAL'}`,
+          `   Target: ${summary.targetDescription || summary.target || 'LOCAL'}`,
         );
-        console.log(`   Status: ${tr.statusText}`);
-        console.log(`   Tasks: ${tr.tasks.length}`);
-        console.log(`   Objects: ${tr.objects.length}`);
+        console.log(`   Status: ${summary.statusText}`);
+        console.log(`   Tasks: ${summary.taskCount}`);
+        console.log(`   Objects: ${summary.objectCount}`);
       }
 
       // Step 2: Pre-release check (not yet implemented - check endpoint not available)
@@ -99,41 +97,19 @@ export const ctsReleaseCommand = new Command('release')
         }
       }
 
-      // Step 4: Release the transport using ADK
       progress.step(`🚀 Releasing transport ${transport}...`);
-
-      let result;
-      if (options.releaseAll) {
-        // Release all tasks first, then the transport
-        result = await tr.releaseAll();
-      } else {
-        // Release transport only (tasks must already be released)
-        result = await tr.release();
-      }
-
+      const result = await lifecycle.release({
+        transport,
+        releaseAll: options.releaseAll,
+      });
       progress.done();
 
-      if (!result.success) {
-        console.error(`❌ Release failed: ${result.message}`);
-        process.exit(1);
-      }
-
       if (options.json) {
-        console.log(
-          JSON.stringify(
-            {
-              transport,
-              status: 'released',
-              result,
-            },
-            null,
-            2,
-          ),
-        );
+        console.log(JSON.stringify(result, null, 2));
       } else {
         console.log(`\n✅ Transport ${transport} released successfully!`);
         console.log(
-          `   Target: ${tr.targetDescription || tr.target || 'LOCAL'}`,
+          `   Target: ${summary.targetDescription || summary.target || 'LOCAL'}`,
         );
       }
     } catch (error) {

--- a/packages/adt-cli/src/lib/commands/cts/tr/task/create.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/task/create.ts
@@ -1,0 +1,36 @@
+import { Command } from 'commander';
+import { getAdtClientV2 } from '../../../../utils/adt-client-v2';
+import { CtsTransportLifecycleService } from '../../../../services/cts';
+
+export const ctsTaskCreateCommand = new Command('create')
+  .description('Create a modifiable task under an existing transport request')
+  .argument('<transport>', 'Parent transport request number')
+  .argument('<owner>', 'SAP user who should own the new task')
+  .option('--json', 'Output result as JSON')
+  .action(
+    async (transport: string, owner: string, options: { json: boolean }) => {
+      try {
+        const client = await getAdtClientV2();
+        const result = await new CtsTransportLifecycleService(
+          client,
+        ).createTask({
+          transport: transport.toUpperCase(),
+          owner: owner.toUpperCase(),
+        });
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(
+            `✅ Task ${result.task} created under ${result.transport}`,
+          );
+          console.log(`   Owner: ${result.owner}`);
+        }
+      } catch (error) {
+        console.error(
+          '❌ Task creation failed:',
+          error instanceof Error ? error.message : String(error),
+        );
+        process.exit(1);
+      }
+    },
+  );

--- a/packages/adt-cli/src/lib/commands/cts/tr/task/create.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/task/create.ts
@@ -1,36 +1,62 @@
 import { Command } from 'commander';
-import { getAdtClientV2 } from '../../../../utils/adt-client-v2';
+import { getAdtClientV2, getCliContext } from '../../../../utils/adt-client-v2';
+import { createProgressReporter } from '../../../../utils/progress-reporter';
+import { createCliLogger } from '../../../../utils/logger-config';
 import { CtsTransportLifecycleService } from '../../../../services/cts';
+import type { Logger } from '@abapify/logger';
+
+const writeLine = (line: string) => {
+  process.stdout.write(`${line}\n`);
+};
+
+const writeError = (line: string) => {
+  process.stderr.write(`${line}\n`);
+};
+
+interface CommandWithLogger extends Command {
+  logger?: Logger;
+}
 
 export const ctsTaskCreateCommand = new Command('create')
   .description('Create a modifiable task under an existing transport request')
   .argument('<transport>', 'Parent transport request number')
   .argument('<owner>', 'SAP user who should own the new task')
   .option('--json', 'Output result as JSON')
-  .action(
-    async (transport: string, owner: string, options: { json: boolean }) => {
-      try {
-        const client = await getAdtClientV2();
-        const result = await new CtsTransportLifecycleService(
-          client,
-        ).createTask({
-          transport: transport.toUpperCase(),
-          owner: owner.toUpperCase(),
-        });
-        if (options.json) {
-          console.log(JSON.stringify(result, null, 2));
-        } else {
-          console.log(
-            `✅ Task ${result.task} created under ${result.transport}`,
-          );
-          console.log(`   Owner: ${result.owner}`);
-        }
-      } catch (error) {
-        console.error(
-          '❌ Task creation failed:',
-          error instanceof Error ? error.message : String(error),
-        );
-        process.exit(1);
+  .action(async function (
+    this: CommandWithLogger,
+    transport: string,
+    owner: string,
+    options: { json: boolean },
+  ) {
+    const globalOpts = this.optsWithGlobals?.() ?? {};
+    const ctx = getCliContext();
+    const verboseFlag = globalOpts.verbose ?? ctx.verbose ?? false;
+    const compact = !verboseFlag;
+    const logger =
+      this.logger ?? ctx.logger ?? createCliLogger({ verbose: verboseFlag });
+    const progress = createProgressReporter({ compact, logger });
+
+    try {
+      const client = await getAdtClientV2({
+        logger,
+        enableLogging: true,
+      });
+      const result = await new CtsTransportLifecycleService(client).createTask({
+        transport,
+        owner,
+      });
+
+      if (options.json) {
+        writeLine(JSON.stringify(result, null, 2));
+      } else {
+        writeLine(`✅ Task ${result.task} created under ${result.transport}`);
+        writeLine(`   Owner: ${result.owner}`);
       }
-    },
-  );
+    } catch (error) {
+      writeError(
+        `❌ Task creation failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      progress.done();
+      process.exit(1);
+    }
+  });

--- a/packages/adt-cli/src/lib/commands/cts/tr/task/index.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/task/index.ts
@@ -1,0 +1,8 @@
+import { Command } from 'commander';
+import { ctsTaskCreateCommand } from './create';
+
+export function createTaskCommand(): Command {
+  const task = new Command('task').description('Transport task operations');
+  task.addCommand(ctsTaskCreateCommand);
+  return task;
+}

--- a/packages/adt-cli/src/lib/commands/function/module.ts
+++ b/packages/adt-cli/src/lib/commands/function/module.ts
@@ -18,6 +18,7 @@
 import { Command } from 'commander';
 import { readFileSync } from 'node:fs';
 import { AdkFunctionModule } from '@abapify/adk';
+import { resolveLockCorrelation } from '@abapify/adt-locks';
 import { getAdtClientV2, getCliContext } from '../../utils/adt-client-v2';
 import { createProgressReporter } from '../../utils/progress-reporter';
 import { createCliLogger } from '../../utils/logger-config';
@@ -229,6 +230,10 @@ functionModuleCommand.addCommand(
         progress.step(`🔒 Locking ${name.toUpperCase()}...`);
         const lockHandle = await fm.lock(options.transport);
         progress.done();
+        const effectiveTransport = resolveLockCorrelation(
+          lockHandle,
+          options.transport,
+        );
 
         try {
           progress.step(`💾 Writing source to ${name.toUpperCase()}...`);
@@ -237,19 +242,19 @@ functionModuleCommand.addCommand(
             fm.name,
             {
               lockHandle: lockHandle.handle,
-              ...(options.transport ? { corrNr: options.transport } : {}),
+              ...(effectiveTransport ? { corrNr: effectiveTransport } : {}),
             },
             source,
           );
           progress.done();
-
-          if (options.activate) {
-            progress.step(`⚡ Activating ${name.toUpperCase()}...`);
-            await fm.activate();
-            progress.done();
-          }
         } finally {
           await fm.unlock();
+        }
+
+        if (options.activate) {
+          progress.step(`⚡ Activating ${name.toUpperCase()}...`);
+          await fm.activate();
+          progress.done();
         }
 
         console.log(

--- a/packages/adt-cli/src/lib/commands/object/builder.test.ts
+++ b/packages/adt-cli/src/lib/commands/object/builder.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from 'vitest';
-import { resolveEffectiveTransport } from './builder';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createWithReadbackRecovery,
+  persistSourceWithReleasedLock,
+  resolveEffectiveTransport,
+} from './builder';
 
 describe('resolveEffectiveTransport', () => {
   it('uses the authoritative correlation number returned by SAP LOCK', () => {
@@ -15,5 +19,182 @@ describe('resolveEffectiveTransport', () => {
     expect(resolveEffectiveTransport({ handle: 'lock-1' }, 'DEVK900002')).toBe(
       'DEVK900002',
     );
+  });
+});
+
+describe('persistSourceWithReleasedLock', () => {
+  it('unlocks before activating the saved source', async () => {
+    const calls: string[] = [];
+    const object = {
+      saveMainSource: vi.fn(async () => {
+        calls.push('save');
+      }),
+      unlock: vi.fn(async () => {
+        calls.push('unlock');
+      }),
+      activate: vi.fn(async () => {
+        calls.push('activate');
+      }),
+    };
+
+    await persistSourceWithReleasedLock(object, 'CLASS source', {
+      lockHandle: { handle: 'lock-1', correlationNumber: 'DEVK900001' },
+      requestedTransport: 'DEVK900002',
+      activate: true,
+    });
+
+    expect(calls).toEqual(['save', 'unlock', 'activate']);
+    expect(object.saveMainSource).toHaveBeenCalledWith('CLASS source', {
+      lockHandle: 'lock-1',
+      transport: 'DEVK900001',
+    });
+  });
+
+  it('always unlocks and never activates after a failed save', async () => {
+    const calls: string[] = [];
+    const object = {
+      saveMainSource: vi.fn(async () => {
+        calls.push('save');
+        throw new Error('write failed');
+      }),
+      unlock: vi.fn(async () => {
+        calls.push('unlock');
+      }),
+      activate: vi.fn(async () => {
+        calls.push('activate');
+      }),
+    };
+
+    await expect(
+      persistSourceWithReleasedLock(object, 'CLASS source', {
+        lockHandle: { handle: 'lock-1' },
+        requestedTransport: 'DEVK900002',
+        activate: true,
+      }),
+    ).rejects.toThrow('write failed');
+
+    expect(calls).toEqual(['save', 'unlock']);
+  });
+
+  it('preserves both the save and unlock failures', async () => {
+    const saveError = new Error('write failed');
+    const unlockError = new Error('unlock failed');
+    const object = {
+      saveMainSource: vi.fn(async () => {
+        throw saveError;
+      }),
+      unlock: vi.fn(async () => {
+        throw unlockError;
+      }),
+      activate: vi.fn(),
+    };
+
+    const failure = await persistSourceWithReleasedLock(object, 'source', {
+      lockHandle: { handle: 'lock-1' },
+      requestedTransport: 'DEVK900002',
+      activate: true,
+    }).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(AggregateError);
+    expect((failure as AggregateError).errors).toEqual([
+      saveError,
+      unlockError,
+    ]);
+    expect(object.activate).not.toHaveBeenCalled();
+  });
+});
+
+describe('createWithReadbackRecovery', () => {
+  it('recovers an object confirmed after an ambiguous server failure', async () => {
+    const recovered = {
+      name: 'ZCL_NEW',
+      description: 'New class',
+      package: 'ZPACKAGE',
+    };
+    const definition = {
+      create: vi.fn(async () => {
+        throw Object.assign(new Error('HTTP 500: Internal Server Error'), {
+          status: 500,
+        });
+      }),
+      get: vi.fn(async () => recovered),
+    };
+
+    await expect(
+      createWithReadbackRecovery(
+        definition,
+        'ZCL_NEW',
+        'New class',
+        'ZPACKAGE',
+        'DEVK900001',
+      ),
+    ).resolves.toEqual({ object: recovered, recovered: true });
+  });
+
+  it('does not mask a client failure or mismatching read-back', async () => {
+    const clientError = Object.assign(new Error('HTTP 403: Forbidden'), {
+      status: 403,
+    });
+    const clientFailure = {
+      create: vi.fn(async () => {
+        throw clientError;
+      }),
+      get: vi.fn(),
+    };
+
+    await expect(
+      createWithReadbackRecovery(
+        clientFailure,
+        'ZCL_NEW',
+        'New class',
+        'ZPACKAGE',
+      ),
+    ).rejects.toBe(clientError);
+    expect(clientFailure.get).not.toHaveBeenCalled();
+
+    const serverError = Object.assign(
+      new Error('HTTP 500: Internal Server Error'),
+      { status: 500 },
+    );
+    const mismatch = {
+      create: vi.fn(async () => {
+        throw serverError;
+      }),
+      get: vi.fn(async () => ({
+        name: 'ZCL_NEW',
+        description: 'Someone else',
+        package: 'ZPACKAGE',
+      })),
+    };
+
+    await expect(
+      createWithReadbackRecovery(mismatch, 'ZCL_NEW', 'New class', 'ZPACKAGE'),
+    ).rejects.toBe(serverError);
+  });
+
+  it('does not recover an object from a different package', async () => {
+    const serverError = Object.assign(
+      new Error('HTTP 500: Internal Server Error'),
+      { status: 500 },
+    );
+    const definition = {
+      create: vi.fn(async () => {
+        throw serverError;
+      }),
+      get: vi.fn(async () => ({
+        name: 'ZCL_NEW',
+        description: 'New class',
+        package: 'ZOTHER',
+      })),
+    };
+
+    await expect(
+      createWithReadbackRecovery(
+        definition,
+        'ZCL_NEW',
+        'New class',
+        'ZPACKAGE',
+      ),
+    ).rejects.toBe(serverError);
   });
 });

--- a/packages/adt-cli/src/lib/commands/object/builder.test.ts
+++ b/packages/adt-cli/src/lib/commands/object/builder.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { resolveEffectiveTransport } from './builder';
+
+describe('resolveEffectiveTransport', () => {
+  it('uses the authoritative correlation number returned by SAP LOCK', () => {
+    expect(
+      resolveEffectiveTransport(
+        { handle: 'lock-1', correlationNumber: 'DEVK900001' },
+        'DEVK900002',
+      ),
+    ).toBe('DEVK900001');
+  });
+
+  it('falls back to the caller transport when LOCK omits correlation data', () => {
+    expect(resolveEffectiveTransport({ handle: 'lock-1' }, 'DEVK900002')).toBe(
+      'DEVK900002',
+    );
+  });
+});

--- a/packages/adt-cli/src/lib/commands/object/builder.ts
+++ b/packages/adt-cli/src/lib/commands/object/builder.ts
@@ -52,6 +52,22 @@ export interface ObjectTypeDef<T> {
   getSource?: (obj: T) => Promise<string>;
 }
 
+interface ObjectLockHandle {
+  handle: string;
+  correlationNumber?: string;
+}
+
+/**
+ * SAP may normalize a concrete task to its parent request during LOCK.
+ * Source writes must use the returned correlation number with the lock handle.
+ */
+export function resolveEffectiveTransport(
+  lockHandle: ObjectLockHandle,
+  requestedTransport?: string,
+): string | undefined {
+  return lockHandle.correlationNumber || requestedTransport;
+}
+
 // ============================================================================
 // Helper: read source from file or stdin
 // ============================================================================
@@ -84,7 +100,7 @@ export function buildObjectCrudCommands<
     name: string;
     description: string;
     activate(): Promise<T>;
-    lock(transport?: string): Promise<{ handle: string }>;
+    lock(transport?: string): Promise<ObjectLockHandle>;
     unlock(lockHandle: string): Promise<void>;
     saveMainSource?(
       source: string,
@@ -302,7 +318,10 @@ export function buildObjectCrudCommands<
               }
               await obj.saveMainSource(source, {
                 lockHandle: lockHandle.handle,
-                transport: options.transport,
+                transport: resolveEffectiveTransport(
+                  lockHandle,
+                  options.transport,
+                ),
               });
               progress.done();
 

--- a/packages/adt-cli/src/lib/commands/object/builder.ts
+++ b/packages/adt-cli/src/lib/commands/object/builder.ts
@@ -17,6 +17,7 @@ import { readFileSync } from 'node:fs';
 import { getAdtClientV2, getCliContext } from '../../utils/adt-client-v2';
 import { createProgressReporter } from '../../utils/progress-reporter';
 import { createCliLogger } from '../../utils/logger-config';
+import { resolveLockCorrelation } from '@abapify/adt-locks';
 
 // ============================================================================
 // Types
@@ -52,6 +53,72 @@ export interface ObjectTypeDef<T> {
   getSource?: (obj: T) => Promise<string>;
 }
 
+interface CreateReadbackOperations<
+  T extends { name: string; description: string; package: string },
+> {
+  create(
+    name: string,
+    description: string,
+    packageName: string,
+    options?: { transport?: string },
+  ): Promise<T>;
+  get(name: string): Promise<T>;
+}
+
+function isAmbiguousCreateFailure(error: unknown): boolean {
+  const status =
+    typeof error === 'object' && error !== null
+      ? (error as { status?: unknown }).status
+      : undefined;
+  if (typeof status === 'number' && status >= 500) return true;
+  return error instanceof Error && error.name === 'AdkPostCreateLockError';
+}
+
+/**
+ * Reconcile a POST whose response failed after SAP may already have committed.
+ * Only an exact name/description/package read-back is accepted as recovery.
+ */
+export async function createWithReadbackRecovery<
+  T extends { name: string; description: string; package: string },
+>(
+  operations: CreateReadbackOperations<T>,
+  name: string,
+  description: string,
+  packageName: string,
+  transport?: string,
+): Promise<{ object: T; recovered: boolean }> {
+  const normalizedName = name.toUpperCase();
+  const normalizedPackage = packageName.toUpperCase();
+  try {
+    return {
+      object: await operations.create(
+        normalizedName,
+        description,
+        normalizedPackage,
+        transport ? { transport } : undefined,
+      ),
+      recovered: false,
+    };
+  } catch (error) {
+    if (!isAmbiguousCreateFailure(error)) throw error;
+
+    let recovered: T;
+    try {
+      recovered = await operations.get(normalizedName);
+    } catch {
+      throw error;
+    }
+
+    const matches =
+      recovered.name.toUpperCase() === normalizedName &&
+      recovered.description.trim() === description.trim() &&
+      recovered.package.toUpperCase() === normalizedPackage;
+    if (!matches) throw error;
+
+    return { object: recovered, recovered: true };
+  }
+}
+
 interface ObjectLockHandle {
   handle: string;
   correlationNumber?: string;
@@ -65,7 +132,62 @@ export function resolveEffectiveTransport(
   lockHandle: ObjectLockHandle,
   requestedTransport?: string,
 ): string | undefined {
-  return lockHandle.correlationNumber || requestedTransport;
+  return resolveLockCorrelation(lockHandle, requestedTransport);
+}
+
+interface SourceLifecycleObject<T = unknown> {
+  saveMainSource(
+    source: string,
+    options?: { lockHandle?: string; transport?: string },
+  ): Promise<void>;
+  unlock(lockHandle: string): Promise<void>;
+  activate(): Promise<T>;
+}
+
+interface PersistSourceOptions {
+  lockHandle: ObjectLockHandle;
+  requestedTransport?: string;
+  activate: boolean;
+  beforeActivate?: () => void;
+}
+
+/** Save under the editor lock, release it, and only then activate. */
+export async function persistSourceWithReleasedLock<T>(
+  object: SourceLifecycleObject<T>,
+  source: string,
+  options: PersistSourceOptions,
+): Promise<void> {
+  let saveError: unknown;
+  try {
+    await object.saveMainSource(source, {
+      lockHandle: options.lockHandle.handle,
+      transport: resolveEffectiveTransport(
+        options.lockHandle,
+        options.requestedTransport,
+      ),
+    });
+  } catch (error) {
+    saveError = error;
+  }
+
+  try {
+    await object.unlock(options.lockHandle.handle);
+  } catch (unlockError) {
+    if (saveError) {
+      throw new AggregateError(
+        [saveError, unlockError],
+        'Source write and lock release both failed',
+        { cause: unlockError },
+      );
+    }
+    throw unlockError;
+  }
+  if (saveError) throw saveError;
+
+  if (options.activate) {
+    options.beforeActivate?.();
+    await object.activate();
+  }
 }
 
 // ============================================================================
@@ -99,6 +221,7 @@ export function buildObjectCrudCommands<
   T extends {
     name: string;
     description: string;
+    package: string;
     activate(): Promise<T>;
     lock(transport?: string): Promise<ObjectLockHandle>;
     unlock(lockHandle: string): Promise<void>;
@@ -175,11 +298,12 @@ export function buildObjectCrudCommands<
           }
 
           progress.step(`📝 Creating ${def.label} ${name.toUpperCase()}...`);
-          const obj = await def.create(
+          const { object: obj, recovered } = await createWithReadbackRecovery(
+            def,
             name,
             description,
             pkg,
-            options.transport ? { transport: options.transport } : undefined,
+            options.transport,
           );
           progress.done();
 
@@ -190,6 +314,7 @@ export function buildObjectCrudCommands<
                   name: obj.name,
                   description: obj.description,
                   status: 'created',
+                  ...(recovered ? { recovered: true } : {}),
                 },
                 null,
                 2,
@@ -198,6 +323,11 @@ export function buildObjectCrudCommands<
           } else {
             console.log(`✅ ${def.label} ${obj.name} created`);
             console.log(`   Description: ${obj.description}`);
+            if (recovered) {
+              console.log(
+                '   Confirmed by read-back after an ambiguous response',
+              );
+            }
           }
         } catch (error) {
           const message =
@@ -307,32 +437,25 @@ export function buildObjectCrudCommands<
             const obj = await def.get(name.toUpperCase());
             progress.done();
 
+            if (!obj.saveMainSource) {
+              throw new Error(`${def.label} does not support source writes`);
+            }
+
             progress.step(`🔒 Locking ${name.toUpperCase()}...`);
             const lockHandle = await obj.lock(options.transport);
             progress.done();
 
-            try {
-              progress.step(`💾 Writing source to ${name.toUpperCase()}...`);
-              if (!obj.saveMainSource) {
-                throw new Error(`${def.label} does not support source writes`);
-              }
-              await obj.saveMainSource(source, {
-                lockHandle: lockHandle.handle,
-                transport: resolveEffectiveTransport(
-                  lockHandle,
-                  options.transport,
-                ),
-              });
-              progress.done();
-
-              if (options.activate) {
-                progress.step(`⚡ Activating ${name.toUpperCase()}...`);
-                await obj.activate();
+            progress.step(`💾 Writing source to ${name.toUpperCase()}...`);
+            await persistSourceWithReleasedLock(obj, source, {
+              lockHandle,
+              requestedTransport: options.transport,
+              activate: options.activate,
+              beforeActivate: () => {
                 progress.done();
-              }
-            } finally {
-              await obj.unlock(lockHandle.handle);
-            }
+                progress.step(`⚡ Activating ${name.toUpperCase()}...`);
+              },
+            });
+            progress.done();
 
             console.log(
               `✅ ${def.label} ${obj.name} written${options.activate ? ' and activated' : ''}`,

--- a/packages/adt-cli/src/lib/commands/source.ts
+++ b/packages/adt-cli/src/lib/commands/source.ts
@@ -18,7 +18,7 @@ import {
   toMetadataOnlySourceVersionListing,
   type ListObjectVersionsResult,
 } from '../services/source-history';
-import { createLockService } from '@abapify/adt-locks';
+import { createLockService, resolveLockCorrelation } from '@abapify/adt-locks';
 import { getObjectUri } from '@abapify/adk';
 import {
   detectMethodBoundary,
@@ -435,6 +435,10 @@ const putSourceCommand = new Command('put')
           objectName,
         });
         lockHandle = lock.handle;
+        const effectiveTransport = resolveLockCorrelation(
+          lock,
+          options.transport,
+        );
 
         try {
           if (!options.json) console.log(`🔄 Writing source to ${uri}...`);
@@ -445,7 +449,7 @@ const putSourceCommand = new Command('put')
               contract.objectName,
               {
                 lockHandle,
-                ...(options.transport ? { corrNr: options.transport } : {}),
+                ...(effectiveTransport ? { corrNr: effectiveTransport } : {}),
               },
               sourceToWrite,
             );
@@ -453,7 +457,7 @@ const putSourceCommand = new Command('put')
             // TODO: generic fallback — remove once all object types have
             // typed source contracts.
             const params = new URLSearchParams({ lockHandle });
-            if (options.transport) params.set('corrNr', options.transport);
+            if (effectiveTransport) params.set('corrNr', effectiveTransport);
             await client.fetch(`${uri}/source/main?${params.toString()}`, {
               method: 'PUT',
               headers: { 'Content-Type': 'text/plain' },

--- a/packages/adt-cli/src/lib/services/changeset/service.ts
+++ b/packages/adt-cli/src/lib/services/changeset/service.ts
@@ -40,17 +40,18 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { createLockService, type LockService } from '@abapify/adt-locks';
+import {
+  createLockService,
+  resolveLockCorrelation,
+  type LockService,
+} from '@abapify/adt-locks';
 import type { AdtClient } from '@abapify/adt-client';
 import type { Logger } from '@abapify/adt-client';
 import type { InferTypedSchema } from '@abapify/adt-schemas';
 import { adtcore } from '@abapify/adt-schemas';
 
 export type ChangesetStatus =
-  | 'open'
-  | 'committing'
-  | 'committed'
-  | 'rolled_back';
+  'open' | 'committing' | 'committed' | 'rolled_back';
 
 export interface ChangesetEntry {
   objectUri: string;
@@ -137,11 +138,12 @@ export class ChangesetService {
       objectName: args.objectName,
       objectType: args.objectType,
     });
+    const effectiveTransport = resolveLockCorrelation(lock, args.transport);
 
     try {
       const params = new URLSearchParams();
       params.set('lockHandle', lock.handle);
-      if (args.transport) params.set('corrNr', args.transport);
+      if (effectiveTransport) params.set('corrNr', effectiveTransport);
       await this.client.fetch(
         `${args.objectUri}/source/main?${params.toString()}`,
         {

--- a/packages/adt-cli/src/lib/services/check/service.test.ts
+++ b/packages/adt-cli/src/lib/services/check/service.test.ts
@@ -1,0 +1,67 @@
+import type { AdtClient } from '@abapify/adt-client';
+import { describe, expect, it, vi } from 'vitest';
+import { CheckService } from './service';
+
+function createClient(response: unknown): {
+  client: AdtClient;
+  post: ReturnType<typeof vi.fn>;
+} {
+  const post = vi.fn(async () => response);
+  return {
+    client: {
+      adt: { checkruns: { checkObjects: { post } } },
+    } as unknown as AdtClient,
+    post,
+  };
+}
+
+describe('CheckService', () => {
+  it('checks inactive source by default', async () => {
+    const { client, post } = createClient({
+      checkRunReports: { checkReport: [] },
+    });
+
+    await new CheckService(client).run({
+      objects: [{ uri: '/sap/bc/adt/oo/classes/zcl_test' }],
+    });
+
+    expect(post).toHaveBeenCalledWith({
+      checkObjectList: {
+        checkObject: [
+          {
+            uri: '/sap/bc/adt/oo/classes/zcl_test',
+            version: 'inactive',
+          },
+        ],
+      },
+    });
+  });
+
+  it('reports SAP error messages as errors', async () => {
+    const { client } = createClient({
+      checkRunReports: {
+        checkReport: [
+          {
+            triggeringUri: '/sap/bc/adt/oo/classes/zcl_test',
+            checkMessageList: {
+              checkMessage: [
+                { type: 'E', shortText: 'Method implementation is missing' },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await new CheckService(client).run({
+      objects: [{ uri: '/sap/bc/adt/oo/classes/zcl_test' }],
+      sourceVersion: 'active',
+    });
+
+    expect(result.hasErrors).toBe(true);
+    expect(result.hasWarnings).toBe(false);
+    expect(result.reports[0]?.checkMessageList?.checkMessage).toEqual([
+      { type: 'E', shortText: 'Method implementation is missing' },
+    ]);
+  });
+});

--- a/packages/adt-cli/src/lib/services/check/service.ts
+++ b/packages/adt-cli/src/lib/services/check/service.ts
@@ -54,6 +54,46 @@ function buildCheckObjectList(
   };
 }
 
+function normalizeCheckMessages(
+  rawMessages: unknown,
+): CheckMessage[] | undefined {
+  if (!rawMessages) return undefined;
+  return Array.isArray(rawMessages)
+    ? rawMessages
+    : [rawMessages as CheckMessage];
+}
+
+function normalizeReport(entry: unknown): CheckReport {
+  const report = (entry ?? {}) as Record<string, unknown>;
+  const messageList = report.checkMessageList as
+    { checkMessage?: CheckMessage | CheckMessage[] } | undefined;
+  const messages = normalizeCheckMessages(messageList?.checkMessage);
+
+  return {
+    reporter: report.reporter as string | undefined,
+    triggeringUri: report.triggeringUri as string | undefined,
+    status: report.status as string | undefined,
+    statusText: report.statusText as string | undefined,
+    checkMessageList: messages ? { checkMessage: messages } : undefined,
+  };
+}
+
+function detectSeverities(
+  reports: CheckReport[],
+): Pick<CheckResult, 'hasErrors' | 'hasWarnings'> {
+  let hasErrors = false;
+  let hasWarnings = false;
+  for (const report of reports) {
+    for (const message of report.checkMessageList?.checkMessage ?? []) {
+      const severity =
+        typeof message.type === 'string' ? message.type : message.category;
+      if (severity === 'E' || severity === 'A') hasErrors = true;
+      if (severity === 'W') hasWarnings = true;
+    }
+  }
+  return { hasErrors, hasWarnings };
+}
+
 function extractReports(response: unknown): CheckResult {
   const root = (response ?? {}) as Record<string, unknown>;
   const reportsBlock = (root.checkRunReports ?? root) as Record<
@@ -67,38 +107,8 @@ function extractReports(response: unknown): CheckResult {
       ? [rawReports]
       : [];
 
-  const reports: CheckReport[] = reportEntries.map((entry) => {
-    const report = entry as Record<string, unknown>;
-    const messageList = report.checkMessageList as
-      { checkMessage?: CheckMessage | CheckMessage[] } | undefined;
-    const rawMessages = messageList?.checkMessage;
-    const messages = rawMessages
-      ? Array.isArray(rawMessages)
-        ? rawMessages
-        : [rawMessages]
-      : undefined;
-
-    return {
-      reporter: report.reporter as string | undefined,
-      triggeringUri: report.triggeringUri as string | undefined,
-      status: report.status as string | undefined,
-      statusText: report.statusText as string | undefined,
-      checkMessageList: messages ? { checkMessage: messages } : undefined,
-    };
-  });
-
-  let hasErrors = false;
-  let hasWarnings = false;
-  for (const report of reports) {
-    for (const message of report.checkMessageList?.checkMessage ?? []) {
-      const severity =
-        typeof message.type === 'string' ? message.type : message.category;
-      if (severity === 'E' || severity === 'A') hasErrors = true;
-      if (severity === 'W') hasWarnings = true;
-    }
-  }
-
-  return { reports, hasErrors, hasWarnings };
+  const reports = reportEntries.map(normalizeReport);
+  return { reports, ...detectSeverities(reports) };
 }
 
 export class CheckService {

--- a/packages/adt-cli/src/lib/services/check/service.ts
+++ b/packages/adt-cli/src/lib/services/check/service.ts
@@ -1,0 +1,120 @@
+import type { AdtClient } from '@abapify/adt-client';
+
+export const DEFAULT_CHECK_SOURCE_VERSION = 'inactive';
+
+export type CheckSourceVersion =
+  | ''
+  | 'active'
+  | 'inactive'
+  | 'workingArea'
+  | 'new'
+  | 'partlyActive'
+  | 'activeWithInactiveVersion';
+
+export type CheckMessage = {
+  uri?: string;
+  type?: unknown;
+  shortText?: string;
+  category?: string;
+  code?: string;
+};
+
+export type CheckReport = {
+  checkMessageList?: {
+    checkMessage?: CheckMessage[];
+  };
+  reporter?: string;
+  triggeringUri?: string;
+  status?: string;
+  statusText?: string;
+};
+
+export interface CheckServiceInput {
+  objects: Array<{ uri: string }>;
+  sourceVersion?: CheckSourceVersion;
+}
+
+export interface CheckResult {
+  reports: CheckReport[];
+  hasErrors: boolean;
+  hasWarnings: boolean;
+}
+
+function buildCheckObjectList(
+  objects: Array<{ uri: string }>,
+  sourceVersion: CheckSourceVersion,
+) {
+  return {
+    checkObjectList: {
+      checkObject: objects.map((object) => ({
+        uri: object.uri,
+        version: sourceVersion,
+      })),
+    },
+  };
+}
+
+function extractReports(response: unknown): CheckResult {
+  const root = (response ?? {}) as Record<string, unknown>;
+  const reportsBlock = (root.checkRunReports ?? root) as Record<
+    string,
+    unknown
+  >;
+  const rawReports = reportsBlock.checkReport;
+  const reportEntries = Array.isArray(rawReports)
+    ? rawReports
+    : rawReports
+      ? [rawReports]
+      : [];
+
+  const reports: CheckReport[] = reportEntries.map((entry) => {
+    const report = entry as Record<string, unknown>;
+    const messageList = report.checkMessageList as
+      { checkMessage?: CheckMessage | CheckMessage[] } | undefined;
+    const rawMessages = messageList?.checkMessage;
+    const messages = rawMessages
+      ? Array.isArray(rawMessages)
+        ? rawMessages
+        : [rawMessages]
+      : undefined;
+
+    return {
+      reporter: report.reporter as string | undefined,
+      triggeringUri: report.triggeringUri as string | undefined,
+      status: report.status as string | undefined,
+      statusText: report.statusText as string | undefined,
+      checkMessageList: messages ? { checkMessage: messages } : undefined,
+    };
+  });
+
+  let hasErrors = false;
+  let hasWarnings = false;
+  for (const report of reports) {
+    for (const message of report.checkMessageList?.checkMessage ?? []) {
+      const severity =
+        typeof message.type === 'string' ? message.type : message.category;
+      if (severity === 'E' || severity === 'A') hasErrors = true;
+      if (severity === 'W') hasWarnings = true;
+    }
+  }
+
+  return { reports, hasErrors, hasWarnings };
+}
+
+export class CheckService {
+  constructor(private readonly client: AdtClient) {}
+
+  async run(input: CheckServiceInput): Promise<CheckResult> {
+    const sourceVersion = input.sourceVersion ?? DEFAULT_CHECK_SOURCE_VERSION;
+    const body = buildCheckObjectList(input.objects, sourceVersion);
+    const endpoint = this.client.adt.checkruns.checkObjects;
+    // The runtime endpoint accepts the schema body, while the generated
+    // contract currently exposes the descriptor factory's zero-argument
+    // signature. Keep that typing mismatch isolated at this boundary.
+    const post = endpoint.post as unknown as (
+      request: typeof body,
+    ) => Promise<unknown>;
+    const response = await post.call(endpoint, body);
+    return extractReports(response);
+  }
+}

--- a/packages/adt-cli/src/lib/services/cts/index.ts
+++ b/packages/adt-cli/src/lib/services/cts/index.ts
@@ -2,6 +2,8 @@ export {
   CtsTransportLifecycleService,
   type CtsTransportLifecycleOperations,
   type CtsTransportSummary,
+  type CreateTaskInput,
+  type CreateTaskResult,
   type ReassignTransportInput,
   type ReassignTransportResult,
   type ReleaseTransportInput,

--- a/packages/adt-cli/src/lib/services/cts/index.ts
+++ b/packages/adt-cli/src/lib/services/cts/index.ts
@@ -1,0 +1,9 @@
+export {
+  CtsTransportLifecycleService,
+  type CtsTransportLifecycleOperations,
+  type CtsTransportSummary,
+  type ReassignTransportInput,
+  type ReassignTransportResult,
+  type ReleaseTransportInput,
+  type ReleaseTransportResult,
+} from './transport-lifecycle';

--- a/packages/adt-cli/src/lib/services/cts/transport-lifecycle.test.ts
+++ b/packages/adt-cli/src/lib/services/cts/transport-lifecycle.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { AdtClient } from '@abapify/adt-client';
-import type { AdkTransportRequest } from '@abapify/adk';
+import type { AdkTransportRequest, AdkTransportTask } from '@abapify/adk';
 import { CtsTransportLifecycleService } from './transport-lifecycle';
 
 function transport(overrides: Partial<AdkTransportRequest> = {}) {
-  return {
+  const model = {
     number: 'DEVK900001',
     status: 'D',
     statusText: 'Modifiable',
@@ -17,13 +17,18 @@ function transport(overrides: Partial<AdkTransportRequest> = {}) {
     release: vi.fn().mockResolvedValue({ success: true }),
     releaseAll: vi.fn().mockResolvedValue({ success: true }),
     reassign: vi.fn().mockResolvedValue(undefined),
-    addTask: vi.fn().mockResolvedValue({
-      number: 'DEVK900004',
-      owner: 'NEWUSER',
-      status: 'D',
+    addTask: vi.fn().mockImplementation((owner: string) => {
+      const task = {
+        number: 'DEVK900004',
+        owner,
+        status: 'D',
+      } as AdkTransportTask;
+      model.tasks.push(task);
+      return Promise.resolve(task);
     }),
     ...overrides,
   } as unknown as AdkTransportRequest;
+  return model;
 }
 
 describe('CtsTransportLifecycleService', () => {
@@ -41,6 +46,22 @@ describe('CtsTransportLifecycleService', () => {
     await expect(service.release({ transport: 'DEVK900001' })).rejects.toThrow(
       'Release report failed',
     );
+  });
+
+  it('normalizes padded lowercase release identifiers', async () => {
+    const model = transport();
+    const getTransport = vi.fn().mockResolvedValue(model);
+    const service = new CtsTransportLifecycleService({} as AdtClient, {
+      getTransport,
+    });
+
+    await expect(
+      service.release({ transport: ' devk900001 ' }),
+    ).resolves.toMatchObject({
+      status: 'released',
+      transport: 'DEVK900001',
+    });
+    expect(getTransport).toHaveBeenCalledWith('DEVK900001', expect.anything());
   });
 
   it('returns the same structured lifecycle results to delivery adapters', async () => {

--- a/packages/adt-cli/src/lib/services/cts/transport-lifecycle.test.ts
+++ b/packages/adt-cli/src/lib/services/cts/transport-lifecycle.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AdtClient } from '@abapify/adt-client';
+import type { AdkTransportRequest } from '@abapify/adk';
+import { CtsTransportLifecycleService } from './transport-lifecycle';
+
+function transport(overrides: Partial<AdkTransportRequest> = {}) {
+  return {
+    number: 'DEVK900001',
+    status: 'D',
+    statusText: 'Modifiable',
+    owner: 'OLDUSER',
+    description: 'Lifecycle test',
+    target: 'PRD',
+    targetDescription: 'Production',
+    tasks: [],
+    objects: [],
+    release: vi.fn().mockResolvedValue({ success: true }),
+    releaseAll: vi.fn().mockResolvedValue({ success: true }),
+    reassign: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as AdkTransportRequest;
+}
+
+describe('CtsTransportLifecycleService', () => {
+  it('surfaces release failures from ADK', async () => {
+    const model = transport({
+      release: vi.fn().mockResolvedValue({
+        success: false,
+        message: 'Release report failed',
+      }),
+    });
+    const service = new CtsTransportLifecycleService({} as AdtClient, {
+      getTransport: vi.fn().mockResolvedValue(model),
+    });
+
+    await expect(service.release({ transport: 'DEVK900001' })).rejects.toThrow(
+      'Release report failed',
+    );
+  });
+
+  it('returns the same structured lifecycle results to delivery adapters', async () => {
+    const model = transport();
+    const service = new CtsTransportLifecycleService({} as AdtClient, {
+      getTransport: vi.fn().mockResolvedValue(model),
+    });
+
+    await expect(
+      service.release({ transport: 'DEVK900001', releaseAll: false }),
+    ).resolves.toMatchObject({
+      status: 'released',
+      transport: 'DEVK900001',
+    });
+    await expect(
+      service.reassign({
+        transport: 'DEVK900001',
+        newOwner: 'NEWUSER',
+        recursive: true,
+      }),
+    ).resolves.toEqual({
+      status: 'reassigned',
+      transport: 'DEVK900001',
+      previousOwner: 'OLDUSER',
+      newOwner: 'NEWUSER',
+      recursive: true,
+    });
+  });
+});

--- a/packages/adt-cli/src/lib/services/cts/transport-lifecycle.test.ts
+++ b/packages/adt-cli/src/lib/services/cts/transport-lifecycle.test.ts
@@ -17,6 +17,11 @@ function transport(overrides: Partial<AdkTransportRequest> = {}) {
     release: vi.fn().mockResolvedValue({ success: true }),
     releaseAll: vi.fn().mockResolvedValue({ success: true }),
     reassign: vi.fn().mockResolvedValue(undefined),
+    addTask: vi.fn().mockResolvedValue({
+      number: 'DEVK900004',
+      owner: 'NEWUSER',
+      status: 'D',
+    }),
     ...overrides,
   } as unknown as AdkTransportRequest;
 }
@@ -44,6 +49,18 @@ describe('CtsTransportLifecycleService', () => {
       getTransport: vi.fn().mockResolvedValue(model),
     });
 
+    await expect(
+      service.createTask({
+        transport: 'devk900001',
+        owner: 'newuser',
+      }),
+    ).resolves.toEqual({
+      status: 'created',
+      transport: 'DEVK900001',
+      task: 'DEVK900004',
+      owner: 'NEWUSER',
+    });
+    expect(model.addTask).toHaveBeenCalledWith('NEWUSER');
     await expect(
       service.release({ transport: 'DEVK900001', releaseAll: false }),
     ).resolves.toMatchObject({

--- a/packages/adt-cli/src/lib/services/cts/transport-lifecycle.test.ts
+++ b/packages/adt-cli/src/lib/services/cts/transport-lifecycle.test.ts
@@ -45,8 +45,12 @@ describe('CtsTransportLifecycleService', () => {
 
   it('returns the same structured lifecycle results to delivery adapters', async () => {
     const model = transport();
+    model.reassign = vi.fn().mockImplementation(async (newOwner: string) => {
+      (model as unknown as { owner: string }).owner = newOwner;
+    });
+    const getTransport = vi.fn().mockResolvedValue(model);
     const service = new CtsTransportLifecycleService({} as AdtClient, {
-      getTransport: vi.fn().mockResolvedValue(model),
+      getTransport,
     });
 
     await expect(
@@ -69,8 +73,8 @@ describe('CtsTransportLifecycleService', () => {
     });
     await expect(
       service.reassign({
-        transport: 'DEVK900001',
-        newOwner: 'NEWUSER',
+        transport: ' devk900001 ',
+        newOwner: ' newuser ',
         recursive: true,
       }),
     ).resolves.toEqual({
@@ -80,5 +84,23 @@ describe('CtsTransportLifecycleService', () => {
       newOwner: 'NEWUSER',
       recursive: true,
     });
+    expect(getTransport).toHaveBeenLastCalledWith(
+      'DEVK900001',
+      expect.anything(),
+    );
+    expect(model.reassign).toHaveBeenCalledWith('NEWUSER', true);
+  });
+
+  it('rejects empty reassignment identity', async () => {
+    const service = new CtsTransportLifecycleService({} as AdtClient, {
+      getTransport: vi.fn(),
+    });
+
+    await expect(
+      service.reassign({ transport: ' ', newOwner: 'NEWUSER' }),
+    ).rejects.toThrow('Transport and new owner are required');
+    await expect(
+      service.reassign({ transport: 'DEVK900001', newOwner: ' ' }),
+    ).rejects.toThrow('Transport and new owner are required');
   });
 });

--- a/packages/adt-cli/src/lib/services/cts/transport-lifecycle.ts
+++ b/packages/adt-cli/src/lib/services/cts/transport-lifecycle.ts
@@ -1,6 +1,17 @@
 import { AdkTransportRequest, type ReleaseResult } from '@abapify/adk';
 import type { AdtClient } from '@abapify/adt-client';
 
+function normalizeTransportIdentifier(
+  transport: string,
+  errorMessage = 'Transport identifier is required',
+): string {
+  const normalized = transport.trim().toUpperCase();
+  if (!normalized) {
+    throw new Error(errorMessage);
+  }
+  return normalized;
+}
+
 export interface CtsTransportLifecycleOperations {
   getTransport(
     transport: string,
@@ -70,7 +81,11 @@ export class CtsTransportLifecycleService {
   ) {}
 
   async getTransport(transport: string): Promise<CtsTransportSummary> {
-    const model = await this.operations.getTransport(transport, this.client);
+    const normalizedTransport = normalizeTransportIdentifier(transport);
+    const model = await this.operations.getTransport(
+      normalizedTransport,
+      this.client,
+    );
     return {
       transport: model.number,
       status: model.status,
@@ -85,11 +100,9 @@ export class CtsTransportLifecycleService {
   }
 
   async release(input: ReleaseTransportInput): Promise<ReleaseTransportResult> {
-    const model = await this.operations.getTransport(
-      input.transport,
-      this.client,
-    );
+    const transport = normalizeTransportIdentifier(input.transport);
     const releaseAll = input.releaseAll ?? false;
+    const model = await this.operations.getTransport(transport, this.client);
     if (model.status === 'R') {
       return {
         status: 'already_released',
@@ -117,13 +130,26 @@ export class CtsTransportLifecycleService {
   }
 
   async createTask(input: CreateTaskInput): Promise<CreateTaskResult> {
-    const transport = input.transport.trim().toUpperCase();
+    const transport = normalizeTransportIdentifier(
+      input.transport,
+      'Transport and task owner are required',
+    );
     const owner = input.owner.trim().toUpperCase();
-    if (!transport || !owner) {
+    if (!owner) {
       throw new Error('Transport and task owner are required');
     }
     const model = await this.operations.getTransport(transport, this.client);
     const task = await model.addTask(owner);
+    const updatedModel = await this.operations.getTransport(
+      transport,
+      this.client,
+    );
+    const confirmed = updatedModel.tasks.some(
+      (t) => t.number === task.number && t.owner === task.owner,
+    );
+    if (!confirmed) {
+      throw new Error(`no new task owned by ${owner}`);
+    }
     return {
       status: 'created',
       transport: model.number,
@@ -135,9 +161,12 @@ export class CtsTransportLifecycleService {
   async reassign(
     input: ReassignTransportInput,
   ): Promise<ReassignTransportResult> {
-    const transport = input.transport.trim().toUpperCase();
+    const transport = normalizeTransportIdentifier(
+      input.transport,
+      'Transport and new owner are required',
+    );
     const newOwner = input.newOwner.trim().toUpperCase();
-    if (!transport || !newOwner) {
+    if (!newOwner) {
       throw new Error('Transport and new owner are required');
     }
     const model = await this.operations.getTransport(transport, this.client);

--- a/packages/adt-cli/src/lib/services/cts/transport-lifecycle.ts
+++ b/packages/adt-cli/src/lib/services/cts/transport-lifecycle.ts
@@ -51,6 +51,18 @@ export interface ReassignTransportResult {
   recursive: boolean;
 }
 
+export interface CreateTaskInput {
+  transport: string;
+  owner: string;
+}
+
+export interface CreateTaskResult {
+  status: 'created';
+  transport: string;
+  task: string;
+  owner: string;
+}
+
 export class CtsTransportLifecycleService {
   constructor(
     private readonly client: AdtClient,
@@ -101,6 +113,22 @@ export class CtsTransportLifecycleService {
       transport: model.number,
       releaseAll,
       result,
+    };
+  }
+
+  async createTask(input: CreateTaskInput): Promise<CreateTaskResult> {
+    const transport = input.transport.trim().toUpperCase();
+    const owner = input.owner.trim().toUpperCase();
+    if (!transport || !owner) {
+      throw new Error('Transport and task owner are required');
+    }
+    const model = await this.operations.getTransport(transport, this.client);
+    const task = await model.addTask(owner);
+    return {
+      status: 'created',
+      transport: model.number,
+      task: task.number,
+      owner: task.owner,
     };
   }
 

--- a/packages/adt-cli/src/lib/services/cts/transport-lifecycle.ts
+++ b/packages/adt-cli/src/lib/services/cts/transport-lifecycle.ts
@@ -1,0 +1,130 @@
+import { AdkTransportRequest, type ReleaseResult } from '@abapify/adk';
+import type { AdtClient } from '@abapify/adt-client';
+
+export interface CtsTransportLifecycleOperations {
+  getTransport(
+    transport: string,
+    client: AdtClient,
+  ): Promise<AdkTransportRequest>;
+}
+
+const DEFAULT_OPERATIONS: CtsTransportLifecycleOperations = {
+  getTransport: (transport, client) =>
+    AdkTransportRequest.get(transport, { client }),
+};
+
+export interface CtsTransportSummary {
+  transport: string;
+  status: string;
+  statusText: string;
+  owner: string;
+  description: string;
+  target: string;
+  targetDescription: string;
+  taskCount: number;
+  objectCount: number;
+}
+
+export interface ReleaseTransportInput {
+  transport: string;
+  releaseAll?: boolean;
+}
+
+export interface ReleaseTransportResult {
+  status: 'released' | 'already_released';
+  transport: string;
+  releaseAll: boolean;
+  result: ReleaseResult;
+}
+
+export interface ReassignTransportInput {
+  transport: string;
+  newOwner: string;
+  recursive?: boolean;
+}
+
+export interface ReassignTransportResult {
+  status: 'reassigned';
+  transport: string;
+  previousOwner: string;
+  newOwner: string;
+  recursive: boolean;
+}
+
+export class CtsTransportLifecycleService {
+  constructor(
+    private readonly client: AdtClient,
+    private readonly operations: CtsTransportLifecycleOperations = DEFAULT_OPERATIONS,
+  ) {}
+
+  async getTransport(transport: string): Promise<CtsTransportSummary> {
+    const model = await this.operations.getTransport(transport, this.client);
+    return {
+      transport: model.number,
+      status: model.status,
+      statusText: model.statusText,
+      owner: model.owner,
+      description: model.description,
+      target: model.target,
+      targetDescription: model.targetDescription,
+      taskCount: model.tasks.length,
+      objectCount: model.objects.length,
+    };
+  }
+
+  async release(input: ReleaseTransportInput): Promise<ReleaseTransportResult> {
+    const model = await this.operations.getTransport(
+      input.transport,
+      this.client,
+    );
+    const releaseAll = input.releaseAll ?? false;
+    if (model.status === 'R') {
+      return {
+        status: 'already_released',
+        transport: model.number,
+        releaseAll,
+        result: { success: true },
+      };
+    }
+
+    const result = releaseAll
+      ? await model.releaseAll()
+      : await model.release();
+    if (!result.success) {
+      throw new Error(
+        result.message || `Release of transport ${model.number} failed`,
+      );
+    }
+
+    return {
+      status: 'released',
+      transport: model.number,
+      releaseAll,
+      result,
+    };
+  }
+
+  async reassign(
+    input: ReassignTransportInput,
+  ): Promise<ReassignTransportResult> {
+    const model = await this.operations.getTransport(
+      input.transport,
+      this.client,
+    );
+    if (model.status === 'R') {
+      throw new Error(`Transport ${model.number} is already released`);
+    }
+
+    const recursive = input.recursive ?? false;
+    const previousOwner = model.owner;
+    await model.reassign(input.newOwner, recursive);
+
+    return {
+      status: 'reassigned',
+      transport: model.number,
+      previousOwner,
+      newOwner: input.newOwner,
+      recursive,
+    };
+  }
+}

--- a/packages/adt-cli/src/lib/services/cts/transport-lifecycle.ts
+++ b/packages/adt-cli/src/lib/services/cts/transport-lifecycle.ts
@@ -135,23 +135,25 @@ export class CtsTransportLifecycleService {
   async reassign(
     input: ReassignTransportInput,
   ): Promise<ReassignTransportResult> {
-    const model = await this.operations.getTransport(
-      input.transport,
-      this.client,
-    );
+    const transport = input.transport.trim().toUpperCase();
+    const newOwner = input.newOwner.trim().toUpperCase();
+    if (!transport || !newOwner) {
+      throw new Error('Transport and new owner are required');
+    }
+    const model = await this.operations.getTransport(transport, this.client);
     if (model.status === 'R') {
       throw new Error(`Transport ${model.number} is already released`);
     }
 
     const recursive = input.recursive ?? false;
     const previousOwner = model.owner;
-    await model.reassign(input.newOwner, recursive);
+    await model.reassign(newOwner, recursive);
 
     return {
       status: 'reassigned',
       transport: model.number,
       previousOwner,
-      newOwner: input.newOwner,
+      newOwner: model.owner,
       recursive,
     };
   }

--- a/packages/adt-cli/tests/e2e/parity.cts.test.ts
+++ b/packages/adt-cli/tests/e2e/parity.cts.test.ts
@@ -151,6 +151,43 @@ describe('parity: cts', () => {
     expect(mcp.json.transport).toMatch(/DEVK\d+/);
   });
 
+  it('create task: CLI `cts tr task create` and MCP `cts_create_task`', async () => {
+    const cli = await runCliCommand(harness, [
+      'cts',
+      'tr',
+      'task',
+      'create',
+      'DEVK900001',
+      'NEWOWNER',
+      '--json',
+    ]);
+    expect(cli.exitCode, cli.stderr || cli.stdout).toBe(0);
+    expect(extractJson(cli)).toEqual({
+      status: 'created',
+      transport: 'DEVK900001',
+      task: 'DEVK900004',
+      owner: 'NEWOWNER',
+    });
+
+    await harness.mock.reset();
+    const mcp = await callMcpTool<{
+      status: string;
+      transport: string;
+      task: string;
+      owner: string;
+    }>(harness, 'cts_create_task', {
+      transport: 'DEVK900001',
+      owner: 'NEWOWNER',
+    });
+    expect(mcp.isError).toBe(false);
+    expect(mcp.json).toEqual({
+      status: 'created',
+      transport: 'DEVK900001',
+      task: 'DEVK900004',
+      owner: 'NEWOWNER',
+    });
+  });
+
   // ──────────────────────────────────────────────────────────────────────────
   // 4. Release transport (CLI + MCP parity)
   // ──────────────────────────────────────────────────────────────────────────

--- a/packages/adt-cli/tests/e2e/parity.cts.test.ts
+++ b/packages/adt-cli/tests/e2e/parity.cts.test.ts
@@ -15,7 +15,7 @@
  * tools covered until the harness gains ADK wiring.
  */
 
-import { describe, it, beforeAll, afterAll, expect } from 'vitest';
+import { describe, it, beforeAll, beforeEach, afterAll, expect } from 'vitest';
 import {
   startAdtHarness,
   runCliCommand,
@@ -54,6 +54,10 @@ describe('parity: cts', () => {
 
   afterAll(async () => {
     if (harness) await harness.stop();
+  });
+
+  beforeEach(async () => {
+    await harness.mock.reset();
   });
 
   // ──────────────────────────────────────────────────────────────────────────
@@ -159,6 +163,10 @@ describe('parity: cts', () => {
       '-y',
     ]);
     expect(cli.exitCode, cli.stderr || cli.stdout).toBe(0);
+
+    // CLI and MCP must execute the same transition from the same initial SAP
+    // state; otherwise the second invocation is correctly idempotent.
+    await harness.mock.reset();
 
     const mcp = await callMcpTool<{ status: string; transport: string }>(
       harness,

--- a/packages/adt-cli/tests/e2e/parity.cts.test.ts
+++ b/packages/adt-cli/tests/e2e/parity.cts.test.ts
@@ -186,6 +186,25 @@ describe('parity: cts', () => {
       owner: 'OTHEROWNER',
     });
 
+    const releasedTask = await runCliCommand(harness, [
+      'cts',
+      'tr',
+      'release',
+      'DEVK900004',
+      '--skip-check',
+      '--yes',
+      '--json',
+    ]);
+    expect(
+      releasedTask.exitCode,
+      releasedTask.stderr || releasedTask.stdout,
+    ).toBe(0);
+    expect(extractJson(releasedTask)).toMatchObject({
+      status: 'released',
+      transport: 'DEVK900004',
+      releaseAll: false,
+    });
+
     await harness.mock.reset();
     const mcp = await callMcpTool<{
       status: string;
@@ -254,6 +273,21 @@ describe('parity: cts', () => {
     );
   });
 
+  it('rejects a task creation request without the required target user', async () => {
+    await expect(
+      harness.client.fetch(
+        '/sap/bc/adt/cts/transportrequests/DEVK900001/tasks',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/vnd.sap.adt.transportorganizer.v1+xml',
+          },
+          body: '<tm:root xmlns:tm="http://www.sap.com/cts/adt/tm"/>',
+        },
+      ),
+    ).rejects.toThrow(/400/u);
+  });
+
   // ──────────────────────────────────────────────────────────────────────────
   // 4. Release transport (CLI + MCP parity)
   // ──────────────────────────────────────────────────────────────────────────
@@ -279,6 +313,41 @@ describe('parity: cts', () => {
     expect(mcp.isError).toBe(false);
     expect(mcp.json.status).toBe('released');
     expect(mcp.json.transport).toBe('DEVK900001');
+  });
+
+  it('release-all releases child tasks before their parent request', async () => {
+    const cli = await runCliCommand(harness, [
+      'cts',
+      'tr',
+      'release',
+      'DEVK900001',
+      '--release-all',
+      '--skip-check',
+      '--yes',
+      '--json',
+    ]);
+    expect(cli.exitCode, cli.stderr || cli.stdout).toBe(0);
+    expect(extractJson(cli)).toMatchObject({
+      status: 'released',
+      transport: 'DEVK900001',
+      releaseAll: true,
+    });
+  });
+
+  it('reads an already released sibling task as the task itself', async () => {
+    const cli = await runCliCommand(harness, [
+      'cts',
+      'tr',
+      'release',
+      'DEVK900003',
+      '--yes',
+      '--json',
+    ]);
+    expect(cli.exitCode, cli.stderr || cli.stdout).toBe(0);
+    expect(extractJson(cli)).toEqual({
+      transport: 'DEVK900003',
+      status: 'already_released',
+    });
   });
 
   // ──────────────────────────────────────────────────────────────────────────

--- a/packages/adt-cli/tests/e2e/parity.cts.test.ts
+++ b/packages/adt-cli/tests/e2e/parity.cts.test.ts
@@ -169,6 +169,23 @@ describe('parity: cts', () => {
       owner: 'NEWOWNER',
     });
 
+    const secondCli = await runCliCommand(harness, [
+      'cts',
+      'tr',
+      'task',
+      'create',
+      'DEVK900001',
+      'OTHEROWNER',
+      '--json',
+    ]);
+    expect(secondCli.exitCode, secondCli.stderr || secondCli.stdout).toBe(0);
+    expect(extractJson(secondCli)).toEqual({
+      status: 'created',
+      transport: 'DEVK900001',
+      task: 'DEVK900005',
+      owner: 'OTHEROWNER',
+    });
+
     await harness.mock.reset();
     const mcp = await callMcpTool<{
       status: string;
@@ -186,6 +203,51 @@ describe('parity: cts', () => {
       task: 'DEVK900004',
       owner: 'NEWOWNER',
     });
+  });
+
+  it('task creation failures remain failures through CLI and MCP', async () => {
+    harness.mock.setTaskCreationMode('noop');
+    const noopCli = await runCliCommand(harness, [
+      'cts',
+      'tr',
+      'task',
+      'create',
+      'DEVK900001',
+      'NEWOWNER',
+      '--json',
+    ]);
+    expect(noopCli.exitCode).toBe(1);
+    expect(noopCli.stderr).toContain('no new task owned by NEWOWNER');
+
+    await harness.mock.reset();
+    harness.mock.setTaskCreationMode('noop');
+    const noopMcp = await callMcpTool(harness, 'cts_create_task', {
+      transport: 'DEVK900001',
+      owner: 'NEWOWNER',
+    });
+    expect(noopMcp.isError).toBe(true);
+    expect(String(noopMcp.json)).toContain('no new task owned by NEWOWNER');
+
+    await harness.mock.reset();
+    const invalidCli = await runCliCommand(harness, [
+      'cts',
+      'tr',
+      'task',
+      'create',
+      'DEVK900002',
+      'NEWOWNER',
+      '--json',
+    ]);
+    expect(invalidCli.exitCode).toBe(1);
+    expect(invalidCli.stderr).toContain('is a task, not a request');
+
+    await harness.mock.reset();
+    const invalidMcp = await callMcpTool(harness, 'cts_create_task', {
+      transport: 'DEVK900002',
+      owner: 'NEWOWNER',
+    });
+    expect(invalidMcp.isError).toBe(true);
+    expect(String(invalidMcp.json)).toContain('is a task, not a request');
   });
 
   // ──────────────────────────────────────────────────────────────────────────

--- a/packages/adt-cli/tests/e2e/parity.cts.test.ts
+++ b/packages/adt-cli/tests/e2e/parity.cts.test.ts
@@ -239,7 +239,9 @@ describe('parity: cts', () => {
       '--json',
     ]);
     expect(invalidCli.exitCode).toBe(1);
-    expect(invalidCli.stderr).toContain('is a task, not a request');
+    expect(invalidCli.stderr).toContain(
+      'Transport DEVK900002 is a task, not a request',
+    );
 
     await harness.mock.reset();
     const invalidMcp = await callMcpTool(harness, 'cts_create_task', {
@@ -247,7 +249,9 @@ describe('parity: cts', () => {
       owner: 'NEWOWNER',
     });
     expect(invalidMcp.isError).toBe(true);
-    expect(String(invalidMcp.json)).toContain('is a task, not a request');
+    expect(String(invalidMcp.json)).toContain(
+      'Transport DEVK900002 is a task, not a request',
+    );
   });
 
   // ──────────────────────────────────────────────────────────────────────────

--- a/packages/adt-contracts/src/adt/cts/transportrequests/add-task-schema.ts
+++ b/packages/adt-contracts/src/adt/cts/transportrequests/add-task-schema.ts
@@ -1,0 +1,22 @@
+import type { Serializable } from '../../../base';
+import { transportmanagment, type InferTypedSchema } from '../../../schemas';
+
+export interface AddTaskBody {
+  root: {
+    targetuser: string;
+  };
+}
+
+type TransportManagementBody = InferTypedSchema<typeof transportmanagment>;
+
+/** Narrow body used by SAP's hypermedia `newtask` relation. */
+export const addTaskBodySchema: Serializable<AddTaskBody> = {
+  _infer: undefined as unknown as AddTaskBody,
+  parse: (raw: string): AddTaskBody => {
+    const parsed = transportmanagment.parse(raw).root;
+    if (!parsed.targetuser) throw new Error('Invalid CTS add-task body');
+    return { root: { targetuser: parsed.targetuser } };
+  },
+  build: (body: AddTaskBody): string =>
+    transportmanagment.build(body as unknown as TransportManagementBody),
+};

--- a/packages/adt-contracts/src/adt/cts/transportrequests/add-task-schema.ts
+++ b/packages/adt-contracts/src/adt/cts/transportrequests/add-task-schema.ts
@@ -13,9 +13,12 @@ type TransportManagementBody = InferTypedSchema<typeof transportmanagment>;
 export const addTaskBodySchema: Serializable<AddTaskBody> = {
   _infer: undefined as unknown as AddTaskBody,
   parse: (raw: string): AddTaskBody => {
-    const parsed = transportmanagment.parse(raw).root;
-    if (!parsed.targetuser) throw new Error('Invalid CTS add-task body');
-    return { root: { targetuser: parsed.targetuser } };
+    const parsed = transportmanagment.parse(raw);
+    const root = parsed?.root;
+    if (!root || !root.targetuser) {
+      throw new Error('Invalid CTS add-task body');
+    }
+    return { root: { targetuser: root.targetuser } };
   },
   build: (body: AddTaskBody): string =>
     transportmanagment.build(body as unknown as TransportManagementBody),

--- a/packages/adt-contracts/src/adt/cts/transportrequests/change-owner-schema.ts
+++ b/packages/adt-contracts/src/adt/cts/transportrequests/change-owner-schema.ts
@@ -21,18 +21,24 @@ type TransportManagementBody = InferTypedSchema<typeof transportmanagment>;
 export const changeOwnerBodySchema: Serializable<ChangeOwnerBody> = {
   _infer: undefined as unknown as ChangeOwnerBody,
   parse: (raw: string): ChangeOwnerBody => {
-    const parsed = transportmanagment.parse(raw).root;
-    if (
-      parsed.useraction !== 'changeowner' ||
-      !parsed.number ||
-      !parsed.targetuser
-    ) {
+    const parsed = transportmanagment.parse(raw);
+    const root = parsed?.root;
+    if (!root) {
+      throw new Error('Invalid CTS change-owner body');
+    }
+    if (root.useraction !== 'changeowner') {
+      throw new Error('Invalid CTS change-owner body');
+    }
+    if (!root.number) {
+      throw new Error('Invalid CTS change-owner body');
+    }
+    if (!root.targetuser) {
       throw new Error('Invalid CTS change-owner body');
     }
     return {
       root: {
-        number: parsed.number,
-        targetuser: parsed.targetuser,
+        number: root.number,
+        targetuser: root.targetuser,
         useraction: 'changeowner',
       },
     };

--- a/packages/adt-contracts/src/adt/cts/transportrequests/change-owner-schema.ts
+++ b/packages/adt-contracts/src/adt/cts/transportrequests/change-owner-schema.ts
@@ -11,6 +11,16 @@ export interface ChangeOwnerBody {
 
 type TransportManagementBody = InferTypedSchema<typeof transportmanagment>;
 
+type ChangeOwnerRoot = ChangeOwnerBody['root'];
+
+function isChangeOwnerRoot(
+  root: TransportManagementBody['root'] | undefined,
+): root is ChangeOwnerRoot {
+  return Boolean(
+    root && root.useraction === 'changeowner' && root.number && root.targetuser,
+  );
+}
+
 /**
  * Narrow request schema for the CTS change-owner action.
  *
@@ -23,16 +33,7 @@ export const changeOwnerBodySchema: Serializable<ChangeOwnerBody> = {
   parse: (raw: string): ChangeOwnerBody => {
     const parsed = transportmanagment.parse(raw);
     const root = parsed?.root;
-    if (!root) {
-      throw new Error('Invalid CTS change-owner body');
-    }
-    if (root.useraction !== 'changeowner') {
-      throw new Error('Invalid CTS change-owner body');
-    }
-    if (!root.number) {
-      throw new Error('Invalid CTS change-owner body');
-    }
-    if (!root.targetuser) {
+    if (!isChangeOwnerRoot(root)) {
       throw new Error('Invalid CTS change-owner body');
     }
     return {

--- a/packages/adt-contracts/src/adt/cts/transportrequests/change-owner-schema.ts
+++ b/packages/adt-contracts/src/adt/cts/transportrequests/change-owner-schema.ts
@@ -1,0 +1,42 @@
+import type { Serializable } from '../../../base';
+import { transportmanagment, type InferTypedSchema } from '../../../schemas';
+
+export interface ChangeOwnerBody {
+  root: {
+    number: string;
+    targetuser: string;
+    useraction: 'changeowner';
+  };
+}
+
+type TransportManagementBody = InferTypedSchema<typeof transportmanagment>;
+
+/**
+ * Narrow request schema for the CTS change-owner action.
+ *
+ * SAP models these attributes on the broader transport-management root. This
+ * wrapper keeps the call-site body narrow while delegating XML parsing and
+ * serialization to that generated SAP schema.
+ */
+export const changeOwnerBodySchema: Serializable<ChangeOwnerBody> = {
+  _infer: undefined as unknown as ChangeOwnerBody,
+  parse: (raw: string): ChangeOwnerBody => {
+    const parsed = transportmanagment.parse(raw).root;
+    if (
+      parsed.useraction !== 'changeowner' ||
+      !parsed.number ||
+      !parsed.targetuser
+    ) {
+      throw new Error('Invalid CTS change-owner body');
+    }
+    return {
+      root: {
+        number: parsed.number,
+        targetuser: parsed.targetuser,
+        useraction: 'changeowner',
+      },
+    };
+  },
+  build: (body: ChangeOwnerBody): string =>
+    transportmanagment.build(body as unknown as TransportManagementBody),
+};

--- a/packages/adt-contracts/src/adt/cts/transportrequests/index.ts
+++ b/packages/adt-contracts/src/adt/cts/transportrequests/index.ts
@@ -15,11 +15,12 @@ import { reference } from './reference';
 import { searchconfiguration } from './searchconfiguration';
 import { useraction } from './useraction';
 
-export { useraction } from './useraction';
+export { useraction, changeOwnerBodySchema } from './useraction';
 export type {
   UseractionContract,
   ReassignOptions,
   CreateRequestOptions,
+  ChangeOwnerBody,
 } from './useraction';
 
 /**

--- a/packages/adt-contracts/src/adt/cts/transportrequests/useraction.ts
+++ b/packages/adt-contracts/src/adt/cts/transportrequests/useraction.ts
@@ -2,10 +2,11 @@
  * /sap/bc/adt/cts/transportrequests - user-action body endpoints
  *
  * SAP ADT uses distinct lifecycle endpoints for release, changeowner, and
- * newrequest actions. This file exposes typed contracts for all three.
+ * newrequest and newtask actions. This file exposes typed contracts for them.
  *
  *   release       → POST /{trkorr}/newreleasejobs (no body)
  *   changeowner   → PUT  /{trkorr}    (requires tm:number and tm:targetuser)
+ *   newtask       → POST /{trkorr}/tasks (requires tm:targetuser)
  *   newrequest    → POST /            (creates a new transport request)
  */
 
@@ -16,9 +17,12 @@ import {
   transportmanagmentSingle,
 } from '../../../schemas';
 import { changeOwnerBodySchema } from './change-owner-schema';
+import { addTaskBodySchema } from './add-task-schema';
 
 export { changeOwnerBodySchema } from './change-owner-schema';
 export type { ChangeOwnerBody } from './change-owner-schema';
+export { addTaskBodySchema } from './add-task-schema';
+export type { AddTaskBody } from './add-task-schema';
 
 /** Options for {@link useraction.reassign} */
 export interface ReassignOptions {
@@ -26,6 +30,11 @@ export interface ReassignOptions {
   targetUser: string;
   /** Cascade the change to all modifiable tasks (default: false) */
   recursive?: boolean;
+}
+
+export interface AddTaskOptions {
+  /** SAP user who should own the new task. */
+  owner: string;
 }
 
 /** Options for {@link useraction.create} (useraction=newrequest) */
@@ -61,6 +70,17 @@ export const useraction = {
     http.put(`/sap/bc/adt/cts/transportrequests/${trkorr}`, {
       body: changeOwnerBodySchema,
       responses: { 200: transportmanagmentSingle },
+      headers: {
+        Accept: CONTENT_TYPE,
+        'Content-Type': CONTENT_TYPE,
+      },
+    }),
+
+  /** Create a modifiable task below an existing request. */
+  addTask: (trkorr: string, _options: AddTaskOptions) =>
+    http.post(`/sap/bc/adt/cts/transportrequests/${trkorr}/tasks`, {
+      body: addTaskBodySchema,
+      responses: { 200: transportmanagment },
       headers: {
         Accept: CONTENT_TYPE,
         'Content-Type': CONTENT_TYPE,

--- a/packages/adt-contracts/src/adt/cts/transportrequests/useraction.ts
+++ b/packages/adt-contracts/src/adt/cts/transportrequests/useraction.ts
@@ -1,24 +1,24 @@
 /**
  * /sap/bc/adt/cts/transportrequests - user-action body endpoints
  *
- * SAP ADT uses POST with a `<tm:root tm:useraction="...">` XML body for
- * release / changeowner / newrequest actions. This file exposes typed
- * endpoints that wrap those three operations.
+ * SAP ADT uses distinct lifecycle endpoints for release, changeowner, and
+ * newrequest actions. This file exposes typed contracts for all three.
  *
- *   release       → POST /{trkorr}
- *   changeowner   → POST /{trkorr}    (requires tm:targetuser, optional tm:recursive)
+ *   release       → POST /{trkorr}/newreleasejobs (no body)
+ *   changeowner   → PUT  /{trkorr}    (requires tm:number and tm:targetuser)
  *   newrequest    → POST /            (creates a new transport request)
- *
- * All three share the same namespace and content-type but differ in
- * request shape and URL, so we expose them as separate methods with
- * strongly-typed options while sharing a single schema.
  */
 
 import { http } from '../../../base';
 import {
   transportUseraction,
+  transportmanagment,
   transportmanagmentSingle,
 } from '../../../schemas';
+import { changeOwnerBodySchema } from './change-owner-schema';
+
+export { changeOwnerBodySchema } from './change-owner-schema';
+export type { ChangeOwnerBody } from './change-owner-schema';
 
 /** Options for {@link useraction.reassign} */
 export interface ReassignOptions {
@@ -46,28 +46,20 @@ const CONTENT_TYPE = 'application/vnd.sap.adt.transportorganizer.v1+xml';
 
 export const useraction = {
   /**
-   * POST /{trkorr} with useraction="release"
-   *
-   * Releases the transport or task.
+   * Start and synchronously report a transport/task release job.
    */
   release: (trkorr: string) =>
-    http.post(`/sap/bc/adt/cts/transportrequests/${trkorr}`, {
-      body: transportUseraction,
-      responses: { 200: transportmanagmentSingle },
-      headers: {
-        Accept: CONTENT_TYPE,
-        'Content-Type': CONTENT_TYPE,
-      },
+    http.post(`/sap/bc/adt/cts/transportrequests/${trkorr}/newreleasejobs`, {
+      responses: { 200: transportmanagment },
+      headers: { Accept: CONTENT_TYPE },
     }),
 
   /**
-   * POST /{trkorr} with useraction="changeowner"
-   *
-   * Reassigns ownership of a transport (and optionally all of its tasks).
+   * PUT /{trkorr} with useraction="changeowner".
    */
   reassign: (trkorr: string, _options: ReassignOptions) =>
-    http.post(`/sap/bc/adt/cts/transportrequests/${trkorr}`, {
-      body: transportUseraction,
+    http.put(`/sap/bc/adt/cts/transportrequests/${trkorr}`, {
+      body: changeOwnerBodySchema,
       responses: { 200: transportmanagmentSingle },
       headers: {
         Accept: CONTENT_TYPE,

--- a/packages/adt-contracts/tests/contracts/cts-useraction.test.ts
+++ b/packages/adt-contracts/tests/contracts/cts-useraction.test.ts
@@ -1,17 +1,21 @@
 /**
  * CTS transportrequests user-action contract scenarios
  *
- * Validates the release / reassign / create endpoints that ADT exposes
- * as POST bodies with `<tm:root tm:useraction="..."/>`.
+ * Validates the release / reassign / create endpoints that ADT exposes.
  */
 
+import { describe, expect, it } from 'vitest';
 import { fixtures } from '@abapify/adt-fixtures';
 import {
   transportUseraction,
+  transportmanagment,
   transportmanagmentSingle,
 } from '../../src/schemas';
 import { ContractScenario, runScenario, type ContractOperation } from './base';
-import { useraction } from '../../src/adt/cts/transportrequests/useraction';
+import {
+  changeOwnerBodySchema,
+  useraction,
+} from '../../src/adt/cts/transportrequests/useraction';
 
 const CONTENT_TYPE = 'application/vnd.sap.adt.transportorganizer.v1+xml';
 
@@ -23,30 +27,24 @@ class TransportUseractionScenario extends ContractScenario {
       name: 'release transport',
       contract: () => useraction.release('DEVK900001'),
       method: 'POST',
-      path: '/sap/bc/adt/cts/transportrequests/DEVK900001',
+      path: '/sap/bc/adt/cts/transportrequests/DEVK900001/newreleasejobs',
       headers: {
         Accept: CONTENT_TYPE,
-        'Content-Type': CONTENT_TYPE,
       },
-      body: {
-        schema: transportUseraction,
-        fixture: fixtures.transport.useractionRelease,
-      },
-      response: { status: 200, schema: transportmanagmentSingle },
+      response: { status: 200, schema: transportmanagment },
     },
     {
       name: 'reassign transport (changeowner)',
       contract: () =>
         useraction.reassign('DEVK900001', { targetUser: 'NEWOWNER' }),
-      method: 'POST',
+      method: 'PUT',
       path: '/sap/bc/adt/cts/transportrequests/DEVK900001',
       headers: {
         Accept: CONTENT_TYPE,
         'Content-Type': CONTENT_TYPE,
       },
       body: {
-        schema: transportUseraction,
-        fixture: fixtures.transport.useractionChangeowner,
+        schema: changeOwnerBodySchema,
       },
       response: { status: 200, schema: transportmanagmentSingle },
     },
@@ -75,3 +73,46 @@ class TransportUseractionScenario extends ContractScenario {
 }
 
 runScenario(new TransportUseractionScenario());
+
+describe('CTS lifecycle request bodies', () => {
+  it('sends release as a body-less new release job', () => {
+    const contract = useraction.release('DEVK900001');
+
+    expect(contract.body).toBeUndefined();
+    expect(contract.headers).not.toHaveProperty('Content-Type');
+  });
+
+  it('builds a typed change-owner body with the transport number', () => {
+    const contract = useraction.reassign('DEVK900001', {
+      targetUser: 'NEWOWNER',
+    });
+
+    expect(contract.body).toBe(changeOwnerBodySchema);
+    expect(
+      changeOwnerBodySchema.build?.({
+        root: {
+          number: 'DEVK900001',
+          targetuser: 'NEWOWNER',
+          useraction: 'changeowner',
+        },
+      }),
+    ).toContain('tm:number="DEVK900001"');
+
+    const xml = changeOwnerBodySchema.build?.({
+      root: {
+        number: 'DEVK900001',
+        targetuser: 'NEWOWNER',
+        useraction: 'changeowner',
+      },
+    });
+    expect(xml).toContain('tm:targetuser="NEWOWNER"');
+    expect(xml).toContain('tm:useraction="changeowner"');
+    expect(changeOwnerBodySchema.parse?.(xml ?? '')).toEqual({
+      root: {
+        number: 'DEVK900001',
+        targetuser: 'NEWOWNER',
+        useraction: 'changeowner',
+      },
+    });
+  });
+});

--- a/packages/adt-contracts/tests/contracts/cts-useraction.test.ts
+++ b/packages/adt-contracts/tests/contracts/cts-useraction.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../../src/schemas';
 import { ContractScenario, runScenario, type ContractOperation } from './base';
 import {
+  addTaskBodySchema,
   changeOwnerBodySchema,
   useraction,
 } from '../../src/adt/cts/transportrequests/useraction';
@@ -49,6 +50,24 @@ class TransportUseractionScenario extends ContractScenario {
       response: { status: 200, schema: transportmanagmentSingle },
     },
     {
+      name: 'create task under request',
+      contract: () => useraction.addTask('DEVK900001', { owner: 'NEWOWNER' }),
+      method: 'POST',
+      path: '/sap/bc/adt/cts/transportrequests/DEVK900001/tasks',
+      headers: {
+        Accept: CONTENT_TYPE,
+        'Content-Type': CONTENT_TYPE,
+      },
+      body: {
+        schema: addTaskBodySchema,
+      },
+      response: {
+        status: 200,
+        schema: transportmanagment,
+        fixture: fixtures.transport.taskCreateResponse,
+      },
+    },
+    {
       name: 'create transport (newrequest)',
       contract: () =>
         useraction.create({
@@ -75,6 +94,21 @@ class TransportUseractionScenario extends ContractScenario {
 runScenario(new TransportUseractionScenario());
 
 describe('CTS lifecycle request bodies', () => {
+  it('builds an add-task body with the requested owner', () => {
+    const contract = useraction.addTask('DEVK900001', {
+      owner: 'NEWOWNER',
+    });
+
+    expect(contract.body).toBe(addTaskBodySchema);
+    const xml = addTaskBodySchema.build?.({
+      root: { targetuser: 'NEWOWNER' },
+    });
+    expect(xml).toContain('tm:targetuser="NEWOWNER"');
+    expect(addTaskBodySchema.parse?.(xml ?? '')).toEqual({
+      root: { targetuser: 'NEWOWNER' },
+    });
+  });
+
   it('sends release as a body-less new release job', () => {
     const contract = useraction.release('DEVK900001');
 

--- a/packages/adt-fixtures/src/fixtures/mcp/transport/release.xml
+++ b/packages/adt-fixtures/src/fixtures/mcp/transport/release.xml
@@ -1,8 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tm:root xmlns:tm="http://www.sap.com/cts/adt/tm">
-  <tm:workbench>
-    <tm:modifiable status="released" />
-    <tm:relstarted status="released" />
-    <tm:released status="released" />
-  </tm:workbench>
+<!-- Sanitized SAP response from POST /sap/bc/adt/cts/transportrequests/{id}/newreleasejobs -->
+<tm:root
+  xmlns:tm="http://www.sap.com/cts/adt/tm"
+  xmlns:chkrun="http://www.sap.com/adt/checkrun"
+  tm:useraction="newreleasejobs"
+  tm:releasetimestamp="20260803172655 "
+  tm:number="DEVK900001"
+>
+  <tm:releasereports>
+    <chkrun:checkReport
+      chkrun:reporter="transportrelease"
+      chkrun:triggeringUri="/sap/bc/adt/cts/transportrequests/DEVK900001"
+      chkrun:status="released"
+      chkrun:statusText="Transport request/task DEVK900001 was successfully released"
+    />
+  </tm:releasereports>
 </tm:root>

--- a/packages/adt-fixtures/src/fixtures/registry.ts
+++ b/packages/adt-fixtures/src/fixtures/registry.ts
@@ -16,6 +16,7 @@ export const registry = {
     useractionRelease: 'transport/useraction-release.xml',
     useractionChangeowner: 'transport/useraction-changeowner.xml',
     useractionNewrequest: 'transport/useraction-newrequest.xml',
+    taskCreateResponse: 'transport/task-create-response.xml',
   },
   atc: {
     customizing: 'atc/customizing.xml',

--- a/packages/adt-fixtures/src/fixtures/transport/task-create-response.xml
+++ b/packages/adt-fixtures/src/fixtures/transport/task-create-response.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Sanitized real BHF response from:
+  Sanitized SAP ADT response captured from:
   POST /sap/bc/adt/cts/transportrequests/{request}/tasks
 -->
 <tm:root

--- a/packages/adt-fixtures/src/fixtures/transport/task-create-response.xml
+++ b/packages/adt-fixtures/src/fixtures/transport/task-create-response.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Sanitized real BHF response from:
+  POST /sap/bc/adt/cts/transportrequests/{request}/tasks
+-->
+<tm:root
+    tm:targetuser="NEWOWNER"
+    tm:useraction="tasks"
+    tm:number="DEVK900004"
+    tm:uri="/sap/bc/adt/cts/transportrequests/DEVK900004"
+    xmlns:tm="http://www.sap.com/cts/adt/tm">
+  <atom:link
+      href="/sap/bc/adt/cts/transportrequests/DEVK900004"
+      rel="http://www.sap.com/cts/relations/adturi"
+      type="application/vnd.sap.adt.transportrequests.v1+xml"
+      title="Transport Organizer ADT URI"
+      xmlns:atom="http://www.w3.org/2005/Atom"/>
+  <atom:link
+      href="/sap/bc/adt/vit/wb/object_type/%20%20%20%20rq/object_name/DEVK900004"
+      rel="http://www.sap.com/cts/relations/vituri"
+      type="application/vnd.sap.sapgui"
+      title="Transport Organizer VIT URI"
+      xmlns:atom="http://www.w3.org/2005/Atom"/>
+  <atom:link
+      href="/sap/bc/adt/cts/transportrequests/DEVK900004/consistencychecks"
+      rel="http://www.sap.com/cts/relations/consistencycheck"
+      type="application/xml"
+      title="Transport Organizer Request/Task Consistency Check"
+      xmlns:atom="http://www.w3.org/2005/Atom"/>
+  <atom:link
+      href="/sap/bc/adt/cts/transportrequests/DEVK900004/releasejobs"
+      rel="http://www.sap.com/cts/relations/releasejobs"
+      type="application/xml"
+      title="Transport Organizer Request/Task Release"
+      xmlns:atom="http://www.w3.org/2005/Atom"/>
+  <atom:link
+      href="/sap/bc/adt/cts/transportrequests/DEVK900004"
+      rel="http://www.sap.com/cts/relations/modify"
+      type="application/xml"
+      title="Transport Organizer Request/Modify"
+      xmlns:atom="http://www.w3.org/2005/Atom"/>
+</tm:root>

--- a/packages/adt-fixtures/src/mock-server/routes.ts
+++ b/packages/adt-fixtures/src/mock-server/routes.ts
@@ -17,6 +17,25 @@ export interface RouteResult {
   headers?: Record<string, string>;
 }
 
+function replaceRequestAttribute(
+  xml: string,
+  attribute: 'owner' | 'status' | 'status_text',
+  value: string,
+): string {
+  return xml.replace(/<tm:request\b([^>]*)>/, (tag, attributes: string) => {
+    const matcher = new RegExp(`\\btm:${attribute}="[^"]*"`);
+    const replacement = `tm:${attribute}="${value}"`;
+    const nextAttributes = matcher.test(attributes)
+      ? attributes.replace(matcher, replacement)
+      : `${attributes} ${replacement}`;
+    return `<tm:request${nextAttributes}>`;
+  });
+}
+
+function extractTargetUser(requestBody: string): string | undefined {
+  return /\btm:targetuser=["']([^"']+)["']/.exec(requestBody)?.[1];
+}
+
 /**
  * Preloaded fixture content — populated once at server start.
  * All routes read from this map to avoid async in matchRoute.
@@ -370,6 +389,7 @@ export function matchRoute(
   f: LoadedFixtures,
   locks: LockRegistry,
   _sessionId?: string,
+  requestBody = '',
 ): RouteResult | undefined {
   const m = method.toUpperCase();
   const pathname = url.split('?')[0];
@@ -827,7 +847,32 @@ export function matchRoute(
     };
   }
 
-  // CTS release / reassign / action — POST on a transport request
+  // CTS release — SAP starts a release job without a request body. Keep the
+  // fixture stateful so the lifecycle service's read-back can verify status R.
+  if (
+    m === 'POST' &&
+    /\/sap\/bc\/adt\/cts\/transportrequests\/\w+\/newreleasejobs$/.test(
+      pathname,
+    )
+  ) {
+    f.transportSingle = replaceRequestAttribute(
+      f.transportSingle,
+      'status',
+      'R',
+    );
+    f.transportSingle = replaceRequestAttribute(
+      f.transportSingle,
+      'status_text',
+      'Released',
+    );
+    return {
+      status: 200,
+      body: f.transportRelease,
+      contentType: 'application/vnd.sap.adt.transportorganizer.v1+xml',
+    };
+  }
+
+  // Legacy CTS action — POST on a transport request.
   // (lock/unlock actions are handled further below by the generic _action handler)
   if (
     m === 'POST' &&
@@ -876,6 +921,14 @@ export function matchRoute(
     m === 'PUT' &&
     /\/sap\/bc\/adt\/cts\/transportrequests\/\w+/.test(pathname)
   ) {
+    const targetUser = extractTargetUser(requestBody);
+    if (targetUser) {
+      f.transportSingle = replaceRequestAttribute(
+        f.transportSingle,
+        'owner',
+        targetUser,
+      );
+    }
     return {
       status: 200,
       body: f.transportSingle,

--- a/packages/adt-fixtures/src/mock-server/routes.ts
+++ b/packages/adt-fixtures/src/mock-server/routes.ts
@@ -17,44 +17,92 @@ export interface RouteResult {
   headers?: Record<string, string>;
 }
 
-function replaceRequestAttribute(
-  xml: string,
-  attribute: 'owner' | 'status' | 'status_text',
-  value: string,
-): string {
+interface XmlAttribute {
+  name: string;
+  value: string;
+}
+
+interface TaskAttribute extends XmlAttribute {
+  taskNumber: string;
+}
+
+interface NewTransportTask {
+  parent: string;
+  number: string;
+  owner: string;
+}
+
+interface DirectTaskResponseInput {
+  template: string;
+  parentResponse: string;
+  taskNumber: string;
+}
+
+interface TaskResponsesInput {
+  template: string;
+  parentResponse: string;
+}
+
+function setXmlAttribute(attributes: string, attr: XmlAttribute): string {
+  const prefix = `${attr.name}=`;
+  const start = attributes.indexOf(prefix);
+  if (start !== -1) {
+    const quoteStart = start + prefix.length;
+    const quote = attributes[quoteStart];
+    if (quote === '"' || quote === "'") {
+      const valueEnd = attributes.indexOf(quote, quoteStart + 1);
+      if (valueEnd !== -1) {
+        return (
+          attributes.slice(0, start) +
+          `${attr.name}="${attr.value}"` +
+          attributes.slice(valueEnd + 1)
+        );
+      }
+    }
+  }
+  return `${attributes} ${attr.name}="${attr.value}"`;
+}
+
+function extractXmlAttribute(xml: string, name: string): string | undefined {
+  const prefix = `${name}=`;
+  const start = xml.indexOf(prefix);
+  if (start === -1) return undefined;
+  const quote = xml[start + prefix.length];
+  if (quote !== '"' && quote !== "'") return undefined;
+  const end = xml.indexOf(quote, start + prefix.length + 1);
+  if (end === -1) return undefined;
+  return xml.slice(start + prefix.length + 1, end);
+}
+
+function replaceRequestAttribute(xml: string, attr: XmlAttribute): string {
   return xml.replace(/<tm:request\b([^>]*)>/, (tag, attributes: string) => {
-    const matcher = new RegExp(`\\btm:${attribute}="[^"]*"`);
-    const replacement = `tm:${attribute}="${value}"`;
-    const nextAttributes = matcher.test(attributes)
-      ? attributes.replace(matcher, replacement)
-      : `${attributes} ${replacement}`;
-    return `<tm:request${nextAttributes}>`;
+    return `<tm:request${setXmlAttribute(attributes, {
+      name: `tm:${attr.name}`,
+      value: attr.value,
+    })}>`;
   });
 }
 
-function replaceTaskAttribute(
-  xml: string,
-  taskNumber: string,
-  attribute: 'owner' | 'status' | 'status_text',
-  value: string,
-): string {
-  return xml.replace(
-    new RegExp(
-      `<tm:task\\b(?=[^>]*\\btm:number=["']${taskNumber}["'])([^>]*)>`,
-    ),
-    (tag, attributes: string) => {
-      const matcher = new RegExp(`\\btm:${attribute}="[^"]*"`);
-      const replacement = `tm:${attribute}="${value}"`;
-      const nextAttributes = matcher.test(attributes)
-        ? attributes.replace(matcher, replacement)
-        : `${attributes} ${replacement}`;
-      return `<tm:task${nextAttributes}>`;
-    },
+function replaceTaskAttribute(xml: string, attr: TaskAttribute): string {
+  const needle = `tm:number="${attr.taskNumber}"`;
+  const numberIdx = xml.indexOf(needle);
+  if (numberIdx === -1) return xml;
+  const tagStart = xml.lastIndexOf('<tm:task', numberIdx);
+  if (tagStart === -1) return xml;
+  const tagEnd = xml.indexOf('>', tagStart);
+  if (tagEnd === -1) return xml;
+  const attributes = xml.slice(tagStart + '<tm:task'.length, tagEnd);
+  const newAttributes = setXmlAttribute(attributes, {
+    name: `tm:${attr.name}`,
+    value: attr.value,
+  });
+  return (
+    xml.slice(0, tagStart) + `<tm:task${newAttributes}>` + xml.slice(tagEnd + 1)
   );
 }
 
 function extractTargetUser(requestBody: string): string | undefined {
-  return /\btm:targetuser=["']([^"']+)["']/.exec(requestBody)?.[1];
+  return extractXmlAttribute(requestBody, 'tm:targetuser');
 }
 
 function extractRequestAttribute(
@@ -62,82 +110,92 @@ function extractRequestAttribute(
   attribute: 'number' | 'status',
 ): string | undefined {
   const request = /<tm:request\b([^>]*)>/.exec(xml)?.[1];
-  return request
-    ? new RegExp(`\\btm:${attribute}=["']([^"']+)["']`).exec(request)?.[1]
-    : undefined;
+  return request ? extractXmlAttribute(request, `tm:${attribute}`) : undefined;
+}
+
+interface SplitDigits {
+  prefix: string;
+  digits: string;
+}
+
+function splitTrailingDigits(value: string): SplitDigits | undefined {
+  let i = value.length - 1;
+  while (i >= 0 && value[i] >= '0' && value[i] <= '9') {
+    i--;
+  }
+  if (i === value.length - 1) return undefined;
+  return { prefix: value.slice(0, i + 1), digits: value.slice(i + 1) };
 }
 
 function nextTransportTaskNumber(xml: string, parent: string): string {
-  const parentMatch = /^(.*?)(\d+)$/.exec(parent);
-  if (!parentMatch) return `${parent}_TASK`;
+  const parentSplit = splitTrailingDigits(parent);
+  if (!parentSplit) return `${parent}_TASK`;
 
-  const [, prefix, digits] = parentMatch;
+  const { prefix, digits } = parentSplit;
   const numbers = Array.from(xml.matchAll(/\btm:number=["']([^"']+)["']/g))
-    .map((match) => /^(.*?)(\d+)$/.exec(match[1]))
-    .filter((match): match is RegExpExecArray =>
-      Boolean(match && match[1] === prefix),
+    .map((match) => splitTrailingDigits(match[1]))
+    .filter((split): split is SplitDigits =>
+      Boolean(split && split.prefix === prefix),
     )
-    .map((match) => Number.parseInt(match[2], 10));
+    .map((split) => Number.parseInt(split.digits, 10));
   const next = Math.max(Number.parseInt(digits, 10), ...numbers) + 1;
   return `${prefix}${String(next).padStart(digits.length, '0')}`;
 }
 
-function appendTransportTask(
-  xml: string,
-  parent: string,
-  task: string,
-  owner: string,
-): string {
-  if (xml.includes(`tm:number="${task}"`)) return xml;
-  const taskXml = `<tm:task tm:number="${task}" tm:parent="${parent}" tm:owner="${owner}" tm:desc="Incremental task" tm:type="S" tm:status="D" tm:status_text="Modifiable" tm:uri="/sap/bc/adt/cts/transportrequests/${task}"><tm:long_desc/></tm:task>`;
+function appendTransportTask(xml: string, task: NewTransportTask): string {
+  if (xml.includes(`tm:number="${task.number}"`)) return xml;
+  const taskXml = `<tm:task tm:number="${task.number}" tm:parent="${task.parent}" tm:owner="${task.owner}" tm:desc="Incremental task" tm:type="S" tm:status="D" tm:status_text="Modifiable" tm:uri="/sap/bc/adt/cts/transportrequests/${task.number}"><tm:long_desc/></tm:task>`;
   return xml.replace('</tm:request>', `${taskXml}</tm:request>`);
 }
 
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
-}
-
 function findTaskElement(xml: string, taskNumber: string): string | undefined {
-  return new RegExp(
-    `<tm:task\\b(?=[^>]*\\btm:number=["']${escapeRegex(taskNumber)}["'])[^>]*>[\\s\\S]*?<\\/tm:task>`,
-    'u',
-  ).exec(xml)?.[0];
+  const needle = `tm:number="${taskNumber}"`;
+  const numberIdx = xml.indexOf(needle);
+  if (numberIdx === -1) return undefined;
+  const tagStart = xml.lastIndexOf('<tm:task', numberIdx);
+  if (tagStart === -1) return undefined;
+  const tagEnd = xml.indexOf('>', tagStart);
+  if (tagEnd === -1) return undefined;
+  const closeTag = '</tm:task>';
+  const closeIdx = xml.indexOf(closeTag, tagEnd);
+  if (closeIdx === -1) return undefined;
+  return xml.slice(tagStart, closeIdx + closeTag.length);
 }
 
-function createDirectTaskResponse(
-  template: string,
-  parentResponse: string,
-  taskNumber: string,
-): string {
-  const templateParent = extractRequestAttribute(template, 'number');
+function createDirectTaskResponse(input: DirectTaskResponseInput): string {
+  const templateParent = extractRequestAttribute(input.template, 'number');
   const templateTask = /<tm:task\b[^>]*\btm:number=["']([^"']+)["']/.exec(
-    template,
+    input.template,
   )?.[1];
-  const parentNumber = extractRequestAttribute(parentResponse, 'number');
-  if (!templateParent || !templateTask || !parentNumber) return template;
+  const parentNumber = extractRequestAttribute(input.parentResponse, 'number');
+  if (!templateParent || !templateTask || !parentNumber) return input.template;
 
-  const response = template
+  const response = input.template
     .replaceAll(templateParent, parentNumber)
-    .replaceAll(templateTask, taskNumber);
-  const templateTaskElement = findTaskElement(response, taskNumber);
-  const actualTaskElement = findTaskElement(parentResponse, taskNumber);
+    .replaceAll(templateTask, input.taskNumber);
+  const templateTaskElement = findTaskElement(response, input.taskNumber);
+  const actualTaskElement = findTaskElement(
+    input.parentResponse,
+    input.taskNumber,
+  );
   return templateTaskElement && actualTaskElement
     ? response.replace(templateTaskElement, actualTaskElement)
     : response;
 }
 
 function createTransportTaskResponses(
-  parentResponse: string,
-  template: string,
+  input: TaskResponsesInput,
 ): Map<string, string> {
   const taskNumbers = Array.from(
-    parentResponse.matchAll(/<tm:task\b[^>]*\btm:number=["']([^"']+)["']/gu),
+    input.parentResponse.matchAll(
+      /<tm:task\b[^>]*\btm:number=["']([^"']+)["']/gu,
+    ),
     (match) => match[1],
   );
   return new Map(
     taskNumbers.map((taskNumber) => [
       taskNumber,
-      createDirectTaskResponse(template, parentResponse, taskNumber),
+      createDirectTaskResponse({ ...input, taskNumber }),
     ]),
   );
 }
@@ -416,10 +474,10 @@ export async function loadRouteFixtures(): Promise<LoadedFixtures> {
     transportList,
     transportSingle,
     transportSingleTask,
-    transportTaskResponses: createTransportTaskResponses(
-      transportSingle,
-      transportSingleTask,
-    ),
+    transportTaskResponses: createTransportTaskResponses({
+      parentResponse: transportSingle,
+      template: transportSingleTask,
+    }),
     transportCreate,
     transportTaskCreate,
     taskCreationMode: 'create',
@@ -983,41 +1041,75 @@ export function matchRoute(
     );
     const requestNumber = extractRequestAttribute(f.transportSingle, 'number');
     if (requested === requestNumber) {
-      f.transportSingle = replaceRequestAttribute(
-        f.transportSingle,
-        'status',
-        'R',
-      );
-      f.transportSingle = replaceRequestAttribute(
-        f.transportSingle,
-        'status_text',
-        'Released',
-      );
-      for (const [taskNumber, response] of f.transportTaskResponses) {
-        f.transportTaskResponses.set(
+      f.transportSingle = replaceRequestAttribute(f.transportSingle, {
+        name: 'status',
+        value: 'R',
+      });
+      f.transportSingle = replaceRequestAttribute(f.transportSingle, {
+        name: 'status_text',
+        value: 'Released',
+      });
+      const taskNumbers = [...f.transportTaskResponses.keys()];
+      for (const taskNumber of taskNumbers) {
+        f.transportSingle = replaceTaskAttribute(f.transportSingle, {
           taskNumber,
-          replaceRequestAttribute(
-            replaceRequestAttribute(response, 'status', 'R'),
-            'status_text',
-            'Released',
-          ),
-        );
+          name: 'status',
+          value: 'R',
+        });
+        f.transportSingle = replaceTaskAttribute(f.transportSingle, {
+          taskNumber,
+          name: 'status_text',
+          value: 'Released',
+        });
+      }
+      for (const [taskNumber, response] of [...f.transportTaskResponses]) {
+        let updated = replaceRequestAttribute(response, {
+          name: 'status',
+          value: 'R',
+        });
+        updated = replaceRequestAttribute(updated, {
+          name: 'status_text',
+          value: 'Released',
+        });
+        updated = replaceTaskAttribute(updated, {
+          taskNumber,
+          name: 'status',
+          value: 'R',
+        });
+        updated = replaceTaskAttribute(updated, {
+          taskNumber,
+          name: 'status_text',
+          value: 'Released',
+        });
+        f.transportTaskResponses.set(taskNumber, updated);
       }
     } else if (f.transportTaskResponses.has(requested)) {
       f.transportSingle = replaceTaskAttribute(
-        replaceTaskAttribute(f.transportSingle, requested, 'status', 'R'),
-        requested,
-        'status_text',
-        'Released',
+        replaceTaskAttribute(f.transportSingle, {
+          taskNumber: requested,
+          name: 'status',
+          value: 'R',
+        }),
+        {
+          taskNumber: requested,
+          name: 'status_text',
+          value: 'Released',
+        },
       );
       const response = f.transportTaskResponses.get(requested)!;
       f.transportTaskResponses.set(
         requested,
         replaceTaskAttribute(
-          replaceTaskAttribute(response, requested, 'status', 'R'),
-          requested,
-          'status_text',
-          'Released',
+          replaceTaskAttribute(response, {
+            taskNumber: requested,
+            name: 'status',
+            value: 'R',
+          }),
+          {
+            taskNumber: requested,
+            name: 'status_text',
+            value: 'Released',
+          },
         ),
       );
     } else {
@@ -1048,19 +1140,18 @@ export function matchRoute(
     }
     const task = nextTransportTaskNumber(f.transportSingle, parent);
     if (f.taskCreationMode === 'create') {
-      f.transportSingle = appendTransportTask(
-        f.transportSingle,
+      f.transportSingle = appendTransportTask(f.transportSingle, {
         parent,
-        task,
+        number: task,
         owner,
-      );
+      });
       f.transportTaskResponses.set(
         task,
-        createDirectTaskResponse(
-          f.transportSingleTask,
-          f.transportSingle,
-          task,
-        ),
+        createDirectTaskResponse({
+          template: f.transportSingleTask,
+          parentResponse: f.transportSingle,
+          taskNumber: task,
+        }),
       );
     }
     return {
@@ -1137,45 +1228,55 @@ export function matchRoute(
     /\/sap\/bc\/adt\/cts\/transportrequests\/\w+/.test(pathname)
   ) {
     const targetUser = extractTargetUser(requestBody);
+    const requested = pathname.split('/').filter(Boolean).at(-1) ?? '';
     if (targetUser) {
-      const requested = pathname.split('/').filter(Boolean).at(-1);
       const requestNumber = extractRequestAttribute(
         f.transportSingle,
         'number',
       );
       if (requested && f.transportTaskResponses.has(requested)) {
-        f.transportSingle = replaceTaskAttribute(
-          f.transportSingle,
-          requested,
-          'owner',
-          targetUser,
-        );
+        f.transportSingle = replaceTaskAttribute(f.transportSingle, {
+          taskNumber: requested,
+          name: 'owner',
+          value: targetUser,
+        });
         f.transportTaskResponses.set(
           requested,
-          replaceTaskAttribute(
-            f.transportTaskResponses.get(requested)!,
-            requested,
-            'owner',
-            targetUser,
-          ),
+          replaceTaskAttribute(f.transportTaskResponses.get(requested)!, {
+            taskNumber: requested,
+            name: 'owner',
+            value: targetUser,
+          }),
         );
       } else if (requested === requestNumber) {
-        f.transportSingle = replaceRequestAttribute(
-          f.transportSingle,
-          'owner',
-          targetUser,
-        );
-        for (const [taskNumber, response] of f.transportTaskResponses) {
-          f.transportTaskResponses.set(
+        f.transportSingle = replaceRequestAttribute(f.transportSingle, {
+          name: 'owner',
+          value: targetUser,
+        });
+        const taskNumbers = [...f.transportTaskResponses.keys()];
+        for (const taskNumber of taskNumbers) {
+          f.transportSingle = replaceTaskAttribute(f.transportSingle, {
             taskNumber,
-            replaceRequestAttribute(response, 'owner', targetUser),
-          );
+            name: 'owner',
+            value: targetUser,
+          });
+        }
+        for (const [taskNumber, response] of [...f.transportTaskResponses]) {
+          let updated = replaceRequestAttribute(response, {
+            name: 'owner',
+            value: targetUser,
+          });
+          updated = replaceTaskAttribute(updated, {
+            taskNumber,
+            name: 'owner',
+            value: targetUser,
+          });
+          f.transportTaskResponses.set(taskNumber, updated);
         }
       } else {
         return { status: 404, body: '', contentType: 'text/plain' };
       }
     }
-    const requested = pathname.split('/').filter(Boolean).at(-1) ?? '';
     return {
       status: 200,
       body: f.transportTaskResponses.get(requested) ?? f.transportSingle,

--- a/packages/adt-fixtures/src/mock-server/routes.ts
+++ b/packages/adt-fixtures/src/mock-server/routes.ts
@@ -35,7 +35,7 @@ function replaceRequestAttribute(
 function replaceTaskAttribute(
   xml: string,
   taskNumber: string,
-  attribute: 'owner',
+  attribute: 'owner' | 'status' | 'status_text',
   value: string,
 ): string {
   return xml.replace(
@@ -93,6 +93,55 @@ function appendTransportTask(
   return xml.replace('</tm:request>', `${taskXml}</tm:request>`);
 }
 
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}
+
+function findTaskElement(xml: string, taskNumber: string): string | undefined {
+  return new RegExp(
+    `<tm:task\\b(?=[^>]*\\btm:number=["']${escapeRegex(taskNumber)}["'])[^>]*>[\\s\\S]*?<\\/tm:task>`,
+    'u',
+  ).exec(xml)?.[0];
+}
+
+function createDirectTaskResponse(
+  template: string,
+  parentResponse: string,
+  taskNumber: string,
+): string {
+  const templateParent = extractRequestAttribute(template, 'number');
+  const templateTask = /<tm:task\b[^>]*\btm:number=["']([^"']+)["']/.exec(
+    template,
+  )?.[1];
+  const parentNumber = extractRequestAttribute(parentResponse, 'number');
+  if (!templateParent || !templateTask || !parentNumber) return template;
+
+  const response = template
+    .replaceAll(templateParent, parentNumber)
+    .replaceAll(templateTask, taskNumber);
+  const templateTaskElement = findTaskElement(response, taskNumber);
+  const actualTaskElement = findTaskElement(parentResponse, taskNumber);
+  return templateTaskElement && actualTaskElement
+    ? response.replace(templateTaskElement, actualTaskElement)
+    : response;
+}
+
+function createTransportTaskResponses(
+  parentResponse: string,
+  template: string,
+): Map<string, string> {
+  const taskNumbers = Array.from(
+    parentResponse.matchAll(/<tm:task\b[^>]*\btm:number=["']([^"']+)["']/gu),
+    (match) => match[1],
+  );
+  return new Map(
+    taskNumbers.map((taskNumber) => [
+      taskNumber,
+      createDirectTaskResponse(template, parentResponse, taskNumber),
+    ]),
+  );
+}
+
 /**
  * Preloaded fixture content — populated once at server start.
  * All routes read from this map to avoid async in matchRoute.
@@ -106,6 +155,7 @@ export interface LoadedFixtures {
   transportList: string;
   transportSingle: string;
   transportSingleTask: string;
+  transportTaskResponses: Map<string, string>;
   transportCreate: string;
   transportTaskCreate: string;
   taskCreationMode: 'create' | 'noop';
@@ -366,6 +416,10 @@ export async function loadRouteFixtures(): Promise<LoadedFixtures> {
     transportList,
     transportSingle,
     transportSingleTask,
+    transportTaskResponses: createTransportTaskResponses(
+      transportSingle,
+      transportSingleTask,
+    ),
     transportCreate,
     transportTaskCreate,
     taskCreationMode: 'create',
@@ -918,20 +972,57 @@ export function matchRoute(
   // fixture stateful so the lifecycle service's read-back can verify status R.
   if (
     m === 'POST' &&
-    /\/sap\/bc\/adt\/cts\/transportrequests\/\w+\/newreleasejobs$/.test(
+    /\/sap\/bc\/adt\/cts\/transportrequests\/([^/]+)\/newreleasejobs$/.test(
       pathname,
     )
   ) {
-    f.transportSingle = replaceRequestAttribute(
-      f.transportSingle,
-      'status',
-      'R',
+    const requested = decodeURIComponent(
+      /\/sap\/bc\/adt\/cts\/transportrequests\/([^/]+)\/newreleasejobs$/.exec(
+        pathname,
+      )?.[1] ?? '',
     );
-    f.transportSingle = replaceRequestAttribute(
-      f.transportSingle,
-      'status_text',
-      'Released',
-    );
+    const requestNumber = extractRequestAttribute(f.transportSingle, 'number');
+    if (requested === requestNumber) {
+      f.transportSingle = replaceRequestAttribute(
+        f.transportSingle,
+        'status',
+        'R',
+      );
+      f.transportSingle = replaceRequestAttribute(
+        f.transportSingle,
+        'status_text',
+        'Released',
+      );
+      for (const [taskNumber, response] of f.transportTaskResponses) {
+        f.transportTaskResponses.set(
+          taskNumber,
+          replaceRequestAttribute(
+            replaceRequestAttribute(response, 'status', 'R'),
+            'status_text',
+            'Released',
+          ),
+        );
+      }
+    } else if (f.transportTaskResponses.has(requested)) {
+      f.transportSingle = replaceTaskAttribute(
+        replaceTaskAttribute(f.transportSingle, requested, 'status', 'R'),
+        requested,
+        'status_text',
+        'Released',
+      );
+      const response = f.transportTaskResponses.get(requested)!;
+      f.transportTaskResponses.set(
+        requested,
+        replaceTaskAttribute(
+          replaceTaskAttribute(response, requested, 'status', 'R'),
+          requested,
+          'status_text',
+          'Released',
+        ),
+      );
+    } else {
+      return { status: 404, body: '', contentType: 'text/plain' };
+    }
     return {
       status: 200,
       body: f.transportRelease,
@@ -951,7 +1042,10 @@ export function matchRoute(
       return { status: 409, body: '', contentType: 'text/plain' };
     }
 
-    const owner = extractTargetUser(requestBody) ?? 'NEWOWNER';
+    const owner = extractTargetUser(requestBody);
+    if (!owner) {
+      return { status: 400, body: '', contentType: 'text/plain' };
+    }
     const task = nextTransportTaskNumber(f.transportSingle, parent);
     if (f.taskCreationMode === 'create') {
       f.transportSingle = appendTransportTask(
@@ -959,6 +1053,14 @@ export function matchRoute(
         parent,
         task,
         owner,
+      );
+      f.transportTaskResponses.set(
+        task,
+        createDirectTaskResponse(
+          f.transportSingleTask,
+          f.transportSingle,
+          task,
+        ),
       );
     }
     return {
@@ -1002,11 +1104,18 @@ export function matchRoute(
     /^\/sap\/bc\/adt\/cts\/transportrequests\/([^/]+)\/?$/.exec(pathname);
   if (m === 'GET' && transportGetMatch) {
     const requested = decodeURIComponent(transportGetMatch[1]);
-    const taskNumber = /\badtcore:name=["']([^"']+)["']/.exec(
-      f.transportSingleTask,
-    )?.[1];
+    const requestNumber = extractRequestAttribute(f.transportSingle, 'number');
+    const createdRequestNumber = extractRequestAttribute(
+      f.transportCreate,
+      'number',
+    );
     const body =
-      requested === taskNumber ? f.transportSingleTask : f.transportSingle;
+      requested === requestNumber
+        ? f.transportSingle
+        : requested === createdRequestNumber
+          ? f.transportCreate
+          : f.transportTaskResponses.get(requested);
+    if (!body) return { status: 404, body: '', contentType: 'text/plain' };
     return {
       status: 200,
       body,
@@ -1030,32 +1139,46 @@ export function matchRoute(
     const targetUser = extractTargetUser(requestBody);
     if (targetUser) {
       const requested = pathname.split('/').filter(Boolean).at(-1);
-      const taskNumber = /\badtcore:name=["']([^"']+)["']/.exec(
-        f.transportSingleTask,
-      )?.[1];
-      if (requested && requested === taskNumber) {
-        f.transportSingleTask = replaceTaskAttribute(
-          f.transportSingleTask,
+      const requestNumber = extractRequestAttribute(
+        f.transportSingle,
+        'number',
+      );
+      if (requested && f.transportTaskResponses.has(requested)) {
+        f.transportSingle = replaceTaskAttribute(
+          f.transportSingle,
           requested,
           'owner',
           targetUser,
         );
-      } else {
+        f.transportTaskResponses.set(
+          requested,
+          replaceTaskAttribute(
+            f.transportTaskResponses.get(requested)!,
+            requested,
+            'owner',
+            targetUser,
+          ),
+        );
+      } else if (requested === requestNumber) {
         f.transportSingle = replaceRequestAttribute(
           f.transportSingle,
           'owner',
           targetUser,
         );
-        f.transportSingleTask = replaceRequestAttribute(
-          f.transportSingleTask,
-          'owner',
-          targetUser,
-        );
+        for (const [taskNumber, response] of f.transportTaskResponses) {
+          f.transportTaskResponses.set(
+            taskNumber,
+            replaceRequestAttribute(response, 'owner', targetUser),
+          );
+        }
+      } else {
+        return { status: 404, body: '', contentType: 'text/plain' };
       }
     }
+    const requested = pathname.split('/').filter(Boolean).at(-1) ?? '';
     return {
       status: 200,
-      body: f.transportSingle,
+      body: f.transportTaskResponses.get(requested) ?? f.transportSingle,
       contentType: 'application/vnd.sap.adt.transportorganizer.v1+xml',
     };
   }

--- a/packages/adt-fixtures/src/mock-server/routes.ts
+++ b/packages/adt-fixtures/src/mock-server/routes.ts
@@ -36,6 +36,17 @@ function extractTargetUser(requestBody: string): string | undefined {
   return /\btm:targetuser=["']([^"']+)["']/.exec(requestBody)?.[1];
 }
 
+function appendTransportTask(
+  xml: string,
+  parent: string,
+  task: string,
+  owner: string,
+): string {
+  if (xml.includes(`tm:number="${task}"`)) return xml;
+  const taskXml = `<tm:task tm:number="${task}" tm:parent="${parent}" tm:owner="${owner}" tm:desc="Incremental task" tm:type="S" tm:status="D" tm:status_text="Modifiable" tm:uri="/sap/bc/adt/cts/transportrequests/${task}"><tm:long_desc/></tm:task>`;
+  return xml.replace('</tm:request>', `${taskXml}</tm:request>`);
+}
+
 /**
  * Preloaded fixture content — populated once at server start.
  * All routes read from this map to avoid async in matchRoute.
@@ -49,6 +60,7 @@ export interface LoadedFixtures {
   transportList: string;
   transportSingle: string;
   transportCreate: string;
+  transportTaskCreate: string;
   transportRelease: string;
   transportFind: string;
   searchconfigMetadata: string;
@@ -145,6 +157,7 @@ export async function loadRouteFixtures(): Promise<LoadedFixtures> {
     transportList,
     transportSingle,
     transportCreate,
+    transportTaskCreate,
     transportRelease,
     transportFind,
     searchconfigMetadata,
@@ -223,6 +236,7 @@ export async function loadRouteFixtures(): Promise<LoadedFixtures> {
     m.transport.list.load(),
     fixtures.transport.single.load(),
     fixtures.transport.createResponse.load(),
+    fixtures.transport.taskCreateResponse.load(),
     m.transport.release.load(),
     fixtures.transport.find.load(),
     fixtures.transport.searchconfigMetadata.load(),
@@ -302,6 +316,7 @@ export async function loadRouteFixtures(): Promise<LoadedFixtures> {
     transportList,
     transportSingle,
     transportCreate,
+    transportTaskCreate,
     transportRelease,
     transportFind,
     searchconfigMetadata,
@@ -868,6 +883,25 @@ export function matchRoute(
     return {
       status: 200,
       body: f.transportRelease,
+      contentType: 'application/vnd.sap.adt.transportorganizer.v1+xml',
+    };
+  }
+
+  // CTS new task — POST the hypermedia /{request}/tasks relation, then expose
+  // the new modifiable task through the parent request read-back.
+  const taskCreateMatch =
+    /^\/sap\/bc\/adt\/cts\/transportrequests\/([^/]+)\/tasks$/.exec(pathname);
+  if (m === 'POST' && taskCreateMatch) {
+    const owner = extractTargetUser(requestBody) ?? 'NEWOWNER';
+    f.transportSingle = appendTransportTask(
+      f.transportSingle,
+      taskCreateMatch[1],
+      'DEVK900004',
+      owner,
+    );
+    return {
+      status: 200,
+      body: f.transportTaskCreate.replace('NEWOWNER', owner),
       contentType: 'application/vnd.sap.adt.transportorganizer.v1+xml',
     };
   }

--- a/packages/adt-fixtures/src/mock-server/routes.ts
+++ b/packages/adt-fixtures/src/mock-server/routes.ts
@@ -32,8 +32,54 @@ function replaceRequestAttribute(
   });
 }
 
+function replaceTaskAttribute(
+  xml: string,
+  taskNumber: string,
+  attribute: 'owner',
+  value: string,
+): string {
+  return xml.replace(
+    new RegExp(
+      `<tm:task\\b(?=[^>]*\\btm:number=["']${taskNumber}["'])([^>]*)>`,
+    ),
+    (tag, attributes: string) => {
+      const matcher = new RegExp(`\\btm:${attribute}="[^"]*"`);
+      const replacement = `tm:${attribute}="${value}"`;
+      const nextAttributes = matcher.test(attributes)
+        ? attributes.replace(matcher, replacement)
+        : `${attributes} ${replacement}`;
+      return `<tm:task${nextAttributes}>`;
+    },
+  );
+}
+
 function extractTargetUser(requestBody: string): string | undefined {
   return /\btm:targetuser=["']([^"']+)["']/.exec(requestBody)?.[1];
+}
+
+function extractRequestAttribute(
+  xml: string,
+  attribute: 'number' | 'status',
+): string | undefined {
+  const request = /<tm:request\b([^>]*)>/.exec(xml)?.[1];
+  return request
+    ? new RegExp(`\\btm:${attribute}=["']([^"']+)["']`).exec(request)?.[1]
+    : undefined;
+}
+
+function nextTransportTaskNumber(xml: string, parent: string): string {
+  const parentMatch = /^(.*?)(\d+)$/.exec(parent);
+  if (!parentMatch) return `${parent}_TASK`;
+
+  const [, prefix, digits] = parentMatch;
+  const numbers = Array.from(xml.matchAll(/\btm:number=["']([^"']+)["']/g))
+    .map((match) => /^(.*?)(\d+)$/.exec(match[1]))
+    .filter((match): match is RegExpExecArray =>
+      Boolean(match && match[1] === prefix),
+    )
+    .map((match) => Number.parseInt(match[2], 10));
+  const next = Math.max(Number.parseInt(digits, 10), ...numbers) + 1;
+  return `${prefix}${String(next).padStart(digits.length, '0')}`;
 }
 
 function appendTransportTask(
@@ -59,8 +105,10 @@ export interface LoadedFixtures {
   grep: string;
   transportList: string;
   transportSingle: string;
+  transportSingleTask: string;
   transportCreate: string;
   transportTaskCreate: string;
+  taskCreationMode: 'create' | 'noop';
   transportRelease: string;
   transportFind: string;
   searchconfigMetadata: string;
@@ -156,6 +204,7 @@ export async function loadRouteFixtures(): Promise<LoadedFixtures> {
     grep,
     transportList,
     transportSingle,
+    transportSingleTask,
     transportCreate,
     transportTaskCreate,
     transportRelease,
@@ -235,6 +284,7 @@ export async function loadRouteFixtures(): Promise<LoadedFixtures> {
     m.grep.load(),
     m.transport.list.load(),
     fixtures.transport.single.load(),
+    fixtures.transport.singleTask.load(),
     fixtures.transport.createResponse.load(),
     fixtures.transport.taskCreateResponse.load(),
     m.transport.release.load(),
@@ -315,8 +365,10 @@ export async function loadRouteFixtures(): Promise<LoadedFixtures> {
     grep,
     transportList,
     transportSingle,
+    transportSingleTask,
     transportCreate,
     transportTaskCreate,
+    taskCreationMode: 'create',
     transportRelease,
     transportFind,
     searchconfigMetadata,
@@ -892,16 +944,28 @@ export function matchRoute(
   const taskCreateMatch =
     /^\/sap\/bc\/adt\/cts\/transportrequests\/([^/]+)\/tasks$/.exec(pathname);
   if (m === 'POST' && taskCreateMatch) {
+    const parent = decodeURIComponent(taskCreateMatch[1]);
+    const requestNumber = extractRequestAttribute(f.transportSingle, 'number');
+    const requestStatus = extractRequestAttribute(f.transportSingle, 'status');
+    if (parent !== requestNumber || requestStatus !== 'D') {
+      return { status: 409, body: '', contentType: 'text/plain' };
+    }
+
     const owner = extractTargetUser(requestBody) ?? 'NEWOWNER';
-    f.transportSingle = appendTransportTask(
-      f.transportSingle,
-      taskCreateMatch[1],
-      'DEVK900004',
-      owner,
-    );
+    const task = nextTransportTaskNumber(f.transportSingle, parent);
+    if (f.taskCreationMode === 'create') {
+      f.transportSingle = appendTransportTask(
+        f.transportSingle,
+        parent,
+        task,
+        owner,
+      );
+    }
     return {
       status: 200,
-      body: f.transportTaskCreate.replace('NEWOWNER', owner),
+      body: f.transportTaskCreate
+        .replaceAll('DEVK900004', task)
+        .replaceAll('NEWOWNER', owner),
       contentType: 'application/vnd.sap.adt.transportorganizer.v1+xml',
     };
   }
@@ -933,11 +997,19 @@ export function matchRoute(
     };
   }
 
-  // CTS get single
-  if (m === 'GET' && /\/sap\/bc\/adt\/cts\/transportrequests\/\w+/.test(url)) {
+  // CTS get request or task. SAP returns a distinct shape for child tasks.
+  const transportGetMatch =
+    /^\/sap\/bc\/adt\/cts\/transportrequests\/([^/]+)\/?$/.exec(pathname);
+  if (m === 'GET' && transportGetMatch) {
+    const requested = decodeURIComponent(transportGetMatch[1]);
+    const taskNumber = /\badtcore:name=["']([^"']+)["']/.exec(
+      f.transportSingleTask,
+    )?.[1];
+    const body =
+      requested === taskNumber ? f.transportSingleTask : f.transportSingle;
     return {
       status: 200,
-      body: f.transportSingle,
+      body,
       contentType: 'application/vnd.sap.adt.transportorganizer.v1+xml',
     };
   }
@@ -957,11 +1029,29 @@ export function matchRoute(
   ) {
     const targetUser = extractTargetUser(requestBody);
     if (targetUser) {
-      f.transportSingle = replaceRequestAttribute(
-        f.transportSingle,
-        'owner',
-        targetUser,
-      );
+      const requested = pathname.split('/').filter(Boolean).at(-1);
+      const taskNumber = /\badtcore:name=["']([^"']+)["']/.exec(
+        f.transportSingleTask,
+      )?.[1];
+      if (requested && requested === taskNumber) {
+        f.transportSingleTask = replaceTaskAttribute(
+          f.transportSingleTask,
+          requested,
+          'owner',
+          targetUser,
+        );
+      } else {
+        f.transportSingle = replaceRequestAttribute(
+          f.transportSingle,
+          'owner',
+          targetUser,
+        );
+        f.transportSingleTask = replaceRequestAttribute(
+          f.transportSingleTask,
+          'owner',
+          targetUser,
+        );
+      }
     }
     return {
       status: 200,

--- a/packages/adt-fixtures/src/mock-server/server.ts
+++ b/packages/adt-fixtures/src/mock-server/server.ts
@@ -29,6 +29,8 @@ export interface MockAdtServer {
   stop(): Promise<void>;
   /** Restore preloaded fixtures and clear mutable mock state. */
   reset(): Promise<void>;
+  /** Configure task creation for verified no-op regression tests. */
+  setTaskCreationMode(mode: 'create' | 'noop'): void;
   /** Access the lock registry (for test assertions). */
   readonly locks: LockRegistry;
 }
@@ -116,6 +118,11 @@ export function createMockAdtServer(
     async reset() {
       fixtures = await loadRouteFixtures();
       locks.clear();
+    },
+
+    setTaskCreationMode(mode) {
+      if (!fixtures) throw new Error('Mock fixtures are not loaded');
+      fixtures.taskCreationMode = mode;
     },
 
     async stop() {

--- a/packages/adt-fixtures/src/mock-server/server.ts
+++ b/packages/adt-fixtures/src/mock-server/server.ts
@@ -27,6 +27,8 @@ export type MockAdtServerOptions = CsrfOptions;
 export interface MockAdtServer {
   start(): Promise<{ port: number }>;
   stop(): Promise<void>;
+  /** Restore preloaded fixtures and clear mutable mock state. */
+  reset(): Promise<void>;
   /** Access the lock registry (for test assertions). */
   readonly locks: LockRegistry;
 }
@@ -35,13 +37,14 @@ export function createMockAdtServer(
   options: MockAdtServerOptions = {},
 ): MockAdtServer {
   let server: Server | undefined;
+  let fixtures: Awaited<ReturnType<typeof loadRouteFixtures>> | undefined;
   const locks = new LockRegistry();
   const csrf = createCsrfState({ strictSession: options.strictSession });
 
   return {
     locks,
     async start() {
-      const fixtures = await loadRouteFixtures();
+      fixtures = await loadRouteFixtures();
 
       return new Promise<{ port: number }>((resolve, reject) => {
         server = createServer((req: IncomingMessage, res: ServerResponse) => {
@@ -57,28 +60,44 @@ export function createMockAdtServer(
             >,
           });
 
-          const route = matchRoute(
-            method,
-            url,
-            fixtures,
-            locks,
-            csrf.sessionId,
-          );
-          if (route) {
-            res.writeHead(route.status, {
-              'Content-Type': route.contentType,
-              ...csrfHeaders,
-              ...(route.headers ?? {}),
-            });
-            res.end(route.body);
-            return;
-          }
-
-          res.writeHead(404, {
-            'Content-Type': 'text/plain',
-            ...csrfHeaders,
+          let requestBody = '';
+          req.setEncoding('utf8');
+          req.on('data', (chunk: string) => {
+            requestBody += chunk;
           });
-          res.end('Not Found');
+          req.on('end', () => {
+            if (!fixtures) {
+              res.writeHead(503, {
+                'Content-Type': 'text/plain',
+                ...csrfHeaders,
+              });
+              res.end('Mock fixtures are not loaded');
+              return;
+            }
+            const route = matchRoute(
+              method,
+              url,
+              fixtures,
+              locks,
+              csrf.sessionId,
+              requestBody,
+            );
+            if (route) {
+              res.writeHead(route.status, {
+                'Content-Type': route.contentType,
+                ...csrfHeaders,
+                ...(route.headers ?? {}),
+              });
+              res.end(route.body);
+              return;
+            }
+
+            res.writeHead(404, {
+              'Content-Type': 'text/plain',
+              ...csrfHeaders,
+            });
+            res.end('Not Found');
+          });
         });
 
         server.listen(0, '127.0.0.1', () => {
@@ -92,6 +111,11 @@ export function createMockAdtServer(
 
         server.on('error', reject);
       });
+    },
+
+    async reset() {
+      fixtures = await loadRouteFixtures();
+      locks.clear();
     },
 
     async stop() {

--- a/packages/adt-flow/src/service.ts
+++ b/packages/adt-flow/src/service.ts
@@ -697,46 +697,79 @@ async function buildMaterializedResult(
   };
 }
 
+async function maybeSkipByAppComponent(
+  ctx: ProcessGroupContext,
+): Promise<GroupResult | undefined> {
+  if (!ctx.hasApplicationComponentFilter) return undefined;
+
+  const { group, dependencies, limiters, pending, calls } = ctx;
+  const model = await limiters.metadata.run(() =>
+    dependencies.loadObject(group.identity),
+  );
+  calls.metadata += model.metadataCalls ?? 1;
+  if (isApplicationComponentExcluded(ctx, model)) {
+    return {
+      desired: [],
+      descriptorPaths: [],
+      ownedPaths: pending.ownedPaths,
+      reusedIndexedComponent: false,
+    };
+  }
+  return undefined;
+}
+
+function canReuseIncrementalBase(
+  previous: ObjectDescriptor,
+  ctx: ProcessGroupContext,
+): boolean {
+  if (previous.state !== 'present') return false;
+  if (previous.configDigest !== ctx.configDigest) return false;
+  if (previous.formatDigest !== ctx.formatDigest) return false;
+  return indexedPackageMatches(previous, ctx.group);
+}
+
+async function handleBaseEmptyGroup(
+  ctx: ProcessGroupContext,
+  identity: FlowObjectIdentity,
+  descriptorPath: string,
+): Promise<GroupResult> {
+  const previous = ctx.pending.previous!;
+  if (canReuseIncrementalBase(previous, ctx)) {
+    return await reuseGroupIfExact(ctx, identity, descriptorPath);
+  }
+  return buildTombstoneResult(ctx, identity, descriptorPath);
+}
+
+async function resolveEmptyGroup(
+  ctx: ProcessGroupContext,
+  identity: FlowObjectIdentity,
+  descriptorPath: string,
+  hasDeletions: boolean,
+): Promise<GroupResult> {
+  const { mode, pending } = ctx;
+  if (mode === 'head' && hasDeletions) {
+    return buildTombstoneResult(ctx, identity, descriptorPath);
+  }
+  if (mode === 'base' && pending.previous) {
+    return handleBaseEmptyGroup(ctx, identity, descriptorPath);
+  }
+  return emptyGroupResult();
+}
+
 async function handleEmptyGroup(
   ctx: ProcessGroupContext,
   descriptorPath: string,
   hasDeletions: boolean,
 ): Promise<GroupResult> {
-  const { group, mode, dependencies, limiters, pending, calls } = ctx;
-  const { identity } = group;
+  const appComponentResult = await maybeSkipByAppComponent(ctx);
+  if (appComponentResult) return appComponentResult;
 
-  if (ctx.hasApplicationComponentFilter) {
-    const model = await limiters.metadata.run(() =>
-      dependencies.loadObject(identity),
-    );
-    calls.metadata += model.metadataCalls ?? 1;
-    if (isApplicationComponentExcluded(ctx, model)) {
-      return {
-        desired: [],
-        descriptorPaths: [],
-        ownedPaths: pending.ownedPaths,
-        reusedIndexedComponent: false,
-      };
-    }
-  }
-
-  if (mode === 'head' && hasDeletions) {
-    return buildTombstoneResult(ctx, identity, descriptorPath);
-  }
-
-  if (mode === 'base' && pending.previous) {
-    const canReuseIncrementalBase =
-      pending.previous.state === 'present' &&
-      pending.previous.configDigest === ctx.configDigest &&
-      pending.previous.formatDigest === ctx.formatDigest &&
-      indexedPackageMatches(pending.previous, group);
-    if (canReuseIncrementalBase) {
-      return reuseGroupIfExact(ctx, identity, descriptorPath);
-    }
-    return buildTombstoneResult(ctx, identity, descriptorPath);
-  }
-
-  return emptyGroupResult();
+  return resolveEmptyGroup(
+    ctx,
+    ctx.group.identity,
+    descriptorPath,
+    hasDeletions,
+  );
 }
 
 async function processGroup(ctx: ProcessGroupContext): Promise<GroupResult> {

--- a/packages/adt-flow/src/service.ts
+++ b/packages/adt-flow/src/service.ts
@@ -725,6 +725,14 @@ async function handleEmptyGroup(
   }
 
   if (mode === 'base' && pending.previous) {
+    const canReuseIncrementalBase =
+      pending.previous.state === 'present' &&
+      pending.previous.configDigest === ctx.configDigest &&
+      pending.previous.formatDigest === ctx.formatDigest &&
+      indexedPackageMatches(pending.previous, group);
+    if (canReuseIncrementalBase) {
+      return reuseGroupIfExact(ctx, identity, descriptorPath);
+    }
     return buildTombstoneResult(ctx, identity, descriptorPath);
   }
 

--- a/packages/adt-flow/tests/service.test.ts
+++ b/packages/adt-flow/tests/service.test.ts
@@ -334,6 +334,12 @@ describe('transport checkout', () => {
         'utf8',
       ),
     ).toBe('repository base\n');
+    expect(
+      await readFile(
+        join(workspace, 'src/feature/zcl_sample.clas.xml'),
+        'utf8',
+      ),
+    ).toBe('<CLASS NAME="ZCL_SAMPLE"/>\n');
     await expect(
       readFile(
         join(workspace, '.adt/objects/CLAS/zcl_sample.clas.adt.json'),

--- a/packages/adt-flow/tests/service.test.ts
+++ b/packages/adt-flow/tests/service.test.ts
@@ -247,6 +247,116 @@ describe('transport checkout', () => {
     ).toBe('source indexed\n');
   });
 
+  it('preserves an indexed object as the base of a later parent-attributed task', async () => {
+    const workspace = await root();
+    let current = manifest(
+      'added',
+      undefined,
+      version('task-one'),
+      'DEVK900001',
+    );
+    const ports = dependencies(() => current);
+    const flow = createAdtFlowService(ports);
+    await flow.checkout({
+      root: workspace,
+      transports: ['DEVK900001'],
+      config,
+    });
+    ports.readSource.mockClear();
+    ports.loadObject.mockClear();
+    current = manifest('added', undefined, version('task-two'), 'DEVK900002');
+
+    const base = await flow.checkout({
+      root: workspace,
+      transports: ['DEVK900002'],
+      mode: 'base',
+      config,
+    });
+
+    expect(base.fastPath).toBe('indexed-components');
+    expect(base.changed).toEqual([]);
+    expect(base.removed).toEqual([]);
+    expect(base.sapCalls).toEqual({ manifest: 1, metadata: 0, source: 0 });
+    expect(ports.readSource).not.toHaveBeenCalled();
+    expect(ports.loadObject).not.toHaveBeenCalled();
+    expect(
+      await readFile(
+        join(workspace, 'src/feature/zcl_sample.clas.abap'),
+        'utf8',
+      ),
+    ).toBe('source task-one\n');
+
+    const head = await flow.checkout({
+      root: workspace,
+      transports: ['DEVK900002'],
+      config,
+    });
+
+    expect(head.changed).toEqual(['src/feature/zcl_sample.clas.abap']);
+    expect(head.removed).toEqual([]);
+    expect(
+      await readFile(
+        join(workspace, 'src/feature/zcl_sample.clas.abap'),
+        'utf8',
+      ),
+    ).toBe('source task-two\n');
+  });
+
+  it('keeps an unindexed recognizable object as an added boundary base', async () => {
+    const workspace = await root();
+    await mkdir(join(workspace, 'src/feature'), { recursive: true });
+    await writeFile(
+      join(workspace, 'src/feature/zcl_sample.clas.abap'),
+      'repository base\n',
+    );
+    await writeFile(
+      join(workspace, 'src/feature/zcl_sample.clas.xml'),
+      '<CLASS NAME="ZCL_SAMPLE"/>\n',
+    );
+    const ports = dependencies(() =>
+      manifest('added', undefined, version('task-head')),
+    );
+    const flow = createAdtFlowService(ports);
+
+    const base = await flow.checkout({
+      root: workspace,
+      transports: ['DEVK900001'],
+      mode: 'base',
+      config,
+    });
+
+    expect(base.changed).toEqual([]);
+    expect(base.removed).toEqual([]);
+    expect(ports.readSource).not.toHaveBeenCalled();
+    expect(
+      await readFile(
+        join(workspace, 'src/feature/zcl_sample.clas.abap'),
+        'utf8',
+      ),
+    ).toBe('repository base\n');
+    await expect(
+      readFile(
+        join(workspace, '.adt/objects/CLAS/zcl_sample.clas.adt.json'),
+        'utf8',
+      ),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+
+    const head = await flow.checkout({
+      root: workspace,
+      transports: ['DEVK900001'],
+      config,
+    });
+
+    expect(head.changed).toEqual(['src/feature/zcl_sample.clas.abap']);
+    expect(head.removed).toEqual([]);
+    expect(
+      await readFile(
+        join(workspace, 'src/feature/zcl_sample.clas.abap'),
+        'utf8',
+      ),
+    ).toBe('source task-head\n');
+  });
+
   it('shows a first-observed deletion even when no descriptor exists', async () => {
     const workspace = await root();
     await mkdir(join(workspace, 'src/feature'), { recursive: true });

--- a/packages/adt-locks/src/index.ts
+++ b/packages/adt-locks/src/index.ts
@@ -36,6 +36,7 @@ export {
   AdtLockHandleUnavailableError,
   createLockService,
   parseLockResponse,
+  resolveLockCorrelation,
 } from './service';
 
 // Batch session — acquire/release N locks atomically (best-effort rollback).

--- a/packages/adt-locks/src/service.ts
+++ b/packages/adt-locks/src/service.ts
@@ -47,6 +47,18 @@ export interface UnlockOptions {
 }
 
 /**
+ * Resolve the CTS correlation for a write performed under a SAP editor lock.
+ * SAP's LOCK response is authoritative because it may normalize a child task
+ * to the request that actually owns the object lock.
+ */
+export function resolveLockCorrelation(
+  handle: Pick<LockHandle, 'correlationNumber'>,
+  requestedTransport?: string,
+): string | undefined {
+  return handle.correlationNumber || requestedTransport;
+}
+
+/**
  * SAP does not expose an ADT operation that returns the handle of an
  * existing CTS/editor lock. A caller can only unlock a handle it persisted
  * when it acquired that lock.

--- a/packages/adt-locks/tests/service.test.ts
+++ b/packages/adt-locks/tests/service.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { createLockService } from '../src/service';
+import { createLockService, resolveLockCorrelation } from '../src/service';
 import type { LockStore } from '../src/store';
 import type { LockEntry } from '../src/types';
 import type { LockClient } from '../src/service';
@@ -55,6 +55,23 @@ function createMockStore(): LockStore & {
     }),
   };
 }
+
+describe('resolveLockCorrelation()', () => {
+  it('prefers the authoritative transport returned by SAP LOCK', () => {
+    expect(
+      resolveLockCorrelation(
+        { handle: 'HANDLE_XYZ', correlationNumber: 'DEVK900001' },
+        'DEVK900002',
+      ),
+    ).toBe('DEVK900001');
+  });
+
+  it('falls back to the requested transport when LOCK omits CORRNR', () => {
+    expect(resolveLockCorrelation({ handle: 'HANDLE_XYZ' }, 'DEVK900002')).toBe(
+      'DEVK900002',
+    );
+  });
+});
 
 // ── lock ─────────────────────────────────────────────────────────────
 

--- a/packages/adt-mcp/README.md
+++ b/packages/adt-mcp/README.md
@@ -462,7 +462,21 @@ Create a new transport request.
 | `description` | string         | ✅      | Transport description                |
 | `type`        | `"K"` \| `"W"` | `"K"`   | Workbench (`K`) or Customizing (`W`) |
 
-> 🚧 Not yet implemented — returns a clear error until the underlying client method is available.
+---
+
+#### `cts_create_task`
+
+Create and verify a modifiable task under an existing transport request.
+
+**Parameters:**
+
+| Parameter   | Type   | Description                     |
+| ----------- | ------ | ------------------------------- |
+| `transport` | string | Parent transport request number |
+| `owner`     | string | SAP user who will own the task  |
+
+**Returns:** The parent transport number, created task number, normalized owner,
+and `created` status.
 
 ---
 
@@ -472,13 +486,10 @@ Release a transport request.
 
 **Parameters:**
 
-| Parameter     | Type   | Description      |
-| ------------- | ------ | ---------------- |
-| `transportId` | string | Transport number |
-
-> 🚧 Not yet implemented.
-
----
+| Parameter    | Type    | Description                                 |
+| ------------ | ------- | ------------------------------------------- |
+| `transport`  | string  | Transport number                            |
+| `releaseAll` | boolean | Release modifiable tasks before the request |
 
 #### `cts_delete_transport`
 
@@ -486,9 +497,9 @@ Delete a transport request.
 
 **Parameters:**
 
-| Parameter     | Type   | Description      |
-| ------------- | ------ | ---------------- |
-| `transportId` | string | Transport number |
+| Parameter   | Type   | Description      |
+| ----------- | ------ | ---------------- |
+| `transport` | string | Transport number |
 
 ---
 
@@ -648,35 +659,36 @@ await mock.stop();
 bunx nx build adt-mcp      # build
 bunx nx typecheck adt-mcp  # type check
 bunx nx lint adt-mcp       # lint
-bunx nx test adt-mcp       # tests (runs integration suite)
+cd packages/adt-mcp && node --test --import tsx tests/integration.test.ts
 ```
 
 ---
 
 ## Feature Parity Map
 
-| CLI Command                  | MCP Tool                        | Status     |
-| ---------------------------- | ------------------------------- | ---------- |
-| `adt discovery`              | `discovery`                     | ✅         |
-| `adt info`                   | `system_info`                   | ✅         |
-| `adt search`                 | `search_objects`                | ✅         |
-| `adt get`                    | `get_object`                    | ✅         |
-| `adt source get`             | `get_source`                    | ✅         |
-| `adt source versions`        | `list_source_versions`          | ✅         |
-| `adt source version get`     | `get_source_version`            | ✅         |
-| `adt source put`             | `update_source`                 | ✅         |
-| `adt activate`               | `activate_object`               | ✅         |
-| `adt check`                  | `check_syntax`                  | ✅         |
-| `adt aunit run`              | `run_unit_tests`                | ✅         |
-| `adt atc run`                | `atc_run`                       | ✅         |
-| `adt cts tr list`            | `cts_list_transports`           | ✅         |
-| `adt cts tr get`             | `cts_get_transport`             | ✅         |
-| `adt cts tr source-manifest` | `cts_transport_source_manifest` | ✅         |
-| `adt cts tr delete`          | `cts_delete_transport`          | ✅         |
-| `adt cts tr create`          | `cts_create_transport`          | 🚧 Not yet |
-| `adt cts tr release`         | `cts_release_transport`         | 🚧 Not yet |
-| `adt flow checkout tr`       | `flow_checkout_tr`              | ✅         |
-| `adt ls`                     | —                               | 🔜 Future  |
-| `adt cts search`             | —                               | 🔜 Future  |
-| `adt import package`         | —                               | 🔜 Future  |
-| `adt import transport`       | —                               | 🔜 Future  |
+| CLI Command                  | MCP Tool                        | Status    |
+| ---------------------------- | ------------------------------- | --------- |
+| `adt discovery`              | `discovery`                     | ✅        |
+| `adt info`                   | `system_info`                   | ✅        |
+| `adt search`                 | `search_objects`                | ✅        |
+| `adt get`                    | `get_object`                    | ✅        |
+| `adt source get`             | `get_source`                    | ✅        |
+| `adt source versions`        | `list_source_versions`          | ✅        |
+| `adt source version get`     | `get_source_version`            | ✅        |
+| `adt source put`             | `update_source`                 | ✅        |
+| `adt activate`               | `activate_object`               | ✅        |
+| `adt check`                  | `check_syntax`                  | ✅        |
+| `adt aunit run`              | `run_unit_tests`                | ✅        |
+| `adt atc run`                | `atc_run`                       | ✅        |
+| `adt cts tr list`            | `cts_list_transports`           | ✅        |
+| `adt cts tr get`             | `cts_get_transport`             | ✅        |
+| `adt cts tr task create`     | `cts_create_task`               | ✅        |
+| `adt cts tr source-manifest` | `cts_transport_source_manifest` | ✅        |
+| `adt cts tr delete`          | `cts_delete_transport`          | ✅        |
+| `adt cts tr create`          | `cts_create_transport`          | ✅        |
+| `adt cts tr release`         | `cts_release_transport`         | ✅        |
+| `adt flow checkout tr`       | `flow_checkout_tr`              | ✅        |
+| `adt ls`                     | —                               | 🔜 Future |
+| `adt cts search`             | —                               | 🔜 Future |
+| `adt import package`         | —                               | 🔜 Future |
+| `adt import transport`       | —                               | 🔜 Future |

--- a/packages/adt-mcp/README.md
+++ b/packages/adt-mcp/README.md
@@ -632,12 +632,11 @@ const server = createMcpServer({
 
 ## Testing
 
-Integration tests use Node.js native test runner (`node:test`) and a built-in mock ADT server that needs no SAP system.
+Integration tests use Vitest and a built-in mock ADT server that needs no SAP system.
 
 ```bash
 # Run all integration tests
-cd packages/adt-mcp
-node --test --import tsx tests/integration.test.ts
+bunx vitest run tests/integration.test.ts
 ```
 
 ### Using the mock server in your own tests
@@ -659,7 +658,7 @@ await mock.stop();
 bunx nx build adt-mcp      # build
 bunx nx typecheck adt-mcp  # type check
 bunx nx lint adt-mcp       # lint
-cd packages/adt-mcp && node --test --import tsx tests/integration.test.ts
+bunx nx test adt-mcp       # run integration tests with Vitest
 ```
 
 ---

--- a/packages/adt-mcp/src/lib/tools/clone-object.ts
+++ b/packages/adt-mcp/src/lib/tools/clone-object.ts
@@ -12,7 +12,7 @@
 
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { createLockService } from '@abapify/adt-locks';
+import { createLockService, resolveLockCorrelation } from '@abapify/adt-locks';
 import type { ToolContext } from '../types';
 import {
   createAdtObject,
@@ -94,10 +94,11 @@ async function copySourceToClone(
       objectType: sourceType,
     });
     lockHandle = lockResult.handle;
+    const effectiveTransport = resolveLockCorrelation(lockResult, transport);
 
     const putParams = new URLSearchParams({
       lockHandle,
-      ...(transport ? { corrNr: transport } : {}),
+      ...(effectiveTransport ? { corrNr: effectiveTransport } : {}),
     });
 
     await client.fetch(

--- a/packages/adt-mcp/src/lib/tools/cts-create-task.ts
+++ b/packages/adt-mcp/src/lib/tools/cts-create-task.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { CtsTransportLifecycleService } from '@abapify/adt-cli';
+import type { ToolContext } from '../types';
+import { sessionOrConnectionShape } from './shared-schemas';
+import { resolveClient } from './session-helpers';
+
+export function registerCtsCreateTaskTool(
+  server: McpServer,
+  ctx: ToolContext,
+): void {
+  server.tool(
+    'cts_create_task',
+    'Create and verify a modifiable task under an existing transport request.',
+    {
+      ...sessionOrConnectionShape,
+      transport: z.string().describe('Parent transport request number'),
+      owner: z.string().describe('SAP user who should own the task'),
+    },
+    async (args, extra) => {
+      try {
+        const { client } = await resolveClient(ctx, args, extra ?? {});
+        const result = await new CtsTransportLifecycleService(
+          client,
+        ).createTask({ transport: args.transport, owner: args.owner });
+        return {
+          content: [
+            { type: 'text' as const, text: JSON.stringify(result, null, 2) },
+          ],
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: `Create transport task failed: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+        };
+      }
+    },
+  );
+}

--- a/packages/adt-mcp/src/lib/tools/cts-reassign-transport.ts
+++ b/packages/adt-mcp/src/lib/tools/cts-reassign-transport.ts
@@ -3,23 +3,15 @@
  *
  * CLI equivalent: `adt cts tr reassign <TR> <new-owner> [--recursive]`
  *
- * POSTs a changeowner user-action body to
- *   /sap/bc/adt/cts/transportrequests/{trkorr}
+ * Delegates to the shared CLI lifecycle service.
  */
 
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { CtsTransportLifecycleService } from '@abapify/adt-cli';
 import type { ToolContext } from '../types';
 import { sessionOrConnectionShape } from './shared-schemas';
 import { resolveClient } from './session-helpers';
-
-function escapeXmlAttr(value: string): string {
-  return value
-    .replaceAll(/&/g, '&amp;')
-    .replaceAll(/</g, '&lt;')
-    .replaceAll(/>/g, '&gt;')
-    .replaceAll(/"/g, '&quot;');
-}
 
 export function registerCtsReassignTransportTool(
   server: McpServer,
@@ -42,42 +34,17 @@ export function registerCtsReassignTransportTool(
     async (args, extra) => {
       try {
         const { client } = await resolveClient(ctx, args, extra ?? {});
-
-        const body =
-          '<?xml version="1.0" encoding="UTF-8"?>' +
-          '<tm:root xmlns:tm="http://www.sap.com/cts/adt/tm" ' +
-          'tm:useraction="changeowner" ' +
-          `tm:targetuser="${escapeXmlAttr(args.targetUser)}"/>`;
-
-        const query = args.recursive ? '?recursive=true' : '';
-
-        await client.fetch(
-          `/sap/bc/adt/cts/transportrequests/${args.transportNumber}${query}`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type':
-                'application/vnd.sap.adt.transportorganizer.v1+xml',
-              Accept: 'application/vnd.sap.adt.transportorganizer.v1+xml',
-            },
-            body,
-          },
-        );
+        const result = await new CtsTransportLifecycleService(client).reassign({
+          transport: args.transportNumber,
+          newOwner: args.targetUser,
+          recursive: args.recursive,
+        });
 
         return {
           content: [
             {
               type: 'text' as const,
-              text: JSON.stringify(
-                {
-                  status: 'reassigned',
-                  transport: args.transportNumber,
-                  newOwner: args.targetUser,
-                  recursive: args.recursive ?? false,
-                },
-                null,
-                2,
-              ),
+              text: JSON.stringify(result, null, 2),
             },
           ],
         };

--- a/packages/adt-mcp/src/lib/tools/cts-release-transport.ts
+++ b/packages/adt-mcp/src/lib/tools/cts-release-transport.ts
@@ -3,11 +3,12 @@
  *
  * CLI equivalent: `adt cts tr release <transport>`
  *
- * POSTs a typed transport organizer body to /sap/bc/adt/cts/transportrequests/{trkorr}
+ * Delegates to the shared CLI lifecycle service.
  */
 
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { CtsTransportLifecycleService } from '@abapify/adt-cli';
 import type { ToolContext } from '../types';
 import { sessionOrConnectionShape } from './shared-schemas';
 import { resolveClient } from './session-helpers';
@@ -24,37 +25,24 @@ export function registerCtsReleaseTransportTool(
       transport: z
         .string()
         .describe('Transport number to release (e.g. TRLK900001)'),
+      releaseAll: z
+        .boolean()
+        .optional()
+        .describe('Release all modifiable tasks before the request'),
     },
     async (args, extra) => {
       try {
         const { client } = await resolveClient(ctx, args, extra ?? {});
-        // SAP expects a namespace-prefixed action attribute here.
-        const body =
-          '<?xml version="1.0" encoding="UTF-8"?>' +
-          '<tm:root xmlns:tm="http://www.sap.com/cts/adt/tm" tm:useraction="release"/>';
-
-        await client.fetch(
-          `/sap/bc/adt/cts/transportrequests/${args.transport}`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type':
-                'application/vnd.sap.adt.transportorganizer.v1+xml',
-              Accept: 'application/vnd.sap.adt.transportorganizer.v1+xml',
-            },
-            body,
-          },
-        );
+        const result = await new CtsTransportLifecycleService(client).release({
+          transport: args.transport,
+          releaseAll: args.releaseAll,
+        });
 
         return {
           content: [
             {
               type: 'text' as const,
-              text: JSON.stringify(
-                { status: 'released', transport: args.transport },
-                null,
-                2,
-              ),
+              text: JSON.stringify(result, null, 2),
             },
           ],
         };

--- a/packages/adt-mcp/src/lib/tools/index.ts
+++ b/packages/adt-mcp/src/lib/tools/index.ts
@@ -17,6 +17,7 @@ import { registerGetObjectTool } from './get-object';
 import { registerCtsListTransportsTool } from './cts-list-transports';
 import { registerCtsGetTransportTool } from './cts-get-transport';
 import { registerCtsCreateTransportTool } from './cts-create-transport';
+import { registerCtsCreateTaskTool } from './cts-create-task';
 import { registerCtsReleaseTransportTool } from './cts-release-transport';
 import { registerCtsDeleteTransportTool } from './cts-delete-transport';
 import { registerCtsSearchTransportsTool } from './cts-search-transports';
@@ -141,6 +142,7 @@ export function registerTools(server: McpServer, ctx: ToolContext): void {
   registerCtsListTransportsTool(server, ctx);
   registerCtsGetTransportTool(server, ctx);
   registerCtsCreateTransportTool(server, ctx);
+  registerCtsCreateTaskTool(server, ctx);
   registerCtsReleaseTransportTool(server, ctx);
   registerCtsDeleteTransportTool(server, ctx);
   registerCtsSearchTransportsTool(server, ctx);

--- a/packages/adt-mcp/src/lib/tools/run-abap.ts
+++ b/packages/adt-mcp/src/lib/tools/run-abap.ts
@@ -18,7 +18,7 @@
 
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { createLockService } from '@abapify/adt-locks';
+import { createLockService, resolveLockCorrelation } from '@abapify/adt-locks';
 import { initializeAdk } from '@abapify/adk';
 import type { ToolContext } from '../types';
 import { sessionOrConnectionShape } from './shared-schemas';
@@ -143,10 +143,11 @@ export function registerRunAbapTool(server: McpServer, ctx: ToolContext): void {
           objectType: 'CLAS',
         });
         lockHandle = lock.handle;
+        const effectiveTransport = resolveLockCorrelation(lock, transport);
 
         const params = new URLSearchParams();
         params.set('lockHandle', lockHandle);
-        if (transport) params.set('corrNr', transport);
+        if (effectiveTransport) params.set('corrNr', effectiveTransport);
 
         await client.fetch(`${classUri}/source/main?${params.toString()}`, {
           method: 'PUT',

--- a/packages/adt-mcp/src/lib/tools/scope-catalogue.ts
+++ b/packages/adt-mcp/src/lib/tools/scope-catalogue.ts
@@ -177,6 +177,7 @@ export const MCP_TOOL_SCOPE_CATALOGUE: Readonly<Record<string, McpToolScope>> =
       'create_srvb',
       'create_srvd',
       'cts_create_transport',
+      'cts_create_task',
       'cts_delete_transport',
       'cts_reassign_transport',
       'cts_release_transport',

--- a/packages/adt-mcp/src/lib/tools/update-source.ts
+++ b/packages/adt-mcp/src/lib/tools/update-source.ts
@@ -9,7 +9,7 @@
 
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { createLockService } from '@abapify/adt-locks';
+import { createLockService, resolveLockCorrelation } from '@abapify/adt-locks';
 import {
   detectMethodBoundary,
   lintSource,
@@ -220,11 +220,12 @@ export function registerUpdateSourceTool(
           objectName: args.objectName,
         });
         lockHandle = lock.handle;
+        const effectiveTransport = resolveLockCorrelation(lock, args.transport);
 
         // 2. PUT source code
         const params = new URLSearchParams();
         params.set('lockHandle', lockHandle);
-        if (args.transport) params.set('corrNr', args.transport);
+        if (effectiveTransport) params.set('corrNr', effectiveTransport);
 
         await client.fetch(`${objectUri}/source/main?${params.toString()}`, {
           method: 'PUT',

--- a/packages/adt-mcp/tests/integration.test.ts
+++ b/packages/adt-mcp/tests/integration.test.ts
@@ -7,7 +7,7 @@
  * A lightweight mock ADT HTTP server provides fixture responses.
  */
 
-import { describe, it, before, after } from 'node:test';
+import { describe, it, beforeAll, afterAll } from 'vitest';
 import assert from 'node:assert';
 import { randomBytes } from 'node:crypto';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -58,7 +58,7 @@ function connArgs(): Record<string, string> {
 }
 
 describe('adt-mcp integration tests', () => {
-  before(async () => {
+  beforeAll(async () => {
     // 1. Start mock ADT backend
     mockAdt = createMockAdtServer();
     const info = await mockAdt.start();
@@ -93,7 +93,7 @@ describe('adt-mcp integration tests', () => {
     await client.connect(clientTransport);
   });
 
-  after(async () => {
+  afterAll(async () => {
     await client.close();
     await mockAdt.stop();
   });

--- a/packages/adt-mcp/tests/integration.test.ts
+++ b/packages/adt-mcp/tests/integration.test.ts
@@ -1112,6 +1112,10 @@ describe('adt-mcp integration tests', () => {
 
   describe('cts_reassign_transport tool', () => {
     it('reassigns a transport to a new owner', async () => {
+      // The release-tool scenario above intentionally transitions this shared
+      // fixture to R. Reassign must be exercised from an independent D state.
+      await mockAdt.reset();
+
       const { json } = await callTool('cts_reassign_transport', {
         ...connArgs(),
         transportNumber: 'DEVK900001',

--- a/packages/adt-mcp/tests/integration.test.ts
+++ b/packages/adt-mcp/tests/integration.test.ts
@@ -496,6 +496,22 @@ describe('adt-mcp integration tests', () => {
     });
   });
 
+  describe('cts_create_task tool', () => {
+    it('creates and verifies a modifiable task under a request', async () => {
+      const { json } = await callTool('cts_create_task', {
+        ...connArgs(),
+        transport: 'DEVK900001',
+        owner: 'NEWOWNER',
+      });
+      assert.deepStrictEqual(json, {
+        status: 'created',
+        transport: 'DEVK900001',
+        task: 'DEVK900004',
+        owner: 'NEWOWNER',
+      });
+    });
+  });
+
   // ── cts_release_transport ──────────────────────────────────────
 
   describe('cts_release_transport tool', () => {
@@ -1389,6 +1405,7 @@ describe('adt-mcp integration tests', () => {
         'cts_list_transports',
         'cts_get_transport',
         'cts_create_transport',
+        'cts_create_task',
         'cts_release_transport',
         'cts_delete_transport',
         'cts_search_transports',

--- a/packages/adt-mcp/tests/integration.test.ts
+++ b/packages/adt-mcp/tests/integration.test.ts
@@ -1132,12 +1132,16 @@ describe('adt-mcp integration tests', () => {
       // fixture to R. Reassign must be exercised from an independent D state.
       await mockAdt.reset();
 
-      const { json } = await callTool('cts_reassign_transport', {
+      const { json, raw } = await callTool('cts_reassign_transport', {
         ...connArgs(),
         transportNumber: 'DEVK900001',
         targetUser: 'NEWOWNER',
         recursive: true,
       });
+      assert.ok(
+        !(raw as { isError?: boolean }).isError,
+        `reassign should succeed: ${String(json)}`,
+      );
       const data = json as {
         status: string;
         transport: string;

--- a/packages/adt-mcp/vitest.config.ts
+++ b/packages/adt-mcp/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/integration.test.ts'],
+  },
+});

--- a/website/docs/mcp/tools/cts_create_task.md
+++ b/website/docs/mcp/tools/cts_create_task.md
@@ -1,0 +1,60 @@
+---
+title: cts_create_task
+sidebar_label: cts_create_task
+description: 'Create a modifiable task under an existing transport request'
+---
+
+# `cts_create_task`
+
+Create and verify a modifiable task under an existing transport request.
+
+Defined in [`packages/adt-mcp/src/lib/tools/cts-create-task.ts`](https://github.com/abapify/adt-cli/blob/main/packages/adt-mcp/src/lib/tools/cts-create-task.ts).
+
+## Input schema
+
+```ts
+{
+  baseUrl: string;   // SAP system base URL
+  client?: string;   // SAP client number
+  username?: string; // Username for basic auth
+  password?: string; // Password for basic auth
+  transport: string; // Parent transport request number
+  owner: string;     // SAP user who should own the task
+}
+```
+
+## Output
+
+The tool returns a single text content item whose body is a JSON-serialised object (`content[0].text`). On error, the response has `isError: true` and a human-readable message.
+
+```json
+{
+  "content": [{ "type": "text", "text": "<JSON.stringify(result, null, 2)>" }]
+}
+```
+
+See the source for the exact shape of `result`.
+
+## Example invocation
+
+```json
+{
+  "name": "cts_create_task",
+  "arguments": {
+    "baseUrl": "https://sap.example.com:44300",
+    "username": "DEVELOPER",
+    "password": "***",
+    "client": "100",
+    "transport": "DEVK900001",
+    "owner": "DEVELOPER"
+  }
+}
+```
+
+## Underlying contract
+
+- `client.adt.cts.transportrequests.createTask`
+
+## See also
+
+- [MCP overview](../overview.md)

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -55,6 +55,7 @@ const mcpTools = [
   'mcp/tools/create_package',
   'mcp/tools/create_srvb',
   'mcp/tools/create_srvd',
+  'mcp/tools/cts_create_task',
   'mcp/tools/cts_create_transport',
   'mcp/tools/cts_delete_transport',
   'mcp/tools/cts_get_transport',


### PR DESCRIPTION
## Summary

- verify CTS transport release, owner change, and delete outcomes against SAP read-back
- honor authoritative lock correlation on all source-write paths (CLI, MCP, ADK)
- add verified transport task creation (CLI + MCP) with SAP response parsing
- preserve task identity when SAP returns authoritative task numbers
- expand transport source manifest scope for parent-attributed task history
- reconcile incremental flow checkout when later tasks change objects from earlier tasks

## Scope

Shared CTS lifecycle behavior across SDK, CLI, and MCP — no consumer-specific wiring.

## Test plan

- [x] Vitest: ADK, adt-cli services, adt-contracts, adt-fixtures
- [x] MCP integration tests
- [x] OpenSpec strict validation
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verify CTS lifecycle with SAP read-back, add verified task creation, and enforce authoritative lock correlation for all writes across `@abapify/adk`, `adt-cli`, and `adt-mcp`. Also harden `adt check` for CI and preserve exact base when later tasks modify objects attributed to the parent request.

- **New Features**
  - Verified release and change-owner: use SAP release jobs and typed update; confirm via read-back. Shared lifecycle service in `adt-cli` and `adt-mcp`; MCP adds `cts_create_task`.
  - Verified task creation: create via `newtask`, parse response, and confirm via parent read-back. Exposed as `adt cts tr task create` and `cts_create_task`.
  - Exact manifest scope: keep concrete task identity; expand scope with parent request; reuse verified descriptors as the incremental base when later tasks change earlier objects; adopt recognizable files as base when descriptors are missing.
  - `adt check`: default to inactive source with `--source-version` (no collision with root `--version`); JSON output matches human output and sets non-zero exits on errors.

- **Bug Fixes**
  - Honor authoritative lock correlation: use `resolveLockCorrelation` in ADK, `adt-cli` (source, `abap run`, function module), and MCP tools to write under SAP-resolved CORRNR.
  - Normalize transport identifiers and route CTS CLI through a shared lifecycle service; unify validation, output, and failure reporting across CLI/MCP.
  - Preserve task identity when SAP responds with parent request names; prefer the authoritative task number from SAP.

<sup>Written for commit 0ff04e3d2d2d04bfc65c9ba1fffe7a320f0e4148. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CTS transport task creation through the CLI and MCP.
  * Improved transport release and owner reassignment with verified results and recursive task handling.
  * Added clearer ADT check source selection, JSON output, and meaningful failure status codes.

* **Bug Fixes**
  * Source updates now use SAP-confirmed transport correlations.
  * Deferred save and deployment failures are now reported.
  * Transport checkout preserves prior versions and exact source provenance.

* **Documentation**
  * Added usage guidance for checks and CTS task operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->