### PR TITLE
feat(badi): classic BAdI read via vit/wb (stacked on #153)

### DIFF
--- a/packages/adk/package.json
+++ b/packages/adk/package.json
@@ -17,6 +17,7 @@
   ],
   "dependencies": {
     "@abapify/adt-client": "0.4.1",
+    "@abapify/adt-contracts": "0.4.1",
     "@abapify/adt-locks": "0.4.1",
     "@abapify/adt-schemas": "0.4.1"
   },

--- a/packages/adk/src/index.ts
+++ b/packages/adk/src/index.ts
@@ -145,6 +145,10 @@ export { AdkDdlSource, AdkDclSource } from './objects/cds';
 // RAP types and classes
 export { AdkBehaviorDefinition } from './objects/repository/bdef';
 export { AdkBadi } from './objects/repository/badi';
+export {
+  AdkClassicBadiDefinition,
+  AdkClassicBadiImplementation,
+} from './objects/repository/classic-badi';
 export { AdkServiceDefinition } from './objects/repository/srvd';
 export { AdkServiceBinding } from './objects/repository/srvb';
 

--- a/packages/adk/src/objects/repository/classic-badi/classic-badi.model.ts
+++ b/packages/adk/src/objects/repository/classic-badi/classic-badi.model.ts
@@ -10,6 +10,14 @@ import { getGlobalContext } from '../../../base/global-context';
 import type { AdkContext } from '../../../base/context';
 import type { BasicObjectPropertiesResponse } from '@abapify/adt-contracts';
 
+function isNotFound(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { status?: unknown }).status === 404
+  );
+}
+
 export class AdkClassicBadiDefinition {
   static readonly kind = 'ClassicBadiDefinition' as const;
   readonly kind = AdkClassicBadiDefinition.kind;
@@ -46,7 +54,8 @@ export class AdkClassicBadiDefinition {
     try {
       await AdkClassicBadiDefinition.get(name, ctx);
       return true;
-    } catch {
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
       return false;
     }
   }
@@ -88,7 +97,8 @@ export class AdkClassicBadiImplementation {
     try {
       await AdkClassicBadiImplementation.get(name, ctx);
       return true;
-    } catch {
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
       return false;
     }
   }

--- a/packages/adk/src/objects/repository/classic-badi/classic-badi.model.ts
+++ b/packages/adk/src/objects/repository/classic-badi/classic-badi.model.ts
@@ -23,10 +23,7 @@ function isNotFound(error: unknown): boolean {
   );
 }
 
-export class AdkClassicBadiDefinition {
-  static readonly kind = 'ClassicBadiDefinition' as const;
-  readonly kind = AdkClassicBadiDefinition.kind;
-
+abstract class AdkClassicBadiBase {
   readonly name: string;
   protected readonly ctx: AdkContext;
 
@@ -34,6 +31,40 @@ export class AdkClassicBadiDefinition {
     this.ctx = input.ctx;
     this.name = input.name.toUpperCase();
   }
+
+  abstract get kind(): string;
+  abstract get objectUri(): string;
+  abstract getMetadata(): Promise<BasicObjectPropertiesResponse>;
+
+  static async get<T extends AdkClassicBadiBase>(
+    this: { new (input: { ctx: AdkContext; name: string }): T },
+    input: ClassicBadiInput,
+  ): Promise<T> {
+    const context = input.ctx ?? getGlobalContext();
+    const obj = new this({ ctx: context, name: input.name });
+    await obj.getMetadata();
+    return obj;
+  }
+
+  static async exists<T extends AdkClassicBadiBase>(
+    this: { new (input: { ctx: AdkContext; name: string }): T },
+    input: ClassicBadiInput,
+  ): Promise<boolean> {
+    try {
+      const ctor = this as unknown as {
+        get(input: ClassicBadiInput): Promise<T>;
+      };
+      await ctor.get(input);
+      return true;
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+      return false;
+    }
+  }
+}
+
+export class AdkClassicBadiDefinition extends AdkClassicBadiBase {
+  readonly kind = 'ClassicBadiDefinition' as const;
 
   get objectUri(): string {
     return `/sap/bc/adt/vit/wb/object_type/sxsdxd/object_name/${encodeURIComponent(this.name.toLowerCase())}`;
@@ -44,39 +75,10 @@ export class AdkClassicBadiDefinition {
       this.name,
     );
   }
-
-  static async get(input: ClassicBadiInput): Promise<AdkClassicBadiDefinition> {
-    const context = input.ctx ?? getGlobalContext();
-    const obj = new AdkClassicBadiDefinition({
-      ctx: context,
-      name: input.name,
-    });
-    await obj.getMetadata();
-    return obj;
-  }
-
-  static async exists(input: ClassicBadiInput): Promise<boolean> {
-    try {
-      await AdkClassicBadiDefinition.get(input);
-      return true;
-    } catch (error) {
-      if (!isNotFound(error)) throw error;
-      return false;
-    }
-  }
 }
 
-export class AdkClassicBadiImplementation {
-  static readonly kind = 'ClassicBadiImplementation' as const;
-  readonly kind = AdkClassicBadiImplementation.kind;
-
-  readonly name: string;
-  protected readonly ctx: AdkContext;
-
-  constructor(input: { ctx: AdkContext; name: string }) {
-    this.ctx = input.ctx;
-    this.name = input.name.toUpperCase();
-  }
+export class AdkClassicBadiImplementation extends AdkClassicBadiBase {
+  readonly kind = 'ClassicBadiImplementation' as const;
 
   get objectUri(): string {
     return `/sap/bc/adt/vit/wb/object_type/sxcixi/object_name/${encodeURIComponent(this.name.toLowerCase())}`;
@@ -86,27 +88,5 @@ export class AdkClassicBadiImplementation {
     return await this.ctx.client.adt.vit.wb.objectProperties.getImplementation(
       this.name,
     );
-  }
-
-  static async get(
-    input: ClassicBadiInput,
-  ): Promise<AdkClassicBadiImplementation> {
-    const context = input.ctx ?? getGlobalContext();
-    const obj = new AdkClassicBadiImplementation({
-      ctx: context,
-      name: input.name,
-    });
-    await obj.getMetadata();
-    return obj;
-  }
-
-  static async exists(input: ClassicBadiInput): Promise<boolean> {
-    try {
-      await AdkClassicBadiImplementation.get(input);
-      return true;
-    } catch (error) {
-      if (!isNotFound(error)) throw error;
-      return false;
-    }
   }
 }

--- a/packages/adk/src/objects/repository/classic-badi/classic-badi.model.ts
+++ b/packages/adk/src/objects/repository/classic-badi/classic-badi.model.ts
@@ -10,6 +10,11 @@ import { getGlobalContext } from '../../../base/global-context';
 import type { AdkContext } from '../../../base/context';
 import type { BasicObjectPropertiesResponse } from '@abapify/adt-contracts';
 
+interface ClassicBadiInput {
+  name: string;
+  ctx?: AdkContext;
+}
+
 function isNotFound(error: unknown): boolean {
   return (
     typeof error === 'object' &&
@@ -25,9 +30,9 @@ export class AdkClassicBadiDefinition {
   readonly name: string;
   protected readonly ctx: AdkContext;
 
-  constructor(ctx: AdkContext, name: string) {
-    this.ctx = ctx;
-    this.name = name.toUpperCase();
+  constructor(input: { ctx: AdkContext; name: string }) {
+    this.ctx = input.ctx;
+    this.name = input.name.toUpperCase();
   }
 
   get objectUri(): string {
@@ -40,19 +45,19 @@ export class AdkClassicBadiDefinition {
     );
   }
 
-  static async get(
-    name: string,
-    ctx?: AdkContext,
-  ): Promise<AdkClassicBadiDefinition> {
-    const context = ctx ?? getGlobalContext();
-    const obj = new AdkClassicBadiDefinition(context, name);
+  static async get(input: ClassicBadiInput): Promise<AdkClassicBadiDefinition> {
+    const context = input.ctx ?? getGlobalContext();
+    const obj = new AdkClassicBadiDefinition({
+      ctx: context,
+      name: input.name,
+    });
     await obj.getMetadata();
     return obj;
   }
 
-  static async exists(name: string, ctx?: AdkContext): Promise<boolean> {
+  static async exists(input: ClassicBadiInput): Promise<boolean> {
     try {
-      await AdkClassicBadiDefinition.get(name, ctx);
+      await AdkClassicBadiDefinition.get(input);
       return true;
     } catch (error) {
       if (!isNotFound(error)) throw error;
@@ -68,9 +73,9 @@ export class AdkClassicBadiImplementation {
   readonly name: string;
   protected readonly ctx: AdkContext;
 
-  constructor(ctx: AdkContext, name: string) {
-    this.ctx = ctx;
-    this.name = name.toUpperCase();
+  constructor(input: { ctx: AdkContext; name: string }) {
+    this.ctx = input.ctx;
+    this.name = input.name.toUpperCase();
   }
 
   get objectUri(): string {
@@ -84,18 +89,20 @@ export class AdkClassicBadiImplementation {
   }
 
   static async get(
-    name: string,
-    ctx?: AdkContext,
+    input: ClassicBadiInput,
   ): Promise<AdkClassicBadiImplementation> {
-    const context = ctx ?? getGlobalContext();
-    const obj = new AdkClassicBadiImplementation(context, name);
+    const context = input.ctx ?? getGlobalContext();
+    const obj = new AdkClassicBadiImplementation({
+      ctx: context,
+      name: input.name,
+    });
     await obj.getMetadata();
     return obj;
   }
 
-  static async exists(name: string, ctx?: AdkContext): Promise<boolean> {
+  static async exists(input: ClassicBadiInput): Promise<boolean> {
     try {
-      await AdkClassicBadiImplementation.get(name, ctx);
+      await AdkClassicBadiImplementation.get(input);
       return true;
     } catch (error) {
       if (!isNotFound(error)) throw error;

--- a/packages/adk/src/objects/repository/classic-badi/classic-badi.model.ts
+++ b/packages/adk/src/objects/repository/classic-badi/classic-badi.model.ts
@@ -1,0 +1,95 @@
+/**
+ * Classic BAdI — read-only ADK models for SXSD/XD and SXCI/XI metadata.
+ *
+ * Served via vit/wb Basic Object Properties:
+ *   GET /sap/bc/adt/vit/wb/object_type/sxsdxd/object_name/{name}
+ *   GET /sap/bc/adt/vit/wb/object_type/sxcixi/object_name/{name}
+ */
+
+import { getGlobalContext } from '../../../base/global-context';
+import type { AdkContext } from '../../../base/context';
+import type { BasicObjectPropertiesResponse } from '@abapify/adt-contracts';
+
+export class AdkClassicBadiDefinition {
+  static readonly kind = 'ClassicBadiDefinition' as const;
+  readonly kind = AdkClassicBadiDefinition.kind;
+
+  readonly name: string;
+  protected readonly ctx: AdkContext;
+
+  constructor(ctx: AdkContext, name: string) {
+    this.ctx = ctx;
+    this.name = name.toUpperCase();
+  }
+
+  get objectUri(): string {
+    return `/sap/bc/adt/vit/wb/object_type/sxsdxd/object_name/${encodeURIComponent(this.name.toLowerCase())}`;
+  }
+
+  async getMetadata(): Promise<BasicObjectPropertiesResponse> {
+    return await this.ctx.client.adt.vit.wb.objectProperties.getDefinition(
+      this.name,
+    );
+  }
+
+  static async get(
+    name: string,
+    ctx?: AdkContext,
+  ): Promise<AdkClassicBadiDefinition> {
+    const context = ctx ?? getGlobalContext();
+    const obj = new AdkClassicBadiDefinition(context, name);
+    await obj.getMetadata();
+    return obj;
+  }
+
+  static async exists(name: string, ctx?: AdkContext): Promise<boolean> {
+    try {
+      await AdkClassicBadiDefinition.get(name, ctx);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+export class AdkClassicBadiImplementation {
+  static readonly kind = 'ClassicBadiImplementation' as const;
+  readonly kind = AdkClassicBadiImplementation.kind;
+
+  readonly name: string;
+  protected readonly ctx: AdkContext;
+
+  constructor(ctx: AdkContext, name: string) {
+    this.ctx = ctx;
+    this.name = name.toUpperCase();
+  }
+
+  get objectUri(): string {
+    return `/sap/bc/adt/vit/wb/object_type/sxcixi/object_name/${encodeURIComponent(this.name.toLowerCase())}`;
+  }
+
+  async getMetadata(): Promise<BasicObjectPropertiesResponse> {
+    return await this.ctx.client.adt.vit.wb.objectProperties.getImplementation(
+      this.name,
+    );
+  }
+
+  static async get(
+    name: string,
+    ctx?: AdkContext,
+  ): Promise<AdkClassicBadiImplementation> {
+    const context = ctx ?? getGlobalContext();
+    const obj = new AdkClassicBadiImplementation(context, name);
+    await obj.getMetadata();
+    return obj;
+  }
+
+  static async exists(name: string, ctx?: AdkContext): Promise<boolean> {
+    try {
+      await AdkClassicBadiImplementation.get(name, ctx);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/packages/adk/src/objects/repository/classic-badi/index.ts
+++ b/packages/adk/src/objects/repository/classic-badi/index.ts
@@ -1,0 +1,4 @@
+export {
+  AdkClassicBadiDefinition,
+  AdkClassicBadiImplementation,
+} from './classic-badi.model';

--- a/packages/adk/tsconfig.lib.json
+++ b/packages/adk/tsconfig.lib.json
@@ -20,6 +20,9 @@
       "path": "../adt-locks/tsconfig.lib.json"
     },
     {
+      "path": "../adt-contracts"
+    },
+    {
       "path": "../adt-client"
     }
   ]

--- a/packages/adt-cli/src/index.ts
+++ b/packages/adt-cli/src/index.ts
@@ -95,10 +95,17 @@ export {
   type ReleaseTransportResult,
 } from './lib/services/cts';
 
-// BAdI / Enhancement Implementation metadata
+// BAdI — ENHO metadata (enhoxhb) and unified read (classic vit/wb + ENHO)
 export {
   getBadiInfo,
   parseEnhancementImplementation,
+  BadiService,
+  ClassicBadiService,
+  normalizeClassicBadiMetadata,
   type BadiInfo,
   type BadiImplementation,
+  type BadiKind,
+  type BadiMetadata,
+  type BadiReadResult,
+  type ClassicBadiMetadata,
 } from './lib/services/badi';

--- a/packages/adt-cli/src/lib/cli.ts
+++ b/packages/adt-cli/src/lib/cli.ts
@@ -65,7 +65,7 @@ import { createDatapreviewCommand } from './commands/datapreview';
 import { createAbapCommand } from './commands/abap';
 import { ddlCommand, dclCommand } from './commands/cds';
 import { bdefCommand } from './commands/bdef';
-import { badiCommand } from './commands/badi';
+import { badiCommand, getBadiCommand } from './commands/badi';
 import { srvdCommand } from './commands/srvd';
 import { srvbCommand } from './commands/srvb';
 import { createCheckoutCommand } from './commands/checkout';
@@ -222,6 +222,7 @@ export async function createCLI(options?: {
 
   // Get subcommands for specific object types (legacy: adt get package <name>)
   getCommand.addCommand(packageGetCommand);
+  getCommand.addCommand(getBadiCommand);
 
   // Package commands (adt package create/list/delete/activate/stat/get)
   program.addCommand(createPackageCommand());

--- a/packages/adt-cli/src/lib/cli.ts
+++ b/packages/adt-cli/src/lib/cli.ts
@@ -137,6 +137,104 @@ function getResolvedConfigPath(argv: string[]): string | undefined {
   return undefined;
 }
 
+function registerAuthAndCoreCommands(program: Command): void {
+  const authCmd = program
+    .command('auth')
+    .description('Authentication commands');
+  authCmd.addCommand(loginCommand);
+  authCmd.addCommand(logoutCommand);
+  authCmd.addCommand(statusCommand);
+  authCmd.addCommand(authListCommand);
+  authCmd.addCommand(setDefaultCommand);
+  authCmd.addCommand(refreshCommand);
+
+  program.addCommand(discoveryCommand);
+  program.addCommand(infoCommand);
+  program.addCommand(fetchCommand);
+  program.addCommand(getCommand);
+  getCommand.addCommand(packageGetCommand);
+  getCommand.addCommand(getBadiCommand);
+  program.addCommand(searchCommand);
+  program.addCommand(lsCommand);
+  program.addCommand(createCtsCommand());
+}
+
+function registerImportAndUtilityCommands(program: Command): void {
+  const importCmd = program
+    .command('import')
+    .description('Import ABAP objects to various formats (abapGit, etc.)');
+  importCmd.addCommand(importObjectCommand);
+  importCmd.addCommand(importPackageCommand);
+  importCmd.addCommand(importTransportCommand);
+
+  program.addCommand(lockCommand);
+  program.addCommand(unlockCommand);
+  program.addCommand(locksCommand);
+  program.addCommand(checkCommand);
+  program.addCommand(sourceCommand);
+  program.addCommand(lintCommand);
+  program.addCommand(contextCommand);
+  program.addCommand(createDiagnoseCommand());
+  program.addCommand(userCommand);
+  program.addCommand(strustCommand);
+}
+
+function registerObjectAndRapCommands(program: Command): void {
+  program.addCommand(createPackageCommand());
+  program.addCommand(classCommand);
+  program.addCommand(programCommand);
+  program.addCommand(interfaceCommand);
+  program.addCommand(includeCommand);
+  program.addCommand(functionCommand);
+  program.addCommand(domainCommand);
+  program.addCommand(dataelementCommand);
+  program.addCommand(tableCommand);
+  program.addCommand(structureCommand);
+  program.addCommand(createDatapreviewCommand());
+  program.addCommand(createAbapCommand());
+  program.addCommand(ddlCommand);
+  program.addCommand(dclCommand);
+  program.addCommand(bdefCommand);
+  program.addCommand(badiCommand);
+  program.addCommand(srvdCommand);
+  program.addCommand(srvbCommand);
+  program.addCommand(createCheckoutCommand());
+  program.addCommand(checkinCommand);
+  program.addCommand(createChangesetCommand());
+  program.addCommand(rfcCommand);
+  program.addCommand(createFlpCommand());
+  program.addCommand(createWbCommand());
+  program.addCommand(createReplCommand());
+  program.addCommand(proxyCommand);
+}
+
+async function registerPluginCommands(
+  program: Command,
+  options?: { preloadedPlugins?: CliCommandPlugin[] },
+): Promise<void> {
+  // gCTS command-plugin (E07). Auto-registered here (not via adt.config.ts)
+  // because `@abapify/adt-plugin-gcts-cli` is a required dependency of
+  // `adt-cli`, matching the pattern used for the abapGit/gCTS *format*
+  // plugins above.
+  await loadStaticPlugins(program, [gctsCommand], process.cwd());
+
+  // Load command plugins from config (adt.config.ts or --config)
+  // NOTE: We need to parse --config early since plugins must be loaded before parseAsync()
+  const configPath = getResolvedConfigPath(process.argv);
+
+  if (options?.preloadedPlugins !== undefined) {
+    // Bundled mode: register statically imported plugins (no dynamic import needed)
+    await loadStaticPlugins(
+      program,
+      options.preloadedPlugins,
+      process.cwd(),
+      configPath,
+    );
+  } else {
+    await loadCommandPlugins(program, process.cwd(), configPath);
+  }
+}
+
 // Create main program
 export async function createCLI(options?: {
   /** Pre-loaded plugins to register instead of loading from config.
@@ -181,13 +279,7 @@ export async function createCLI(options?: {
     )
     .hook('preAction', (thisCommand) => {
       const opts = thisCommand.optsWithGlobals();
-
-      // Create logger based on global options
-      const logger = createCliLogger({
-        verbose: opts.verbose,
-      });
-
-      // Store logger and logging config for use in commands
+      const logger = createCliLogger({ verbose: opts.verbose });
       (thisCommand as any).logger = logger;
       (thisCommand as any).loggingConfig = {
         logLevel: opts.logLevel || 'info',
@@ -196,164 +288,11 @@ export async function createCLI(options?: {
       };
     });
 
-  // Auth commands
-  const authCmd = program
-    .command('auth')
-    .description('Authentication commands');
+  registerAuthAndCoreCommands(program);
+  registerImportAndUtilityCommands(program);
+  registerObjectAndRapCommands(program);
+  await registerPluginCommands(program, options);
 
-  authCmd.addCommand(loginCommand);
-  authCmd.addCommand(logoutCommand);
-  authCmd.addCommand(statusCommand);
-  authCmd.addCommand(authListCommand);
-  authCmd.addCommand(setDefaultCommand);
-  authCmd.addCommand(refreshCommand);
-
-  // Discovery command
-  program.addCommand(discoveryCommand);
-
-  // Info command (system and session info)
-  program.addCommand(infoCommand);
-
-  // Fetch command (authenticated HTTP requests)
-  program.addCommand(fetchCommand);
-
-  // Object inspector command
-  program.addCommand(getCommand);
-
-  // Get subcommands for specific object types (legacy: adt get package <name>)
-  getCommand.addCommand(packageGetCommand);
-  getCommand.addCommand(getBadiCommand);
-
-  // Package commands (adt package create/list/delete/activate/stat/get)
-  program.addCommand(createPackageCommand());
-
-  // ATC (ABAP Test Cockpit) command - now loaded as plugin from @abapify/adt-atc
-  // Add '@abapify/adt-atc/commands/atc' to adt.config.ts commands array to enable
-
-  // Search command
-  program.addCommand(searchCommand);
-
-  // List objects in repository (format-aware: abapgit, AFF)
-  program.addCommand(lsCommand);
-
-  // CTS commands (v2 client) - replaces old 'transport' command
-  // Use: adt cts search, adt cts get <TR>
-  // NOTE: Future commands - adt cts create, adt cts release (via ADK), adt cts check
-  program.addCommand(createCtsCommand());
-
-  // Import commands
-  const importCmd = program
-    .command('import')
-    .description('Import ABAP objects to various formats (abapGit, etc.)');
-
-  importCmd.addCommand(importObjectCommand);
-  importCmd.addCommand(importPackageCommand);
-  importCmd.addCommand(importTransportCommand);
-
-  // Export commands - moved to @abapify/adt-export plugin
-  // Add '@abapify/adt-export/commands/export' to adt.config.ts commands array to enable
-
-  // Deploy command moved to @abapify/adt-export plugin
-  // Add '@abapify/adt-export/commands/export' to adt.config.ts commands array to enable
-
-  // Lock command (acquire lock, persist handle)
-  program.addCommand(lockCommand);
-
-  // Unlock command (force-release stale locks)
-  program.addCommand(unlockCommand);
-
-  // Locks command (list/cleanup persisted lock handles)
-  program.addCommand(locksCommand);
-
-  // Check command (syntax check / checkruns)
-  program.addCommand(checkCommand);
-
-  // Source command (read/write ABAP source code)
-  program.addCommand(sourceCommand);
-  program.addCommand(lintCommand);
-  program.addCommand(contextCommand);
-  program.addCommand(createDiagnoseCommand());
-
-  // User lookup command
-  program.addCommand(userCommand);
-
-  // STRUST command (SSL PSE cert management)
-  program.addCommand(strustCommand);
-
-  // Object CRUD commands (class, program, interface, include)
-  program.addCommand(classCommand);
-  program.addCommand(programCommand);
-  program.addCommand(interfaceCommand);
-  program.addCommand(includeCommand);
-  program.addCommand(functionCommand);
-
-  // DDIC commands (domain, dataelement, table, structure)
-  program.addCommand(domainCommand);
-  program.addCommand(dataelementCommand);
-  program.addCommand(tableCommand);
-  program.addCommand(structureCommand);
-
-  // Datapreview (OSQL queries)
-  program.addCommand(createDatapreviewCommand());
-
-  // ABAP execution (abap run)
-  program.addCommand(createAbapCommand());
-
-  // CDS/RAP commands (DDL, DCL)
-  program.addCommand(ddlCommand);
-  program.addCommand(dclCommand);
-  program.addCommand(bdefCommand);
-  program.addCommand(badiCommand);
-  program.addCommand(srvdCommand);
-  program.addCommand(srvbCommand);
-
-  // Checkout command (download SAP objects to abapgit-compatible files)
-  program.addCommand(createCheckoutCommand());
-
-  // Checkin command (push local abapGit/gCTS directory into SAP — inverse of checkout)
-  program.addCommand(checkinCommand);
-
-  // Changeset command (Wave 3) — transactional unit-of-work: begin/add/commit/rollback
-  program.addCommand(createChangesetCommand());
-
-  // RFC command (E13) — invoke classic RFC function modules via SOAP-over-HTTP
-  program.addCommand(rfcCommand);
-
-  // FLP command (E14) — Fiori Launchpad inventory (read-only)
-  program.addCommand(createFlpCommand());
-
-  // Workbench navigation (E15) — where-used, callers, callees, definition, outline
-  program.addCommand(createWbCommand());
-
-  // REPL - Interactive hypermedia navigator
-  program.addCommand(createReplCommand());
-
-  // Proxy command - ADT proxy server with JSON↔XML conversion
-  program.addCommand(proxyCommand);
-
-  // gCTS command-plugin (E07). Auto-registered here (not via adt.config.ts)
-  // because `@abapify/adt-plugin-gcts-cli` is a required dependency of
-  // `adt-cli`, matching the pattern used for the abapGit/gCTS *format*
-  // plugins above.
-  await loadStaticPlugins(program, [gctsCommand], process.cwd());
-
-  // Load command plugins from config (adt.config.ts or --config)
-  // NOTE: We need to parse --config early since plugins must be loaded before parseAsync()
-  const configPath = getResolvedConfigPath(process.argv);
-
-  if (options?.preloadedPlugins !== undefined) {
-    // Bundled mode: register statically imported plugins (no dynamic import needed)
-    await loadStaticPlugins(
-      program,
-      options.preloadedPlugins,
-      process.cwd(),
-      configPath,
-    );
-  } else {
-    await loadCommandPlugins(program, process.cwd(), configPath);
-  }
-
-  // Apply global options help to all commands using afterAll hook
   addGlobalOptionsHelpToAll(program);
 
   return program;

--- a/packages/adt-cli/src/lib/commands/badi/index.ts
+++ b/packages/adt-cli/src/lib/commands/badi/index.ts
@@ -1,34 +1,28 @@
 /**
- * adt badi — BAdI / Enhancement Implementation (ENHO/XHH) commands
+ * BAdI commands — ENHO CRUD + metadata (`adt badi`) and unified read (`adt get badi`).
  *
- * Enhancement Implementations are RAP-era containers for BAdI
- * implementations. Full CRUD + activation exposed at
- * `/sap/bc/adt/enhancements/enhoxhh`. Source (the BAdI payload) is
- * served as text via `/source/main`.
- *
- * BAdI implementation metadata (the list of implementations, their
- * active/default flags and implementing classes) is exposed by SAP at
- * `/sap/bc/adt/enhancements/enhoxhb/{name}` and is surfaced by the
- * default `adt badi <name>` command with the `--implementations` flag.
- *
- * Usage:
+ * ENHO/XHH (enhancement implementation):
  *   adt badi ZE_MY_BADI_IMPL
  *   adt badi ZE_MY_BADI_IMPL --implementations
  *   adt badi ZE_MY_BADI_IMPL --json
  *   adt badi create ZE_MY_BADI_IMPL "My BAdI impl" ZMYPKG
  *   adt badi read   ZE_MY_BADI_IMPL
- *   adt badi write  ZE_MY_BADI_IMPL impl.abap --transport DEVK900001
- *   adt badi activate ZE_MY_BADI_IMPL
- *   adt badi delete ZE_MY_BADI_IMPL --transport DEVK900001
  *
- * References:
- *   - sapcli: `sap/cli/badi.py` (list, set-active)
- *   - ARC-1: `src/adt/client.ts` `getEnhancementImplementation`
+ * Classic SXSD/SXCI (read-only via get):
+ *   adt get badi CTS_REQUEST_CHECK --json
+ *   adt get badi CTS_REQUEST_CHECK --implementations --json
  */
 
 import { AdkBadi } from '@abapify/adk';
-import { getAdtClientV2 } from '../../utils/adt-client-v2';
-import { getBadiInfo } from '../../services/badi';
+import { Command } from 'commander';
+import { getAdtClientV2, getCliContext } from '../../utils/adt-client-v2';
+import { createProgressReporter } from '../../utils/progress-reporter';
+import { createCliLogger } from '../../utils/logger-config';
+import {
+  BadiService,
+  getBadiInfo,
+  type BadiReadResult,
+} from '../../services/badi';
 import { buildObjectCrudCommands } from '../object/builder';
 
 const badiCommand = buildObjectCrudCommands({
@@ -125,5 +119,87 @@ badiCommand
       }
     },
   );
+
+function printHumanResult(result: BadiReadResult): void {
+  if (result.source) {
+    process.stdout.write(result.source);
+    return;
+  }
+
+  console.log(`Kind:        ${result.kind}`);
+  console.log(`Name:        ${result.name}`);
+  console.log(`Type:        ${result.type}`);
+  if (result.description) console.log(`Description: ${result.description}`);
+  if (result.packageName) console.log(`Package:     ${result.packageName}`);
+  if (result.version) console.log(`Version:     ${result.version}`);
+
+  if (result.implementations?.length) {
+    console.log('');
+    console.log(`Implementations (${result.implementations.length}):`);
+    for (const impl of result.implementations) {
+      const suffix = impl.description ? ` — ${impl.description}` : '';
+      console.log(`  ${impl.name}${suffix}`);
+    }
+  }
+}
+
+export const getBadiCommand = new Command('badi')
+  .argument('<name>', 'BAdI definition, implementation, or ENHO name')
+  .description(
+    'Get BAdI metadata; use --implementations on a definition to list classic implementations',
+  )
+  .option('--json', 'Output as JSON')
+  .option(
+    '--implementations',
+    'When reading a classic definition (SXSD/XD), include its SXCI/XI implementations',
+  )
+  .action(async function (
+    this: Command,
+    name: string,
+    options: { json?: boolean; implementations?: boolean },
+  ) {
+    const globalOpts = this.optsWithGlobals?.() ?? {};
+    const ctx = getCliContext();
+    const verboseFlag = globalOpts.verbose ?? ctx.verbose ?? false;
+    const logger =
+      (this as any).logger ??
+      ctx.logger ??
+      createCliLogger({ verbose: verboseFlag });
+    const progress = createProgressReporter({
+      compact: !verboseFlag,
+      logger,
+    });
+
+    try {
+      const client = await getAdtClientV2();
+      const service = new BadiService(client);
+
+      progress.step(`🔍 Loading ${name.toUpperCase()}...`);
+      const result = await service.get(name, {
+        includeSource: !options.json,
+        includeImplementations: options.implementations,
+      });
+      progress.done();
+
+      if (options.implementations && result.kind !== 'definition') {
+        console.error(
+          '❌ --implementations is only valid for classic BAdI definitions (SXSD/XD)',
+        );
+        process.exit(1);
+      }
+
+      if (options.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+
+      printHumanResult(result);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      progress.done(`❌ ${message}`);
+      console.error(`❌ Get BAdI failed:`, message);
+      process.exit(1);
+    }
+  });
 
 export { badiCommand };

--- a/packages/adt-cli/src/lib/commands/badi/index.ts
+++ b/packages/adt-cli/src/lib/commands/badi/index.ts
@@ -55,7 +55,10 @@ badiCommand
 
       try {
         const adtClient = await getAdtClientV2();
-        const info = await getBadiInfo(adtClient, normalizedName);
+        const info = await getBadiInfo({
+          client: adtClient,
+          name: normalizedName,
+        });
 
         if (options.json) {
           console.log(JSON.stringify(info, null, 2));
@@ -117,11 +120,6 @@ badiCommand
   );
 
 function printHumanResult(result: BadiReadResult): void {
-  if (result.source) {
-    process.stdout.write(result.source);
-    return;
-  }
-
   console.log(`Kind:        ${result.kind}`);
   console.log(`Name:        ${result.name}`);
   console.log(`Type:        ${result.type}`);
@@ -182,9 +180,12 @@ export const getBadiCommand = new Command('badi')
       if (!opts.json) {
         progress.step(`🔍 Loading ${name.toUpperCase()}...`);
       }
-      const result = await service.get(name, {
-        includeSource: !opts.json,
-        includeImplementations: opts.implementations,
+      const result = await service.get({
+        name,
+        options: {
+          includeSource: !opts.json,
+          includeImplementations: opts.implementations,
+        },
       });
       if (!opts.json) {
         progress.done();
@@ -199,6 +200,11 @@ export const getBadiCommand = new Command('badi')
 
       if (opts.json) {
         console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+
+      if (result.source) {
+        process.stdout.write(result.source);
         return;
       }
 

--- a/packages/adt-cli/src/lib/commands/badi/index.ts
+++ b/packages/adt-cli/src/lib/commands/badi/index.ts
@@ -1,6 +1,7 @@
 /**
  * BAdI commands — ENHO CRUD + metadata (`adt badi`) and unified read (`adt get badi`).
  *
+<<<<<<< HEAD
  * ENHO/XHH (enhancement implementation):
  *   adt badi ZE_MY_BADI_IMPL
  *   adt badi ZE_MY_BADI_IMPL --implementations
@@ -11,6 +12,14 @@
  * Classic SXSD/SXCI (read-only via get):
  *   adt get badi CTS_REQUEST_CHECK --json
  *   adt get badi CTS_REQUEST_CHECK --implementations --json
+=======
+ *   adt get badi MOCK_CTS_REQUEST_CHECK --json
+ *   adt get badi MOCK_CTS_REQUEST_CHECK --implementations --json
+ *   adt get badi ZE_MOCK_CLASSIC_BADI_IMPL --json
+ *   adt get badi ZE_MOCK_BADI                 # ENHO/XHH source
+ *
+ * Mutating operations (create, write, delete) belong under deploy/checkin.
+>>>>>>> c3132ed3 (chore(badi): sanitize examples and fixture comments for upstream PR)
  */
 
 import { AdkBadi } from '@abapify/adk';

--- a/packages/adt-cli/src/lib/commands/badi/index.ts
+++ b/packages/adt-cli/src/lib/commands/badi/index.ts
@@ -1,25 +1,12 @@
 /**
  * BAdI commands — ENHO CRUD + metadata (`adt badi`) and unified read (`adt get badi`).
  *
-<<<<<<< HEAD
- * ENHO/XHH (enhancement implementation):
- *   adt badi ZE_MY_BADI_IMPL
- *   adt badi ZE_MY_BADI_IMPL --implementations
- *   adt badi ZE_MY_BADI_IMPL --json
- *   adt badi create ZE_MY_BADI_IMPL "My BAdI impl" ZMYPKG
- *   adt badi read   ZE_MY_BADI_IMPL
- *
- * Classic SXSD/SXCI (read-only via get):
- *   adt get badi CTS_REQUEST_CHECK --json
- *   adt get badi CTS_REQUEST_CHECK --implementations --json
-=======
  *   adt get badi MOCK_CTS_REQUEST_CHECK --json
  *   adt get badi MOCK_CTS_REQUEST_CHECK --implementations --json
  *   adt get badi ZE_MOCK_CLASSIC_BADI_IMPL --json
  *   adt get badi ZE_MOCK_BADI                 # ENHO/XHH source
  *
  * Mutating operations (create, write, delete) belong under deploy/checkin.
->>>>>>> c3132ed3 (chore(badi): sanitize examples and fixture comments for upstream PR)
  */
 
 import { AdkBadi } from '@abapify/adk';
@@ -167,7 +154,16 @@ export const getBadiCommand = new Command('badi')
     name: string,
     options: { json?: boolean; implementations?: boolean },
   ) {
-    const globalOpts = this.optsWithGlobals?.() ?? {};
+    const globalOpts = (this.optsWithGlobals?.() ?? {}) as {
+      json?: boolean;
+      implementations?: boolean;
+      verbose?: boolean;
+    };
+    const opts = {
+      json: options.json ?? globalOpts.json ?? false,
+      implementations:
+        options.implementations ?? globalOpts.implementations ?? false,
+    };
     const ctx = getCliContext();
     const verboseFlag = globalOpts.verbose ?? ctx.verbose ?? false;
     const logger =
@@ -183,21 +179,25 @@ export const getBadiCommand = new Command('badi')
       const client = await getAdtClientV2();
       const service = new BadiService(client);
 
-      progress.step(`🔍 Loading ${name.toUpperCase()}...`);
+      if (!opts.json) {
+        progress.step(`🔍 Loading ${name.toUpperCase()}...`);
+      }
       const result = await service.get(name, {
-        includeSource: !options.json,
-        includeImplementations: options.implementations,
+        includeSource: !opts.json,
+        includeImplementations: opts.implementations,
       });
-      progress.done();
+      if (!opts.json) {
+        progress.done();
+      }
 
-      if (options.implementations && result.kind !== 'definition') {
+      if (opts.implementations && result.kind !== 'definition') {
         console.error(
           '❌ --implementations is only valid for classic BAdI definitions (SXSD/XD)',
         );
         process.exit(1);
       }
 
-      if (options.json) {
+      if (opts.json) {
         console.log(JSON.stringify(result, null, 2));
         return;
       }
@@ -205,7 +205,9 @@ export const getBadiCommand = new Command('badi')
       printHumanResult(result);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      progress.done(`❌ ${message}`);
+      if (!opts.json) {
+        progress.done(`❌ ${message}`);
+      }
       console.error(`❌ Get BAdI failed:`, message);
       process.exit(1);
     }

--- a/packages/adt-cli/src/lib/services/badi/index.ts
+++ b/packages/adt-cli/src/lib/services/badi/index.ts
@@ -6,7 +6,7 @@
  * - `BadiService` — auto-detect kind and read classic SXSD/SXCI or ENHO/XHH.
  */
 import type { AdtClient } from '@abapify/adt-client';
-import type { AdtClientType } from '@abapify/adt-contracts';
+
 import type { BasicObjectPropertiesResponse } from '@abapify/adt-contracts';
 import { DOMParser } from '@xmldom/xmldom';
 
@@ -164,6 +164,8 @@ export type BadiMetadata = {
   responsible?: string;
   masterLanguage?: string;
   masterSystem?: string;
+  /** When SAP supplies a container reference, it can be used to validate lineage. */
+  containerRef?: { name?: string; type?: string };
 };
 
 export type BadiReadResult = BadiMetadata & {
@@ -177,12 +179,7 @@ export type BadiReadResult = BadiMetadata & {
 /** @deprecated Use BadiMetadata */
 export type ClassicBadiMetadata = Omit<BadiMetadata, 'kind'>;
 
-const BADI_REPOSITORY_TYPES = new Set([
-  'SXSD/XD',
-  'SXCI/XI',
-  'ENHO/XHH',
-  'ENHO/XHB',
-]);
+const BADI_REPOSITORY_TYPES = new Set(['SXSD/XD', 'SXCI/XI', 'ENHO/XHH']);
 
 function isNotFound(error: unknown): boolean {
   return (
@@ -229,14 +226,14 @@ export function normalizeClassicBadiMetadata(
   response: BasicObjectPropertiesResponse,
   kind: 'definition' | 'implementation',
 ): BadiMetadata {
-  const main = response.mainObject;
-  if (!main) {
+  if (!('mainObject' in response) || !response.mainObject) {
     throw new Error('BAdI response missing mainObject');
   }
+  const main = response.mainObject;
   return {
     kind,
-    name: main.name.toUpperCase(),
-    type: main.type,
+    name: (main.name ?? '').toUpperCase(),
+    type: main.type ?? '',
     description: main.description,
     language: main.language,
     version: main.version,
@@ -245,6 +242,9 @@ export function normalizeClassicBadiMetadata(
     responsible: main.responsible,
     masterLanguage: main.masterLanguage,
     masterSystem: main.masterSystem,
+    containerRef: main.containerRef
+      ? { name: main.containerRef.name, type: main.containerRef.type }
+      : undefined,
   };
 }
 
@@ -264,133 +264,309 @@ function searchQueriesForDefinition(definitionName: string): string[] {
   return [...queries];
 }
 
+interface ServiceContext {
+  readonly client: AdtClient;
+  readonly normalized: string;
+}
+
+interface ReadContext extends ServiceContext {
+  readonly options?: {
+    includeSource?: boolean;
+    includeImplementations?: boolean;
+  };
+}
+
+async function resolveBySearch({
+  client,
+  normalized,
+}: ServiceContext): Promise<BadiKind | undefined> {
+  const search =
+    await client.adt.repository.informationsystem.search.quickSearch({
+      query: normalized,
+      maxResults: 20,
+    });
+  const matches = extractSearchObjects(search).filter(
+    (obj) =>
+      obj.name?.toUpperCase() === normalized &&
+      obj.type &&
+      BADI_REPOSITORY_TYPES.has(obj.type.toUpperCase()),
+  );
+  if (matches.length === 1) {
+    return badiKindFromType(matches[0].type!);
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Ambiguous BAdI name ${normalized}: ${matches.map((m) => m.type).join(', ')}`,
+    );
+  }
+  return undefined;
+}
+
+async function runProbe({
+  client,
+  normalized,
+  kind,
+  expectedType,
+}: ServiceContext & { kind: BadiKind; expectedType: string }): Promise<
+  BadiKind | undefined
+> {
+  const response =
+    kind === 'definition'
+      ? await client.adt.vit.wb.objectProperties.getDefinition(normalized)
+      : await client.adt.vit.wb.objectProperties.getImplementation(normalized);
+  if (!('mainObject' in response) || !response.mainObject) {
+    return undefined;
+  }
+  const main = response.mainObject;
+  if (
+    main.type?.toUpperCase() === expectedType &&
+    main.name?.toUpperCase() === normalized
+  ) {
+    return kind;
+  }
+  return undefined;
+}
+
+async function resolveEnhancement({
+  client,
+  normalized,
+}: ServiceContext): Promise<BadiKind | undefined> {
+  try {
+    await getBadiInfo(client, normalized);
+    return 'enhancement';
+  } catch (error) {
+    if (!isNotFound(error)) throw error;
+    return undefined;
+  }
+}
+
+async function resolveKind(ctx: ServiceContext): Promise<BadiKind> {
+  const bySearch = await resolveBySearch(ctx);
+  if (bySearch) return bySearch;
+
+  const definition = await runProbe({
+    ...ctx,
+    kind: 'definition',
+    expectedType: 'SXSD/XD',
+  });
+  if (definition) return definition;
+
+  const implementation = await runProbe({
+    ...ctx,
+    kind: 'implementation',
+    expectedType: 'SXCI/XI',
+  });
+  if (implementation) return implementation;
+
+  const enhancement = await resolveEnhancement(ctx);
+  if (enhancement) return enhancement;
+
+  throw new Error(`BAdI object not found: ${ctx.normalized}`);
+}
+
+async function readDefinition({
+  client,
+  normalized,
+}: ServiceContext): Promise<BadiMetadata> {
+  const response =
+    await client.adt.vit.wb.objectProperties.getDefinition(normalized);
+  return normalizeClassicBadiMetadata(response, 'definition');
+}
+
+async function readImplementation({
+  client,
+  normalized,
+}: ServiceContext): Promise<BadiMetadata> {
+  const response =
+    await client.adt.vit.wb.objectProperties.getImplementation(normalized);
+  return normalizeClassicBadiMetadata(response, 'implementation');
+}
+
+async function readEnhancement({
+  client,
+  normalized,
+  options,
+}: ReadContext): Promise<BadiReadResult> {
+  const lower = normalized.toLowerCase();
+  const info = await getBadiInfo(client, normalized);
+  const source = options?.includeSource
+    ? String(await client.adt.enhancements.enhoxhh.source.main.get(lower))
+    : undefined;
+  return {
+    kind: 'enhancement',
+    name: info.name.toUpperCase(),
+    type: info.type,
+    description: info.description,
+    version: info.version,
+    packageName: info.package,
+    responsible: info.responsible,
+    enhancement: info,
+    source,
+  };
+}
+
+async function getBadi(ctx: ReadContext): Promise<BadiReadResult> {
+  const kind = await resolveKind(ctx);
+  switch (kind) {
+    case 'definition': {
+      const definition = await readDefinition(ctx);
+      if (!ctx.options?.includeImplementations) {
+        return definition;
+      }
+      const implementations = await listImplementations(ctx);
+      return { ...definition, implementations };
+    }
+    case 'implementation':
+      return readImplementation(ctx);
+    case 'enhancement':
+      return readEnhancement(ctx);
+    default:
+      throw new Error(`Unsupported BAdI kind: ${kind satisfies never}`);
+  }
+}
+
+interface SearchCandidateContext extends ServiceContext {
+  readonly query: string;
+  readonly objectType?: 'SXCI';
+  readonly seen: Set<string>;
+}
+
+function candidateNames(
+  search: unknown,
+  normalized: string,
+  seen: Set<string>,
+): string[] {
+  const names: string[] = [];
+  for (const obj of extractSearchObjects(search)) {
+    if (obj.type?.toUpperCase() !== 'SXCI/XI') continue;
+    const implName = obj.name?.toUpperCase();
+    if (!implName) continue;
+    if (implName === normalized) continue;
+    if (seen.has(implName)) continue;
+    seen.add(implName);
+    names.push(implName);
+  }
+  return names;
+}
+
+async function tryReadImplementation({
+  client,
+  definitionName,
+  implName,
+}: {
+  client: AdtClient;
+  definitionName: string;
+  implName: string;
+}): Promise<BadiMetadata | undefined> {
+  try {
+    const impl = await readImplementation({ client, normalized: implName });
+    const containerName = impl.containerRef?.name?.toUpperCase();
+    if (containerName && containerName !== definitionName) {
+      return undefined;
+    }
+    return impl;
+  } catch (error) {
+    if (!isNotFound(error)) throw error;
+    return undefined;
+  }
+}
+
+async function collectSearchCandidates({
+  client,
+  normalized,
+  query,
+  objectType,
+  seen,
+}: SearchCandidateContext): Promise<BadiMetadata[]> {
+  const params: { query: string; maxResults: number; objectType?: 'SXCI' } = {
+    query,
+    maxResults: 100,
+  };
+  if (objectType) {
+    params.objectType = objectType;
+  }
+  const search =
+    await client.adt.repository.informationsystem.search.quickSearch(params);
+
+  const names = candidateNames(search, normalized, seen);
+  const found: BadiMetadata[] = [];
+  for (const implName of names) {
+    const impl = await tryReadImplementation({
+      client,
+      definitionName: normalized,
+      implName,
+    });
+    if (impl) found.push(impl);
+  }
+  return found;
+}
+
+async function listImplementations({
+  client,
+  normalized,
+}: ServiceContext): Promise<BadiMetadata[]> {
+  await readDefinition({ client, normalized });
+
+  const queries = searchQueriesForDefinition(normalized);
+  const seen = new Set<string>();
+  const all: BadiMetadata[] = [];
+
+  for (const query of queries) {
+    all.push(
+      ...(await collectSearchCandidates({
+        client,
+        normalized,
+        query,
+        seen,
+      })),
+    );
+    all.push(
+      ...(await collectSearchCandidates({
+        client,
+        normalized,
+        query,
+        objectType: 'SXCI',
+        seen,
+      })),
+    );
+  }
+
+  return all.sort((a, b) => a.name.localeCompare(b.name));
+}
+
 export class BadiService {
-  constructor(private readonly client: AdtClientType) {}
+  constructor(private readonly client: AdtClient) {}
 
   async resolveKind(name: string): Promise<BadiKind> {
-    const normalized = name.trim().toUpperCase();
-
-    const search =
-      await this.client.adt.repository.informationsystem.search.quickSearch({
-        query: normalized,
-        maxResults: 20,
-      });
-    const matches = extractSearchObjects(search).filter(
-      (obj) =>
-        obj.name?.toUpperCase() === normalized &&
-        obj.type &&
-        BADI_REPOSITORY_TYPES.has(obj.type.toUpperCase()),
-    );
-    if (matches.length === 1) {
-      return badiKindFromType(matches[0].type!);
-    }
-    if (matches.length > 1) {
-      throw new Error(
-        `Ambiguous BAdI name ${normalized}: ${matches.map((m) => m.type).join(', ')}`,
-      );
-    }
-
-    const probes: Array<{
-      kind: BadiKind;
-      expectedType: string;
-      run: () => Promise<BasicObjectPropertiesResponse>;
-    }> = [
-      {
-        kind: 'definition',
-        expectedType: 'SXSD/XD',
-        run: () => this.client.adt.vit.wb.objectProperties.getDefinition(name),
-      },
-      {
-        kind: 'implementation',
-        expectedType: 'SXCI/XI',
-        run: () =>
-          this.client.adt.vit.wb.objectProperties.getImplementation(name),
-      },
-    ];
-
-    for (const probe of probes) {
-      try {
-        const response = await probe.run();
-        const main = response.mainObject;
-        if (
-          main?.type?.toUpperCase() === probe.expectedType &&
-          main.name?.toUpperCase() === normalized
-        ) {
-          return probe.kind;
-        }
-      } catch (error) {
-        if (!isNotFound(error)) throw error;
-      }
-    }
-
-    try {
-      await getBadiInfo(this.client as unknown as AdtClient, normalized);
-      return 'enhancement';
-    } catch (error) {
-      if (!isNotFound(error)) throw error;
-    }
-
-    throw new Error(`BAdI object not found: ${normalized}`);
+    return resolveKind({
+      client: this.client,
+      normalized: name.trim().toUpperCase(),
+    });
   }
 
   async get(
     name: string,
     options?: { includeSource?: boolean; includeImplementations?: boolean },
   ): Promise<BadiReadResult> {
-    const kind = await this.resolveKind(name);
-    switch (kind) {
-      case 'definition': {
-        const response =
-          await this.client.adt.vit.wb.objectProperties.getDefinition(name);
-        const definition = normalizeClassicBadiMetadata(response, 'definition');
-        if (!options?.includeImplementations) {
-          return definition;
-        }
-        const implementations = await this.listImplementations(name);
-        return { ...definition, implementations };
-      }
-      case 'implementation': {
-        const response =
-          await this.client.adt.vit.wb.objectProperties.getImplementation(name);
-        return normalizeClassicBadiMetadata(response, 'implementation');
-      }
-      case 'enhancement': {
-        const normalized = name.trim().toUpperCase();
-        const lower = normalized.toLowerCase();
-        const info = await getBadiInfo(
-          this.client as unknown as AdtClient,
-          normalized,
-        );
-        const source = options?.includeSource
-          ? String(
-              await this.client.adt.enhancements.enhoxhh.source.main.get(lower),
-            )
-          : undefined;
-        return {
-          kind: 'enhancement',
-          name: info.name.toUpperCase(),
-          type: info.type,
-          description: info.description,
-          version: info.version,
-          packageName: info.package,
-          responsible: info.responsible,
-          enhancement: info,
-          source,
-        };
-      }
-    }
+    return getBadi({
+      client: this.client,
+      normalized: name.trim().toUpperCase(),
+      options,
+    });
   }
 
   async getDefinition(name: string): Promise<BadiMetadata> {
-    const response =
-      await this.client.adt.vit.wb.objectProperties.getDefinition(name);
-    return normalizeClassicBadiMetadata(response, 'definition');
+    return readDefinition({
+      client: this.client,
+      normalized: name.trim().toUpperCase(),
+    });
   }
 
   async getImplementation(name: string): Promise<BadiMetadata> {
-    const response =
-      await this.client.adt.vit.wb.objectProperties.getImplementation(name);
-    return normalizeClassicBadiMetadata(response, 'implementation');
+    return readImplementation({
+      client: this.client,
+      normalized: name.trim().toUpperCase(),
+    });
   }
 
   /**
@@ -399,40 +575,10 @@ export class BadiService {
    * state requires SXC_ATTR (not exposed on all systems).
    */
   async listImplementations(definitionName: string): Promise<BadiMetadata[]> {
-    const normalized = definitionName.trim().toUpperCase();
-    await this.getDefinition(normalized);
-
-    const queries = searchQueriesForDefinition(normalized);
-    const seen = new Set<string>();
-    const implementations: BadiMetadata[] = [];
-
-    for (const query of queries) {
-      for (const objectType of [undefined, 'SXCI'] as const) {
-        const search =
-          await this.client.adt.repository.informationsystem.search.quickSearch(
-            {
-              query,
-              maxResults: 500,
-              ...(objectType ? { objectType } : {}),
-            },
-          );
-        for (const obj of extractSearchObjects(search)) {
-          if (obj.type?.toUpperCase() !== 'SXCI/XI') continue;
-          const implName = obj.name?.toUpperCase();
-          if (!implName || implName === normalized || seen.has(implName)) {
-            continue;
-          }
-          seen.add(implName);
-          try {
-            implementations.push(await this.getImplementation(implName));
-          } catch {
-            /* skip entries that cannot be read via vit/wb */
-          }
-        }
-      }
-    }
-
-    return implementations.sort((a, b) => a.name.localeCompare(b.name));
+    return listImplementations({
+      client: this.client,
+      normalized: definitionName.trim().toUpperCase(),
+    });
   }
 }
 

--- a/packages/adt-cli/src/lib/services/badi/index.ts
+++ b/packages/adt-cli/src/lib/services/badi/index.ts
@@ -132,10 +132,13 @@ export function parseEnhancementImplementation(xml: string): BadiInfo {
  * Fetch ENHO metadata for a BAdI / enhancement implementation and parse
  * the BAdI implementation list.
  */
-export async function getBadiInfo(
-  client: AdtClient,
-  name: string,
-): Promise<BadiInfo> {
+export async function getBadiInfo({
+  client,
+  name,
+}: {
+  client: AdtClient;
+  name: string;
+}): Promise<BadiInfo> {
   const response = await client.fetch(
     `/sap/bc/adt/enhancements/enhoxhb/${encodeURIComponent(name.toLowerCase())}`,
     {
@@ -222,10 +225,13 @@ function extractSearchObjects(results: unknown): Array<{
   return Array.isArray(raw) ? raw : [raw];
 }
 
-export function normalizeClassicBadiMetadata(
-  response: BasicObjectPropertiesResponse,
-  kind: 'definition' | 'implementation',
-): BadiMetadata {
+export function normalizeClassicBadiMetadata({
+  response,
+  kind,
+}: {
+  response: BasicObjectPropertiesResponse;
+  kind: 'definition' | 'implementation';
+}): BadiMetadata {
   if (!('mainObject' in response) || !response.mainObject) {
     throw new Error('BAdI response missing mainObject');
   }
@@ -248,8 +254,8 @@ export function normalizeClassicBadiMetadata(
   };
 }
 
-function searchQueriesForDefinition(definitionName: string): string[] {
-  const normalized = definitionName.trim().toUpperCase();
+function searchQueriesForDefinition({ name }: { name: string }): string[] {
+  const normalized = name.trim().toUpperCase();
   const queries = new Set<string>([
     `*${normalized}*`,
     `*${normalized.replace(/_/g, '*')}*`,
@@ -276,18 +282,17 @@ interface ReadContext extends ServiceContext {
   };
 }
 
-async function resolveBySearch({
-  client,
-  normalized,
-}: ServiceContext): Promise<BadiKind | undefined> {
+async function resolveBySearch(
+  ctx: ServiceContext,
+): Promise<BadiKind | undefined> {
   const search =
-    await client.adt.repository.informationsystem.search.quickSearch({
-      query: normalized,
+    await ctx.client.adt.repository.informationsystem.search.quickSearch({
+      query: ctx.normalized,
       maxResults: 20,
     });
   const matches = extractSearchObjects(search).filter(
     (obj) =>
-      obj.name?.toUpperCase() === normalized &&
+      obj.name?.toUpperCase() === ctx.normalized &&
       obj.type &&
       BADI_REPOSITORY_TYPES.has(obj.type.toUpperCase()),
   );
@@ -296,43 +301,41 @@ async function resolveBySearch({
   }
   if (matches.length > 1) {
     throw new Error(
-      `Ambiguous BAdI name ${normalized}: ${matches.map((m) => m.type).join(', ')}`,
+      `Ambiguous BAdI name ${ctx.normalized}: ${matches.map((m) => m.type).join(', ')}`,
     );
   }
   return undefined;
 }
 
-async function runProbe({
-  client,
-  normalized,
-  kind,
-  expectedType,
-}: ServiceContext & { kind: BadiKind; expectedType: string }): Promise<
-  BadiKind | undefined
-> {
+async function runProbe(
+  ctx: ServiceContext & { kind: BadiKind; expectedType: string },
+): Promise<BadiKind | undefined> {
   const response =
-    kind === 'definition'
-      ? await client.adt.vit.wb.objectProperties.getDefinition(normalized)
-      : await client.adt.vit.wb.objectProperties.getImplementation(normalized);
+    ctx.kind === 'definition'
+      ? await ctx.client.adt.vit.wb.objectProperties.getDefinition(
+          ctx.normalized,
+        )
+      : await ctx.client.adt.vit.wb.objectProperties.getImplementation(
+          ctx.normalized,
+        );
   if (!('mainObject' in response) || !response.mainObject) {
     return undefined;
   }
   const main = response.mainObject;
   if (
-    main.type?.toUpperCase() === expectedType &&
-    main.name?.toUpperCase() === normalized
+    main.type?.toUpperCase() === ctx.expectedType &&
+    main.name?.toUpperCase() === ctx.normalized
   ) {
-    return kind;
+    return ctx.kind;
   }
   return undefined;
 }
 
-async function resolveEnhancement({
-  client,
-  normalized,
-}: ServiceContext): Promise<BadiKind | undefined> {
+async function resolveEnhancement(
+  ctx: ServiceContext,
+): Promise<BadiKind | undefined> {
   try {
-    await getBadiInfo(client, normalized);
+    await getBadiInfo({ client: ctx.client, name: ctx.normalized });
     return 'enhancement';
   } catch (error) {
     if (!isNotFound(error)) throw error;
@@ -364,33 +367,26 @@ async function resolveKind(ctx: ServiceContext): Promise<BadiKind> {
   throw new Error(`BAdI object not found: ${ctx.normalized}`);
 }
 
-async function readDefinition({
-  client,
-  normalized,
-}: ServiceContext): Promise<BadiMetadata> {
-  const response =
-    await client.adt.vit.wb.objectProperties.getDefinition(normalized);
-  return normalizeClassicBadiMetadata(response, 'definition');
+async function readDefinition(ctx: ServiceContext): Promise<BadiMetadata> {
+  const response = await ctx.client.adt.vit.wb.objectProperties.getDefinition(
+    ctx.normalized,
+  );
+  return normalizeClassicBadiMetadata({ response, kind: 'definition' });
 }
 
-async function readImplementation({
-  client,
-  normalized,
-}: ServiceContext): Promise<BadiMetadata> {
+async function readImplementation(ctx: ServiceContext): Promise<BadiMetadata> {
   const response =
-    await client.adt.vit.wb.objectProperties.getImplementation(normalized);
-  return normalizeClassicBadiMetadata(response, 'implementation');
+    await ctx.client.adt.vit.wb.objectProperties.getImplementation(
+      ctx.normalized,
+    );
+  return normalizeClassicBadiMetadata({ response, kind: 'implementation' });
 }
 
-async function readEnhancement({
-  client,
-  normalized,
-  options,
-}: ReadContext): Promise<BadiReadResult> {
-  const lower = normalized.toLowerCase();
-  const info = await getBadiInfo(client, normalized);
-  const source = options?.includeSource
-    ? String(await client.adt.enhancements.enhoxhh.source.main.get(lower))
+async function readEnhancement(ctx: ReadContext): Promise<BadiReadResult> {
+  const lower = ctx.normalized.toLowerCase();
+  const info = await getBadiInfo({ client: ctx.client, name: ctx.normalized });
+  const source = ctx.options?.includeSource
+    ? String(await ctx.client.adt.enhancements.enhoxhh.source.main.get(lower))
     : undefined;
   return {
     kind: 'enhancement',
@@ -431,37 +427,36 @@ interface SearchCandidateContext extends ServiceContext {
   readonly seen: Set<string>;
 }
 
-function candidateNames(
-  search: unknown,
-  normalized: string,
-  seen: Set<string>,
-): string[] {
+function candidateNames(ctx: {
+  search: unknown;
+  normalized: string;
+  seen: Set<string>;
+}): string[] {
   const names: string[] = [];
-  for (const obj of extractSearchObjects(search)) {
+  for (const obj of extractSearchObjects(ctx.search)) {
     if (obj.type?.toUpperCase() !== 'SXCI/XI') continue;
     const implName = obj.name?.toUpperCase();
     if (!implName) continue;
-    if (implName === normalized) continue;
-    if (seen.has(implName)) continue;
-    seen.add(implName);
+    if (implName === ctx.normalized) continue;
+    if (ctx.seen.has(implName)) continue;
+    ctx.seen.add(implName);
     names.push(implName);
   }
   return names;
 }
 
-async function tryReadImplementation({
-  client,
-  definitionName,
-  implName,
-}: {
+async function tryReadImplementation(ctx: {
   client: AdtClient;
   definitionName: string;
   implName: string;
 }): Promise<BadiMetadata | undefined> {
   try {
-    const impl = await readImplementation({ client, normalized: implName });
+    const impl = await readImplementation({
+      client: ctx.client,
+      normalized: ctx.implName,
+    });
     const containerName = impl.containerRef?.name?.toUpperCase();
-    if (containerName && containerName !== definitionName) {
+    if (containerName && containerName !== ctx.definitionName) {
       return undefined;
     }
     return impl;
@@ -471,29 +466,31 @@ async function tryReadImplementation({
   }
 }
 
-async function collectSearchCandidates({
-  client,
-  normalized,
-  query,
-  objectType,
-  seen,
-}: SearchCandidateContext): Promise<BadiMetadata[]> {
+async function collectSearchCandidates(
+  ctx: SearchCandidateContext,
+): Promise<BadiMetadata[]> {
   const params: { query: string; maxResults: number; objectType?: 'SXCI' } = {
-    query,
+    query: ctx.query,
     maxResults: 100,
   };
-  if (objectType) {
-    params.objectType = objectType;
+  if (ctx.objectType) {
+    params.objectType = ctx.objectType;
   }
   const search =
-    await client.adt.repository.informationsystem.search.quickSearch(params);
+    await ctx.client.adt.repository.informationsystem.search.quickSearch(
+      params,
+    );
 
-  const names = candidateNames(search, normalized, seen);
+  const names = candidateNames({
+    search,
+    normalized: ctx.normalized,
+    seen: ctx.seen,
+  });
   const found: BadiMetadata[] = [];
   for (const implName of names) {
     const impl = await tryReadImplementation({
-      client,
-      definitionName: normalized,
+      client: ctx.client,
+      definitionName: ctx.normalized,
       implName,
     });
     if (impl) found.push(impl);
@@ -501,29 +498,28 @@ async function collectSearchCandidates({
   return found;
 }
 
-async function listImplementations({
-  client,
-  normalized,
-}: ServiceContext): Promise<BadiMetadata[]> {
-  await readDefinition({ client, normalized });
+async function listImplementations(
+  ctx: ServiceContext,
+): Promise<BadiMetadata[]> {
+  await readDefinition(ctx);
 
-  const queries = searchQueriesForDefinition(normalized);
+  const queries = searchQueriesForDefinition({ name: ctx.normalized });
   const seen = new Set<string>();
   const all: BadiMetadata[] = [];
 
   for (const query of queries) {
     all.push(
       ...(await collectSearchCandidates({
-        client,
-        normalized,
+        client: ctx.client,
+        normalized: ctx.normalized,
         query,
         seen,
       })),
     );
     all.push(
       ...(await collectSearchCandidates({
-        client,
-        normalized,
+        client: ctx.client,
+        normalized: ctx.normalized,
         query,
         objectType: 'SXCI',
         seen,
@@ -537,17 +533,20 @@ async function listImplementations({
 export class BadiService {
   constructor(private readonly client: AdtClient) {}
 
-  async resolveKind(name: string): Promise<BadiKind> {
+  async resolveKind({ name }: { name: string }): Promise<BadiKind> {
     return resolveKind({
       client: this.client,
       normalized: name.trim().toUpperCase(),
     });
   }
 
-  async get(
-    name: string,
-    options?: { includeSource?: boolean; includeImplementations?: boolean },
-  ): Promise<BadiReadResult> {
+  async get({
+    name,
+    options,
+  }: {
+    name: string;
+    options?: { includeSource?: boolean; includeImplementations?: boolean };
+  }): Promise<BadiReadResult> {
     return getBadi({
       client: this.client,
       normalized: name.trim().toUpperCase(),
@@ -555,14 +554,14 @@ export class BadiService {
     });
   }
 
-  async getDefinition(name: string): Promise<BadiMetadata> {
+  async getDefinition({ name }: { name: string }): Promise<BadiMetadata> {
     return readDefinition({
       client: this.client,
       normalized: name.trim().toUpperCase(),
     });
   }
 
-  async getImplementation(name: string): Promise<BadiMetadata> {
+  async getImplementation({ name }: { name: string }): Promise<BadiMetadata> {
     return readImplementation({
       client: this.client,
       normalized: name.trim().toUpperCase(),
@@ -574,10 +573,14 @@ export class BadiService {
    * Uses repository quick search heuristics — authoritative active/inactive
    * state requires SXC_ATTR (not exposed on all systems).
    */
-  async listImplementations(definitionName: string): Promise<BadiMetadata[]> {
+  async listImplementations({
+    name,
+  }: {
+    name: string;
+  }): Promise<BadiMetadata[]> {
     return listImplementations({
       client: this.client,
-      normalized: definitionName.trim().toUpperCase(),
+      normalized: name.trim().toUpperCase(),
     });
   }
 }

--- a/packages/adt-cli/src/lib/services/badi/index.ts
+++ b/packages/adt-cli/src/lib/services/badi/index.ts
@@ -533,11 +533,19 @@ async function listImplementations(
 export class BadiService {
   constructor(private readonly client: AdtClient) {}
 
+  private contextFor(name: string): ServiceContext {
+    return { client: this.client, normalized: name.trim().toUpperCase() };
+  }
+
+  private readContextFor(
+    name: string,
+    options?: { includeSource?: boolean; includeImplementations?: boolean },
+  ): ReadContext {
+    return { ...this.contextFor(name), options };
+  }
+
   async resolveKind({ name }: { name: string }): Promise<BadiKind> {
-    return resolveKind({
-      client: this.client,
-      normalized: name.trim().toUpperCase(),
-    });
+    return resolveKind(this.contextFor(name));
   }
 
   async get({
@@ -547,25 +555,15 @@ export class BadiService {
     name: string;
     options?: { includeSource?: boolean; includeImplementations?: boolean };
   }): Promise<BadiReadResult> {
-    return getBadi({
-      client: this.client,
-      normalized: name.trim().toUpperCase(),
-      options,
-    });
+    return getBadi(this.readContextFor(name, options));
   }
 
   async getDefinition({ name }: { name: string }): Promise<BadiMetadata> {
-    return readDefinition({
-      client: this.client,
-      normalized: name.trim().toUpperCase(),
-    });
+    return readDefinition(this.contextFor(name));
   }
 
   async getImplementation({ name }: { name: string }): Promise<BadiMetadata> {
-    return readImplementation({
-      client: this.client,
-      normalized: name.trim().toUpperCase(),
-    });
+    return readImplementation(this.contextFor(name));
   }
 
   /**
@@ -578,10 +576,7 @@ export class BadiService {
   }: {
     name: string;
   }): Promise<BadiMetadata[]> {
-    return listImplementations({
-      client: this.client,
-      normalized: name.trim().toUpperCase(),
-    });
+    return listImplementations(this.contextFor(name));
   }
 }
 

--- a/packages/adt-cli/src/lib/services/badi/index.ts
+++ b/packages/adt-cli/src/lib/services/badi/index.ts
@@ -1,16 +1,13 @@
 /**
- * BAdI / Enhancement Implementation metadata service.
+ * BAdI services — ENHO metadata (enhoxhb) and unified read (classic vit/wb + ENHO).
  *
- * Reads ENHO metadata from `/sap/bc/adt/enhancements/enhoxhb/{name}`
- * (the ADT endpoint that exposes BAdI implementation details) and
- * returns a structured, UI-agnostic result. Used by both the CLI and MCP.
- *
- * Based on the ARC-1 / sapcli ENHO payload shape:
- *   - root element `enho:objectData`
- *   - `enho:contentCommon` for the tool type / switch flag
- *   - `enho:contentSpecific/enho:badiTechnology/enho:badiImplementations`
+ * - `getBadiInfo` / `parseEnhancementImplementation` — ENHO/XHB metadata from
+ *   `/sap/bc/adt/enhancements/enhoxhb/{name}` (used by `adt badi <name>`).
+ * - `BadiService` — auto-detect kind and read classic SXSD/SXCI or ENHO/XHH.
  */
 import type { AdtClient } from '@abapify/adt-client';
+import type { AdtClientType } from '@abapify/adt-contracts';
+import type { BasicObjectPropertiesResponse } from '@abapify/adt-contracts';
 import { DOMParser } from '@xmldom/xmldom';
 
 const NS_ENHO = 'http://www.sap.com/adt/enhancements/enho';
@@ -152,3 +149,292 @@ export async function getBadiInfo(
 
   return parseEnhancementImplementation(response);
 }
+
+export type BadiKind = 'definition' | 'implementation' | 'enhancement';
+
+export type BadiMetadata = {
+  name: string;
+  type: string;
+  kind: BadiKind;
+  description?: string;
+  language?: string;
+  version?: string;
+  packageName?: string;
+  packageUri?: string;
+  responsible?: string;
+  masterLanguage?: string;
+  masterSystem?: string;
+};
+
+export type BadiReadResult = BadiMetadata & {
+  /** ENHO/XHB metadata when kind is enhancement. */
+  enhancement?: BadiInfo;
+  source?: string;
+  /** Present when `--implementations` is used on a classic definition. */
+  implementations?: BadiMetadata[];
+};
+
+/** @deprecated Use BadiMetadata */
+export type ClassicBadiMetadata = Omit<BadiMetadata, 'kind'>;
+
+const BADI_REPOSITORY_TYPES = new Set([
+  'SXSD/XD',
+  'SXCI/XI',
+  'ENHO/XHH',
+  'ENHO/XHB',
+]);
+
+function isNotFound(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { status?: unknown }).status === 404
+  );
+}
+
+function badiKindFromType(adtType: string): BadiKind {
+  const type = adtType.toUpperCase();
+  if (type === 'SXSD/XD') return 'definition';
+  if (type === 'SXCI/XI') return 'implementation';
+  return 'enhancement';
+}
+
+function extractSearchObjects(results: unknown): Array<{
+  name?: string;
+  type?: string;
+}> {
+  const record = results as Record<string, unknown>;
+  let raw:
+    | Array<{ name?: string; type?: string }>
+    | { name?: string; type?: string }
+    | undefined;
+
+  if (record.objectReferences && typeof record.objectReferences === 'object') {
+    const refs = record.objectReferences as {
+      objectReference?: typeof raw;
+    };
+    raw = refs.objectReference;
+  } else if (record.objectReference) {
+    raw = record.objectReference as typeof raw;
+  } else if (record.mainObject && typeof record.mainObject === 'object') {
+    const main = record.mainObject as { objectReference?: typeof raw };
+    raw = main.objectReference;
+  }
+
+  if (!raw) return [];
+  return Array.isArray(raw) ? raw : [raw];
+}
+
+export function normalizeClassicBadiMetadata(
+  response: BasicObjectPropertiesResponse,
+  kind: 'definition' | 'implementation',
+): BadiMetadata {
+  const main = response.mainObject;
+  if (!main) {
+    throw new Error('BAdI response missing mainObject');
+  }
+  return {
+    kind,
+    name: main.name.toUpperCase(),
+    type: main.type,
+    description: main.description,
+    language: main.language,
+    version: main.version,
+    packageName: main.packageRef?.name,
+    packageUri: main.packageRef?.uri,
+    responsible: main.responsible,
+    masterLanguage: main.masterLanguage,
+    masterSystem: main.masterSystem,
+  };
+}
+
+function searchQueriesForDefinition(definitionName: string): string[] {
+  const normalized = definitionName.trim().toUpperCase();
+  const queries = new Set<string>([
+    `*${normalized}*`,
+    `*${normalized.replace(/_/g, '*')}*`,
+  ]);
+  const parts = normalized.split('_').filter(Boolean);
+  if (parts.length >= 2) {
+    const tail2 = parts.slice(-2).join('_');
+    if (tail2.length >= 10) {
+      queries.add(`*${tail2}*`);
+    }
+  }
+  return [...queries];
+}
+
+export class BadiService {
+  constructor(private readonly client: AdtClientType) {}
+
+  async resolveKind(name: string): Promise<BadiKind> {
+    const normalized = name.trim().toUpperCase();
+
+    const search =
+      await this.client.adt.repository.informationsystem.search.quickSearch({
+        query: normalized,
+        maxResults: 20,
+      });
+    const matches = extractSearchObjects(search).filter(
+      (obj) =>
+        obj.name?.toUpperCase() === normalized &&
+        obj.type &&
+        BADI_REPOSITORY_TYPES.has(obj.type.toUpperCase()),
+    );
+    if (matches.length === 1) {
+      return badiKindFromType(matches[0].type!);
+    }
+    if (matches.length > 1) {
+      throw new Error(
+        `Ambiguous BAdI name ${normalized}: ${matches.map((m) => m.type).join(', ')}`,
+      );
+    }
+
+    const probes: Array<{
+      kind: BadiKind;
+      expectedType: string;
+      run: () => Promise<BasicObjectPropertiesResponse>;
+    }> = [
+      {
+        kind: 'definition',
+        expectedType: 'SXSD/XD',
+        run: () => this.client.adt.vit.wb.objectProperties.getDefinition(name),
+      },
+      {
+        kind: 'implementation',
+        expectedType: 'SXCI/XI',
+        run: () =>
+          this.client.adt.vit.wb.objectProperties.getImplementation(name),
+      },
+    ];
+
+    for (const probe of probes) {
+      try {
+        const response = await probe.run();
+        const main = response.mainObject;
+        if (
+          main?.type?.toUpperCase() === probe.expectedType &&
+          main.name?.toUpperCase() === normalized
+        ) {
+          return probe.kind;
+        }
+      } catch (error) {
+        if (!isNotFound(error)) throw error;
+      }
+    }
+
+    try {
+      await getBadiInfo(this.client as unknown as AdtClient, normalized);
+      return 'enhancement';
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+    }
+
+    throw new Error(`BAdI object not found: ${normalized}`);
+  }
+
+  async get(
+    name: string,
+    options?: { includeSource?: boolean; includeImplementations?: boolean },
+  ): Promise<BadiReadResult> {
+    const kind = await this.resolveKind(name);
+    switch (kind) {
+      case 'definition': {
+        const response =
+          await this.client.adt.vit.wb.objectProperties.getDefinition(name);
+        const definition = normalizeClassicBadiMetadata(response, 'definition');
+        if (!options?.includeImplementations) {
+          return definition;
+        }
+        const implementations = await this.listImplementations(name);
+        return { ...definition, implementations };
+      }
+      case 'implementation': {
+        const response =
+          await this.client.adt.vit.wb.objectProperties.getImplementation(name);
+        return normalizeClassicBadiMetadata(response, 'implementation');
+      }
+      case 'enhancement': {
+        const normalized = name.trim().toUpperCase();
+        const lower = normalized.toLowerCase();
+        const info = await getBadiInfo(
+          this.client as unknown as AdtClient,
+          normalized,
+        );
+        const source = options?.includeSource
+          ? String(
+              await this.client.adt.enhancements.enhoxhh.source.main.get(lower),
+            )
+          : undefined;
+        return {
+          kind: 'enhancement',
+          name: info.name.toUpperCase(),
+          type: info.type,
+          description: info.description,
+          version: info.version,
+          packageName: info.package,
+          responsible: info.responsible,
+          enhancement: info,
+          source,
+        };
+      }
+    }
+  }
+
+  async getDefinition(name: string): Promise<BadiMetadata> {
+    const response =
+      await this.client.adt.vit.wb.objectProperties.getDefinition(name);
+    return normalizeClassicBadiMetadata(response, 'definition');
+  }
+
+  async getImplementation(name: string): Promise<BadiMetadata> {
+    const response =
+      await this.client.adt.vit.wb.objectProperties.getImplementation(name);
+    return normalizeClassicBadiMetadata(response, 'implementation');
+  }
+
+  /**
+   * List classic BAdI implementations (SXCI/XI) for a definition name.
+   * Uses repository quick search heuristics — authoritative active/inactive
+   * state requires SXC_ATTR (not exposed on all systems).
+   */
+  async listImplementations(definitionName: string): Promise<BadiMetadata[]> {
+    const normalized = definitionName.trim().toUpperCase();
+    await this.getDefinition(normalized);
+
+    const queries = searchQueriesForDefinition(normalized);
+    const seen = new Set<string>();
+    const implementations: BadiMetadata[] = [];
+
+    for (const query of queries) {
+      for (const objectType of [undefined, 'SXCI'] as const) {
+        const search =
+          await this.client.adt.repository.informationsystem.search.quickSearch(
+            {
+              query,
+              maxResults: 500,
+              ...(objectType ? { objectType } : {}),
+            },
+          );
+        for (const obj of extractSearchObjects(search)) {
+          if (obj.type?.toUpperCase() !== 'SXCI/XI') continue;
+          const implName = obj.name?.toUpperCase();
+          if (!implName || implName === normalized || seen.has(implName)) {
+            continue;
+          }
+          seen.add(implName);
+          try {
+            implementations.push(await this.getImplementation(implName));
+          } catch {
+            /* skip entries that cannot be read via vit/wb */
+          }
+        }
+      }
+    }
+
+    return implementations.sort((a, b) => a.name.localeCompare(b.name));
+  }
+}
+
+/** @deprecated Use BadiService */
+export const ClassicBadiService = BadiService;

--- a/packages/adt-cli/src/lib/services/classic-badi/index.ts
+++ b/packages/adt-cli/src/lib/services/classic-badi/index.ts
@@ -1,0 +1,10 @@
+/** @deprecated Import from ./badi instead */
+export {
+  BadiService,
+  ClassicBadiService,
+  normalizeClassicBadiMetadata,
+  type BadiKind,
+  type BadiMetadata,
+  type BadiReadResult,
+  type ClassicBadiMetadata,
+} from '../badi';

--- a/packages/adt-cli/src/lib/services/classic-badi/index.ts
+++ b/packages/adt-cli/src/lib/services/classic-badi/index.ts
@@ -1,4 +1,4 @@
-/** @deprecated Import from ./badi instead */
+/** @deprecated Import from ../badi instead */
 export {
   BadiService,
   ClassicBadiService,

--- a/packages/adt-cli/tests/e2e/parity.badi.test.ts
+++ b/packages/adt-cli/tests/e2e/parity.badi.test.ts
@@ -1,18 +1,8 @@
 /**
- * CLI + MCP parity tests for BAdI / Enhancement Implementation (ENHO/XHH).
- *
- * Targets the `/sap/bc/adt/enhancements/enhoxhh` endpoint. Covers read,
- * read-source, create, write, delete — exactly the five operations the
- * epic (E03) mandates for CRUD + activate parity.
- *
- * Both paths hit the shared in-process mock ADT server, so CLI and MCP
- * surfaces are pinned to identical backend behaviour.
+ * CLI + MCP parity tests for BAdI commands.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { mkdtempSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import {
   startAdtHarness,
   runCliCommand,
@@ -31,7 +21,7 @@ describe('CLI + MCP parity (badi)', () => {
     if (harness) await harness.stop();
   });
 
-  it('parity: read BAdI info with implementations', async () => {
+  it('parity: read ENHO BAdI info with implementations', async () => {
     const cli = await runCliCommand(harness, [
       'badi',
       'ZE_MOCK_BADI',
@@ -43,7 +33,7 @@ describe('CLI + MCP parity (badi)', () => {
     expect(cli.stdout).toContain('ZE_MOCK_BADI_DEF');
   });
 
-  it('parity: read BAdI info as JSON', async () => {
+  it('parity: read ENHO BAdI info as JSON', async () => {
     const cli = await runCliCommand(harness, [
       'badi',
       'ZE_MOCK_BADI',
@@ -58,12 +48,8 @@ describe('CLI + MCP parity (badi)', () => {
     );
   });
 
-  it('parity: read BAdI source', async () => {
-    // CLI `read` (no --json) prints the source to stdout. Run this
-    // FIRST: commander retains parsed options between invocations on a
-    // shared program, so `--json` from a later test would otherwise
-    // flip this case into the metadata branch.
-    const cli = await runCliCommand(harness, ['badi', 'read', 'ZE_MOCK_BADI']);
+  it('parity: read ENHO/XHH source via get badi', async () => {
+    const cli = await runCliCommand(harness, ['get', 'badi', 'ZE_MOCK_BADI']);
     expect(cli.exitCode, cli.stderr || cli.stdout).toBe(0);
     expect(cli.stdout).toContain('lcl_badi_impl');
 
@@ -75,11 +61,10 @@ describe('CLI + MCP parity (badi)', () => {
     expect(String(JSON.stringify(mcp.json))).toContain('lcl_badi_impl');
   });
 
-  it('parity: read BAdI metadata', async () => {
-    // CLI `read --json` returns metadata only (skips source fetch).
+  it('parity: read ENHO/XHH metadata via get badi', async () => {
     const cli = await runCliCommand(harness, [
+      'get',
       'badi',
-      'read',
       'ZE_MOCK_BADI',
       '--json',
     ]);
@@ -91,62 +76,63 @@ describe('CLI + MCP parity (badi)', () => {
     expect(mcp.isError, JSON.stringify(mcp.json)).toBe(false);
   });
 
-  it('parity: create BAdI', async () => {
+  it('parity: read classic BAdI definition', async () => {
     const cli = await runCliCommand(harness, [
+      'get',
       'badi',
-      'create',
-      'ZE_NEW_BADI',
-      'Mock BAdI impl',
-      '$TMP',
+      'MOCK_CTS_REQUEST_CHECK',
+      '--json',
     ]);
     expect(cli.exitCode, cli.stderr || cli.stdout).toBe(0);
 
-    const mcp = await callMcpTool(harness, 'create_badi', {
-      badiName: 'ZE_NEW_BADI_M',
-      description: 'Mock BAdI impl',
-      packageName: '$TMP',
+    const mcp = await callMcpTool(harness, 'get_badi', {
+      badiName: 'MOCK_CTS_REQUEST_CHECK',
     });
     expect(mcp.isError, JSON.stringify(mcp.json)).toBe(false);
+    expect(mcp.json.kind).toBe('definition');
+    expect(mcp.json.type).toBe('SXSD/XD');
   });
 
-  it('parity: write BAdI source', async () => {
-    const tmp = mkdtempSync(join(tmpdir(), 'adt-badi-'));
-    const srcPath = join(tmp, 'impl.abap');
-    writeFileSync(
-      srcPath,
-      '* Updated BAdI source\nCLASS lcl_badi_v2 IMPLEMENTATION.\nENDCLASS.\n',
-      'utf8',
+  it('parity: read classic BAdI implementation', async () => {
+    const cli = await runCliCommand(harness, [
+      'get',
+      'badi',
+      'ZE_MOCK_CLASSIC_BADI_IMPL',
+      '--json',
+    ]);
+    expect(cli.exitCode, cli.stderr || cli.stdout).toBe(0);
+
+    const mcp = await callMcpTool(harness, 'get_badi', {
+      badiName: 'ZE_MOCK_CLASSIC_BADI_IMPL',
+    });
+    expect(mcp.isError, JSON.stringify(mcp.json)).toBe(false);
+    expect(mcp.json.kind).toBe('implementation');
+    expect(mcp.json.type).toBe('SXCI/XI');
+  });
+
+  it('parity: list classic implementations with --implementations', async () => {
+    const cli = await runCliCommand(harness, [
+      'get',
+      'badi',
+      'MOCK_CTS_REQUEST_CHECK',
+      '--implementations',
+      '--json',
+    ]);
+    expect(cli.exitCode, cli.stderr || cli.stdout).toBe(0);
+
+    const mcp = await callMcpTool(harness, 'get_badi', {
+      badiName: 'MOCK_CTS_REQUEST_CHECK',
+      includeImplementations: true,
+    });
+    expect(mcp.isError, JSON.stringify(mcp.json)).toBe(false);
+    expect(mcp.json.implementations?.length).toBe(2);
+    expect(
+      mcp.json.implementations?.map((entry: { name: string }) => entry.name),
+    ).toEqual(
+      expect.arrayContaining([
+        'ZE_MOCK_CLASSIC_BADI_IMPL',
+        'ZE_MOCK_CLASSIC_BADI_IMPL_B',
+      ]),
     );
-
-    const cli = await runCliCommand(harness, [
-      'badi',
-      'write',
-      'ZE_MOCK_BADI',
-      srcPath,
-    ]);
-    expect(cli.exitCode, cli.stderr || cli.stdout).toBe(0);
-
-    const mcp = await callMcpTool(harness, 'update_source', {
-      objectName: 'ZE_MOCK_BADI',
-      objectType: 'ENHO',
-      sourceCode:
-        '* Updated BAdI source via MCP\nCLASS lcl_badi_v2 IMPLEMENTATION.\nENDCLASS.\n',
-    });
-    expect(mcp.isError, JSON.stringify(mcp.json)).toBe(false);
-  });
-
-  it('parity: delete BAdI', async () => {
-    const cli = await runCliCommand(harness, [
-      'badi',
-      'delete',
-      'ZE_MOCK_BADI',
-      '-y',
-    ]);
-    expect(cli.exitCode, cli.stderr || cli.stdout).toBe(0);
-
-    const mcp = await callMcpTool(harness, 'delete_badi', {
-      badiName: 'ZE_MOCK_BADI',
-    });
-    expect(mcp.isError, JSON.stringify(mcp.json)).toBe(false);
   });
 });

--- a/packages/adt-cli/tests/e2e/parity.badi.test.ts
+++ b/packages/adt-cli/tests/e2e/parity.badi.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { BadiInfo, BadiReadResult } from '../../src/lib/services/badi';
 import {
   startAdtHarness,
   runCliCommand,
@@ -41,9 +42,10 @@ describe('CLI + MCP parity (badi)', () => {
     ]);
     expect(cli.exitCode, cli.stderr || cli.stdout).toBe(0);
     expect(cli.json).toBeDefined();
-    expect(cli.json?.name).toBe('ZE_MOCK_BADI');
-    expect(cli.json?.badiImplementations).toHaveLength(1);
-    expect(cli.json?.badiImplementations[0].implementingClass).toBe(
+    const result = cli.json as BadiInfo;
+    expect(result.name).toBe('ZE_MOCK_BADI');
+    expect(result.badiImplementations).toHaveLength(1);
+    expect(result.badiImplementations[0].implementingClass).toBe(
       'ZCL_MOCK_BADI_IMPL',
     );
   });
@@ -53,12 +55,12 @@ describe('CLI + MCP parity (badi)', () => {
     expect(cli.exitCode, cli.stderr || cli.stdout).toBe(0);
     expect(cli.stdout).toContain('lcl_badi_impl');
 
-    const mcp = await callMcpTool(harness, 'get_badi', {
+    const mcp = await callMcpTool<BadiReadResult>(harness, 'get_badi', {
       badiName: 'ZE_MOCK_BADI',
       includeSource: true,
     });
     expect(mcp.isError, JSON.stringify(mcp.json)).toBe(false);
-    expect(String(JSON.stringify(mcp.json))).toContain('lcl_badi_impl');
+    expect(mcp.json.source).toContain('lcl_badi_impl');
   });
 
   it('parity: read ENHO/XHH metadata via get badi', async () => {
@@ -69,11 +71,13 @@ describe('CLI + MCP parity (badi)', () => {
       '--json',
     ]);
     expect(cli.exitCode, cli.stderr || cli.stdout).toBe(0);
+    expect(cli.json).toBeDefined();
 
-    const mcp = await callMcpTool(harness, 'get_badi', {
+    const mcp = await callMcpTool<BadiReadResult>(harness, 'get_badi', {
       badiName: 'ZE_MOCK_BADI',
     });
     expect(mcp.isError, JSON.stringify(mcp.json)).toBe(false);
+    expect(cli.json).toEqual(mcp.json);
   });
 
   it('parity: read classic BAdI definition', async () => {
@@ -84,13 +88,13 @@ describe('CLI + MCP parity (badi)', () => {
       '--json',
     ]);
     expect(cli.exitCode, cli.stderr || cli.stdout).toBe(0);
+    expect(cli.json).toBeDefined();
 
-    const mcp = await callMcpTool(harness, 'get_badi', {
+    const mcp = await callMcpTool<BadiReadResult>(harness, 'get_badi', {
       badiName: 'MOCK_CTS_REQUEST_CHECK',
     });
     expect(mcp.isError, JSON.stringify(mcp.json)).toBe(false);
-    expect(mcp.json.kind).toBe('definition');
-    expect(mcp.json.type).toBe('SXSD/XD');
+    expect(cli.json).toEqual(mcp.json);
   });
 
   it('parity: read classic BAdI implementation', async () => {
@@ -101,13 +105,13 @@ describe('CLI + MCP parity (badi)', () => {
       '--json',
     ]);
     expect(cli.exitCode, cli.stderr || cli.stdout).toBe(0);
+    expect(cli.json).toBeDefined();
 
-    const mcp = await callMcpTool(harness, 'get_badi', {
+    const mcp = await callMcpTool<BadiReadResult>(harness, 'get_badi', {
       badiName: 'ZE_MOCK_CLASSIC_BADI_IMPL',
     });
     expect(mcp.isError, JSON.stringify(mcp.json)).toBe(false);
-    expect(mcp.json.kind).toBe('implementation');
-    expect(mcp.json.type).toBe('SXCI/XI');
+    expect(cli.json).toEqual(mcp.json);
   });
 
   it('parity: list classic implementations with --implementations', async () => {
@@ -119,20 +123,13 @@ describe('CLI + MCP parity (badi)', () => {
       '--json',
     ]);
     expect(cli.exitCode, cli.stderr || cli.stdout).toBe(0);
+    expect(cli.json).toBeDefined();
 
-    const mcp = await callMcpTool(harness, 'get_badi', {
+    const mcp = await callMcpTool<BadiReadResult>(harness, 'get_badi', {
       badiName: 'MOCK_CTS_REQUEST_CHECK',
       includeImplementations: true,
     });
     expect(mcp.isError, JSON.stringify(mcp.json)).toBe(false);
-    expect(mcp.json.implementations?.length).toBe(2);
-    expect(
-      mcp.json.implementations?.map((entry: { name: string }) => entry.name),
-    ).toEqual(
-      expect.arrayContaining([
-        'ZE_MOCK_CLASSIC_BADI_IMPL',
-        'ZE_MOCK_CLASSIC_BADI_IMPL_B',
-      ]),
-    );
+    expect(cli.json).toEqual(mcp.json);
   });
 });

--- a/packages/adt-contracts/src/adt/index.ts
+++ b/packages/adt-contracts/src/adt/index.ts
@@ -24,6 +24,7 @@ export * from './businessservices';
 export * from './enhancements';
 export * from './uifsa';
 export * from './codeassistance';
+export * from './vit';
 
 /**
  * Complete ADT Contract
@@ -62,6 +63,7 @@ import {
   codeassistanceContract,
   type CodeassistanceContract,
 } from './codeassistance';
+import { vitContract, type VitContract } from './vit';
 
 /**
  * Explicit type to avoid TS7056 "inferred type exceeds maximum length"
@@ -89,6 +91,7 @@ export interface AdtContract {
   enhancements: EnhancementsContract;
   flp: FlpContract;
   codeassistance: CodeassistanceContract;
+  vit: VitContract;
 }
 
 export const adtContract: AdtContract = {
@@ -114,6 +117,7 @@ export const adtContract: AdtContract = {
   enhancements: enhancementsContract,
   flp: flpContract,
   codeassistance: codeassistanceContract,
+  vit: vitContract,
 };
 
 // Import RestClient from base for client type definition

--- a/packages/adt-contracts/src/adt/vit/index.ts
+++ b/packages/adt-contracts/src/adt/vit/index.ts
@@ -1,0 +1,22 @@
+/**
+ * ADT vit (Virtual Integration Technology) contracts.
+ */
+
+export * from './wb/objectproperties';
+
+import {
+  vitWbObjectPropertiesContract,
+  type VitWbObjectPropertiesContract,
+} from './wb/objectproperties';
+
+export interface VitContract {
+  wb: {
+    objectProperties: VitWbObjectPropertiesContract;
+  };
+}
+
+export const vitContract: VitContract = {
+  wb: {
+    objectProperties: vitWbObjectPropertiesContract,
+  },
+};

--- a/packages/adt-contracts/src/adt/vit/wb/objectproperties.ts
+++ b/packages/adt-contracts/src/adt/vit/wb/objectproperties.ts
@@ -1,0 +1,62 @@
+/**
+ * ADT vit/wb — Basic Object Properties (classic Workbench metadata).
+ *
+ * Endpoint template (from ADT discovery):
+ *   GET /sap/bc/adt/vit/wb/object_type/{type}/object_name/{name}
+ *
+ * Accept: application/vnd.sap.adt.basic.object.properties+xml
+ * Response: adtcore:mainObject
+ *
+ * Classic BAdI uses vit types:
+ *   sxsdxd — BAdI definition  (repository type SXSD/XD)
+ *   sxcixi — BAdI implementation (repository type SXCI/XI)
+ */
+
+import { contract, http } from '../../../base';
+import { adtcore, type InferTypedSchema } from '../../../schemas';
+
+export const BASIC_OBJECT_PROPERTIES_MIME =
+  'application/vnd.sap.adt.basic.object.properties+xml';
+
+/** vit/wb object_type segment for classic BAdI definitions. */
+export const CLASSIC_BADI_DEFINITION_VIT_TYPE = 'sxsdxd';
+
+/** vit/wb object_type segment for classic BAdI implementations. */
+export const CLASSIC_BADI_IMPLEMENTATION_VIT_TYPE = 'sxcixi';
+
+export type BasicObjectPropertiesResponse = InferTypedSchema<typeof adtcore>;
+
+function objectPropertiesPath(vitType: string, objectName: string): string {
+  const normalizedType = vitType.trim().toLowerCase();
+  const normalizedName = objectName.trim().toLowerCase();
+  return `/sap/bc/adt/vit/wb/object_type/${encodeURIComponent(normalizedType)}/object_name/${encodeURIComponent(normalizedName)}`;
+}
+
+function getByVitType(vitType: string) {
+  return (objectName: string) =>
+    http.get(objectPropertiesPath(vitType, objectName), {
+      responses: { 200: adtcore },
+      headers: { Accept: BASIC_OBJECT_PROPERTIES_MIME },
+    });
+}
+
+/**
+ * /sap/bc/adt/vit/wb/object_type/{type}/object_name/{name}
+ */
+export const vitWbObjectPropertiesContract = contract({
+  /** Generic read for any vit/wb object_type segment. */
+  get: (params: { vitType: string; objectName: string }) =>
+    http.get(objectPropertiesPath(params.vitType, params.objectName), {
+      responses: { 200: adtcore },
+      headers: { Accept: BASIC_OBJECT_PROPERTIES_MIME },
+    }),
+
+  /** Classic BAdI definition (SXSD/XD). */
+  getDefinition: getByVitType(CLASSIC_BADI_DEFINITION_VIT_TYPE),
+
+  /** Classic BAdI implementation (SXCI/XI). */
+  getImplementation: getByVitType(CLASSIC_BADI_IMPLEMENTATION_VIT_TYPE),
+});
+
+export type VitWbObjectPropertiesContract =
+  typeof vitWbObjectPropertiesContract;

--- a/packages/adt-contracts/tests/contracts/vit-wb.test.ts
+++ b/packages/adt-contracts/tests/contracts/vit-wb.test.ts
@@ -1,0 +1,51 @@
+/**
+ * vit/wb Basic Object Properties contract scenarios
+ *
+ * Endpoint: /sap/bc/adt/vit/wb/object_type/{type}/object_name/{name}
+ * Accept: application/vnd.sap.adt.basic.object.properties+xml
+ */
+
+import { fixtures } from '@abapify/adt-fixtures';
+import { adtcore } from '../../src/schemas';
+import { ContractScenario, runScenario, type ContractOperation } from './base';
+import {
+  BASIC_OBJECT_PROPERTIES_MIME,
+  vitWbObjectPropertiesContract,
+} from '../../src/adt/vit/wb/objectproperties';
+
+class VitWbScenario extends ContractScenario {
+  readonly name = 'vit/wb Basic Object Properties (classic BAdI)';
+
+  readonly operations: ContractOperation[] = [
+    {
+      name: 'get classic BAdI definition',
+      contract: () =>
+        vitWbObjectPropertiesContract.getDefinition('MOCK_CTS_REQUEST_CHECK'),
+      method: 'GET',
+      path: '/sap/bc/adt/vit/wb/object_type/sxsdxd/object_name/mock_cts_request_check',
+      headers: { Accept: BASIC_OBJECT_PROPERTIES_MIME },
+      response: {
+        status: 200,
+        schema: adtcore,
+        fixture: fixtures.vit.wb.sxsdxdSingle,
+      },
+    },
+    {
+      name: 'get classic BAdI implementation',
+      contract: () =>
+        vitWbObjectPropertiesContract.getImplementation(
+          'ZE_MOCK_CLASSIC_BADI_IMPL',
+        ),
+      method: 'GET',
+      path: '/sap/bc/adt/vit/wb/object_type/sxcixi/object_name/ze_mock_classic_badi_impl',
+      headers: { Accept: BASIC_OBJECT_PROPERTIES_MIME },
+      response: {
+        status: 200,
+        schema: adtcore,
+        fixture: fixtures.vit.wb.sxcixiSingle,
+      },
+    },
+  ];
+}
+
+runScenario(new VitWbScenario());

--- a/packages/adt-fixtures/src/fixtures/badi/implementations-search.json
+++ b/packages/adt-fixtures/src/fixtures/badi/implementations-search.json
@@ -1,0 +1,18 @@
+{
+  "objectReference": [
+    {
+      "name": "ZE_MOCK_CLASSIC_BADI_IMPL",
+      "type": "SXCI/XI",
+      "uri": "/sap/bc/adt/vit/wb/object_type/sxcixi/object_name/ze_mock_classic_badi_impl",
+      "description": "Mock classic BAdI implementation",
+      "packageName": "MOCK_PKG"
+    },
+    {
+      "name": "ZE_MOCK_CLASSIC_BADI_IMPL_B",
+      "type": "SXCI/XI",
+      "uri": "/sap/bc/adt/vit/wb/object_type/sxcixi/object_name/ze_mock_classic_badi_impl_b",
+      "description": "Second mock classic BAdI implementation",
+      "packageName": "MOCK_PKG"
+    }
+  ]
+}

--- a/packages/adt-fixtures/src/fixtures/registry.ts
+++ b/packages/adt-fixtures/src/fixtures/registry.ts
@@ -90,6 +90,16 @@ export const registry = {
       single: 'enhancements/enhoxhb/single.xml',
     },
   },
+  badi: {
+    implementationsSearch: 'badi/implementations-search.json',
+  },
+  vit: {
+    wb: {
+      sxsdxdSingle: 'vit/wb/sxsdxd-single.xml',
+      sxcixiSingle: 'vit/wb/sxcixi-single.xml',
+      sxcixiSingleB: 'vit/wb/sxcixi-single-b.xml',
+    },
+  },
   businessservices: {
     bindings: {
       single: 'businessservices/binding.xml',

--- a/packages/adt-fixtures/src/fixtures/vit/wb/sxcixi-single-b.xml
+++ b/packages/adt-fixtures/src/fixtures/vit/wb/sxcixi-single-b.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<adtcore:mainObject
+    xmlns:adtcore="http://www.sap.com/adt/core"
+    adtcore:name="ze_mock_classic_badi_impl_b"
+    adtcore:type="SXCI/XI"
+    adtcore:version="active"
+    adtcore:description="Second mock classic BAdI implementation"
+    adtcore:language="EN"/>

--- a/packages/adt-fixtures/src/fixtures/vit/wb/sxcixi-single.xml
+++ b/packages/adt-fixtures/src/fixtures/vit/wb/sxcixi-single.xml
@@ -2,7 +2,7 @@
 <!--
   Fixture: GET /sap/bc/adt/vit/wb/object_type/sxcixi/object_name/ze_mock_classic_badi_impl
 
-  Sanitized from S0D classic BAdI implementation shape.
+  TODO-synthetic mock fixture for classic BAdI implementation (SXCI/XI) shape.
 -->
 <adtcore:mainObject
     xmlns:adtcore="http://www.sap.com/adt/core"

--- a/packages/adt-fixtures/src/fixtures/vit/wb/sxcixi-single.xml
+++ b/packages/adt-fixtures/src/fixtures/vit/wb/sxcixi-single.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Fixture: GET /sap/bc/adt/vit/wb/object_type/sxcixi/object_name/ze_mock_classic_badi_impl
+
+  Sanitized from S0D classic BAdI implementation shape.
+-->
+<adtcore:mainObject
+    xmlns:adtcore="http://www.sap.com/adt/core"
+    adtcore:name="ze_mock_classic_badi_impl"
+    adtcore:type="SXCI/XI"
+    adtcore:version="active"
+    adtcore:description="Mock classic BAdI implementation"
+    adtcore:language="EN"/>

--- a/packages/adt-fixtures/src/fixtures/vit/wb/sxsdxd-single.xml
+++ b/packages/adt-fixtures/src/fixtures/vit/wb/sxsdxd-single.xml
@@ -2,7 +2,7 @@
 <!--
   Fixture: GET /sap/bc/adt/vit/wb/object_type/sxsdxd/object_name/mock_cts_request_check
 
-  Sanitized from S0D (CTS_REQUEST_CHECK). Mock names per fixture rules.
+  TODO-synthetic mock fixture per packages/adt-fixtures/AGENTS.md sanitization rules.
 -->
 <adtcore:mainObject
     xmlns:adtcore="http://www.sap.com/adt/core"

--- a/packages/adt-fixtures/src/fixtures/vit/wb/sxsdxd-single.xml
+++ b/packages/adt-fixtures/src/fixtures/vit/wb/sxsdxd-single.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Fixture: GET /sap/bc/adt/vit/wb/object_type/sxsdxd/object_name/mock_cts_request_check
+
+  Sanitized from S0D (CTS_REQUEST_CHECK). Mock names per fixture rules.
+-->
+<adtcore:mainObject
+    xmlns:adtcore="http://www.sap.com/adt/core"
+    adtcore:responsible="TESTUSER"
+    adtcore:masterLanguage="EN"
+    adtcore:masterSystem="MCK"
+    adtcore:name="MOCK_CTS_REQUEST_CHECK"
+    adtcore:type="SXSD/XD"
+    adtcore:version="active"
+    adtcore:description="Mock request checks BAdI definition"
+    adtcore:language="EN">
+  <adtcore:packageRef
+      adtcore:uri="/sap/bc/adt/packages/mock_pkg"
+      adtcore:type="DEVC/K"
+      adtcore:name="MOCK_PKG"/>
+</adtcore:mainObject>

--- a/packages/adt-fixtures/src/mock-server/routes.ts
+++ b/packages/adt-fixtures/src/mock-server/routes.ts
@@ -287,6 +287,11 @@ export interface LoadedFixtures {
   badiSource: string;
   // BAdI / Enhancement Implementation metadata (ENHO/XHB)
   badiInfoSingle: string;
+  // vit/wb Basic Object Properties (classic BAdI SXSD/SXCI)
+  vitWbSxsdxdSingle: string;
+  vitWbSxcixiSingle: string;
+  vitWbSxcixiSingleB: string;
+  badiImplementationsSearch: string;
   // SRVD (RAP service definition)
   srvdSingle: string;
   srvdSource: string;
@@ -379,6 +384,10 @@ export async function loadRouteFixtures(): Promise<LoadedFixtures> {
     badiSingle,
     badiSource,
     badiInfoSingle,
+    vitWbSxsdxdSingle,
+    vitWbSxcixiSingle,
+    vitWbSxcixiSingleB,
+    badiImplementationsSearch,
     srvdSingle,
     srvdSource,
     srvbSingle,
@@ -460,6 +469,10 @@ export async function loadRouteFixtures(): Promise<LoadedFixtures> {
     fixtures.enhancements.enhoxhh.single.load(),
     fixtures.enhancements.enhoxhh.source.load(),
     fixtures.enhancements.enhoxhb.single.load(),
+    fixtures.vit.wb.sxsdxdSingle.load(),
+    fixtures.vit.wb.sxcixiSingle.load(),
+    fixtures.vit.wb.sxcixiSingleB.load(),
+    fixtures.badi.implementationsSearch.load(),
     fixtures.ddic.srvd.single.load(),
     fixtures.ddic.srvd.source.load(),
     fixtures.businessservices.bindings.single.load(),
@@ -547,6 +560,10 @@ export async function loadRouteFixtures(): Promise<LoadedFixtures> {
     badiSingle,
     badiSource,
     badiInfoSingle,
+    vitWbSxsdxdSingle,
+    vitWbSxcixiSingle,
+    vitWbSxcixiSingleB,
+    badiImplementationsSearch,
     srvdSingle,
     srvdSource,
     srvbSingle,
@@ -617,6 +634,20 @@ export function matchRoute(
     m === 'GET' &&
     url.startsWith('/sap/bc/adt/repository/informationsystem/search')
   ) {
+    const query =
+      new URL(url, 'http://mock').searchParams.get('query')?.toUpperCase() ??
+      '';
+    if (
+      query.includes('MOCK_CTS') ||
+      query.includes('CTS_REQUEST') ||
+      query.includes('REQUEST_CHECK')
+    ) {
+      return {
+        status: 200,
+        body: f.badiImplementationsSearch,
+        contentType: 'application/json',
+      };
+    }
     return { status: 200, body: f.search, contentType: 'application/json' };
   }
 
@@ -905,6 +936,36 @@ export function matchRoute(
   }
   if (m === 'DELETE' && url.startsWith('/sap/bc/adt/enhancements/enhoxhh/')) {
     return { status: 204, body: '', contentType: 'text/plain' };
+  }
+
+  // ── vit/wb Basic Object Properties (classic BAdI SXSD/SXCI) ─────
+  // Endpoint: /sap/bc/adt/vit/wb/object_type/{type}/object_name/{name}
+  if (
+    m === 'GET' &&
+    /^\/sap\/bc\/adt\/vit\/wb\/object_type\/sxsdxd\/object_name\//.test(
+      pathname,
+    )
+  ) {
+    return {
+      status: 200,
+      body: f.vitWbSxsdxdSingle,
+      contentType: 'application/vnd.sap.adt.basic.object.properties+xml',
+    };
+  }
+  if (
+    m === 'GET' &&
+    /^\/sap\/bc\/adt\/vit\/wb\/object_type\/sxcixi\/object_name\//.test(
+      pathname,
+    )
+  ) {
+    const body = pathname.includes('ze_mock_classic_badi_impl_b')
+      ? f.vitWbSxcixiSingleB
+      : f.vitWbSxcixiSingle;
+    return {
+      status: 200,
+      body,
+      contentType: 'application/vnd.sap.adt.basic.object.properties+xml',
+    };
   }
 
   // ── SRVD (RAP service definition) ──────────────────────────────

--- a/packages/adt-mcp/src/lib/tools/get-badi.ts
+++ b/packages/adt-mcp/src/lib/tools/get-badi.ts
@@ -34,9 +34,12 @@ export function registerGetBadiTool(server: McpServer, ctx: ToolContext): void {
     async (args, extra) => {
       try {
         const { client } = await resolveClient(ctx, args, extra ?? {});
-        const result = await new BadiService(client).get(args.badiName, {
-          includeSource: args.includeSource,
-          includeImplementations: args.includeImplementations,
+        const result = await new BadiService(client).get({
+          name: args.badiName,
+          options: {
+            includeSource: args.includeSource,
+            includeImplementations: args.includeImplementations,
+          },
         });
         if (args.includeImplementations && result.kind !== 'definition') {
           return {

--- a/packages/adt-mcp/src/lib/tools/get-badi.ts
+++ b/packages/adt-mcp/src/lib/tools/get-badi.ts
@@ -18,7 +18,7 @@ export function registerGetBadiTool(server: McpServer, ctx: ToolContext): void {
       badiName: z
         .string()
         .describe(
-          'BAdI name — definition (e.g. CTS_REQUEST_CHECK), implementation, or ENHO container',
+          'BAdI name — definition, implementation (SXCI/XI), or ENHO container',
         ),
       includeSource: z
         .boolean()

--- a/packages/adt-mcp/src/lib/tools/get-badi.ts
+++ b/packages/adt-mcp/src/lib/tools/get-badi.ts
@@ -1,11 +1,9 @@
 /**
- * Tool: get_badi – fetch BAdI / Enhancement Implementation (ENHO/XHH)
- * metadata, optionally including the source payload that lists
- * the BAdI implementations.
+ * Tool: get_badi – read-only BAdI information for any flavour.
  */
 
 import { z } from 'zod';
-import { getBadiInfo } from '@abapify/adt-cli';
+import { BadiService } from '@abapify/adt-cli';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ToolContext } from '../types';
 import { sessionOrConnectionShape } from './shared-schemas';
@@ -14,26 +12,42 @@ import { resolveClient } from './session-helpers';
 export function registerGetBadiTool(server: McpServer, ctx: ToolContext): void {
   server.tool(
     'get_badi',
-    'Fetch Enhancement Implementation (ENHO/XHH — BAdI container) metadata, optionally including the source payload with its BAdI implementations.',
+    'Read BAdI information (classic SXSD/SXCI definition or implementation, or ENHO/XHH). Kind is auto-detected. Use includeImplementations on a definition to list its classic implementations.',
     {
       ...sessionOrConnectionShape,
       badiName: z
         .string()
-        .describe('Enhancement Implementation name (e.g. ZE_MY_BADI_IMPL)'),
+        .describe(
+          'BAdI name — definition (e.g. CTS_REQUEST_CHECK), implementation, or ENHO container',
+        ),
       includeSource: z
         .boolean()
         .optional()
-        .describe('Include source text listing the BAdI implementations'),
+        .describe('Include ENHO/XHH source text when kind is enhancement'),
+      includeImplementations: z
+        .boolean()
+        .optional()
+        .describe(
+          'When badiName is a classic definition (SXSD/XD), include its SXCI/XI implementations',
+        ),
     },
     async (args, extra) => {
       try {
         const { client } = await resolveClient(ctx, args, extra ?? {});
-        const info = await getBadiInfo(client, args.badiName);
-        const result: Record<string, unknown> = { info };
-        if (args.includeSource) {
-          result.source = await client.adt.enhancements.enhoxhh.source.main.get(
-            args.badiName.toLowerCase(),
-          );
+        const result = await new BadiService(client).get(args.badiName, {
+          includeSource: args.includeSource,
+          includeImplementations: args.includeImplementations,
+        });
+        if (args.includeImplementations && result.kind !== 'definition') {
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text' as const,
+                text: 'includeImplementations is only valid for classic BAdI definitions (SXSD/XD)',
+              },
+            ],
+          };
         }
         return {
           content: [

--- a/packages/adt-server/src/broker.ts
+++ b/packages/adt-server/src/broker.ts
@@ -1284,8 +1284,11 @@ export function createHttpBrokerOperations(
           enhancement: _enhancement,
           source: _source,
           ...metadata
-        } = await new BadiService(client).get(badiName, {
-          includeImplementations: options?.includeImplementations,
+        } = await new BadiService(client).get({
+          name: badiName,
+          options: {
+            includeImplementations: options?.includeImplementations,
+          },
         });
         return metadata;
       });

--- a/packages/adt-server/src/broker.ts
+++ b/packages/adt-server/src/broker.ts
@@ -8,7 +8,7 @@ import {
   SourceVersionTooLargeError,
   type AdtClient,
 } from '@abapify/adt-client';
-import { ExactSourceHistoryService } from '@abapify/adt-cli';
+import { ExactSourceHistoryService, BadiService } from '@abapify/adt-cli';
 import type {
   DestinationContextFactory,
   DestinationLeaseProvider,
@@ -1277,6 +1277,18 @@ export function createHttpBrokerOperations(
           );
         },
       );
+    },
+    async getBadi(destination, badiName, options) {
+      return await withClient(destination, 'get_badi', async (client) => {
+        const {
+          enhancement: _enhancement,
+          source: _source,
+          ...metadata
+        } = await new BadiService(client).get(badiName, {
+          includeImplementations: options?.includeImplementations,
+        });
+        return metadata;
+      });
     },
     async getObjectSourceHistory(destination, objectType, objectName) {
       return await withClient(

--- a/packages/adt-server/src/openapi.ts
+++ b/packages/adt-server/src/openapi.ts
@@ -7,6 +7,7 @@ import {
   atcRunResponse,
   destinationSummaryResponse,
   objectMetadataResponse,
+  badiResponse,
   objectNamePathParameter,
   objectPageResponse,
   objectSearchQuery,
@@ -53,6 +54,7 @@ const packageSearchQuerySchema = z.toJSONSchema(packageSearchQuery);
 const packageTreeQuerySchema = z.toJSONSchema(packageTreeQuery);
 const objectPageResponseSchema = z.toJSONSchema(objectPageResponse);
 const objectMetadataResponseSchema = z.toJSONSchema(objectMetadataResponse);
+const badiResponseSchema = z.toJSONSchema(badiResponse);
 const objectSourceHistoryResponseSchema = z.toJSONSchema(
   objectSourceHistoryResponse,
 );
@@ -384,6 +386,40 @@ export const openApiDocument = {
               'Canonical object metadata, facets and allowlisted relation capabilities',
             content: {
               'application/json': { schema: objectMetadataResponseSchema },
+            },
+          },
+          '400': { description: 'Invalid request' },
+        },
+      },
+    },
+    '/v1/destinations/{destination}/badi/{name}': {
+      get: {
+        operationId: 'getBadi',
+        parameters: [
+          { $ref: '#/components/parameters/destination' },
+          {
+            name: 'name',
+            in: 'path',
+            required: true,
+            schema: objectNamePathParameterSchema,
+            description:
+              'BAdI name — definition, implementation, or ENHO container',
+          },
+          {
+            name: 'implementations',
+            in: 'query',
+            required: false,
+            schema: { type: 'boolean' },
+            description:
+              'When name is a classic definition (SXSD/XD), include its SXCI/XI implementations',
+          },
+        ],
+        responses: {
+          '200': {
+            description:
+              'Canonical BAdI metadata; kind is resolved from repository type',
+            content: {
+              'application/json': { schema: badiResponseSchema },
             },
           },
           '400': { description: 'Invalid request' },

--- a/packages/adt-server/src/request-handler.ts
+++ b/packages/adt-server/src/request-handler.ts
@@ -27,6 +27,7 @@ import {
   MAX_SOURCE_BYTES,
   objectPageResponse,
   objectMetadataResponse,
+  badiResponse,
   objectNamePathParameter,
   objectSearchResult,
   objectSourceReadBody,
@@ -575,6 +576,40 @@ async function handleObjectMetadata(
   }
 }
 
+async function handleBadiRead(
+  ctx: RequestHandlerContext,
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+  match: RegExpExecArray,
+): Promise<void> {
+  try {
+    const destination = match[1]!;
+    const badiName = parseObjectName(match[2]!);
+    const query = z
+      .object({
+        implementations: z
+          .enum(['true', 'false'])
+          .optional()
+          .transform((value) => value === 'true'),
+      })
+      .strict()
+      .parse(readQuery(request));
+    if (!ctx.options.operations.getBadi) {
+      writeNotFound(response);
+      return;
+    }
+    const data = badiResponse.parse(
+      await ctx.options.operations.getBadi(destination, badiName, {
+        includeImplementations: query.implementations,
+      }),
+    );
+    sendJson(response, data);
+  } catch (error) {
+    if (handleKnownError(response, error)) return;
+    throw error;
+  }
+}
+
 async function handleObjectSourceHistory(
   ctx: RequestHandlerContext,
   request: http.IncomingMessage,
@@ -872,6 +907,12 @@ const defaultRoutes: Route[] = [
       /^\/v1\/destinations\/([a-z][a-z0-9-]{1,62})\/objects\/([^/]+)\/([^/]+)$/u,
     requiresRest: true,
     handler: handleObjectMetadata,
+  },
+  {
+    method: 'GET',
+    pattern: /^\/v1\/destinations\/([a-z][a-z0-9-]{1,62})\/badi\/([^/]+)$/u,
+    requiresRest: true,
+    handler: handleBadiRead,
   },
   {
     method: 'GET',

--- a/packages/adt-server/src/rest-schemas.ts
+++ b/packages/adt-server/src/rest-schemas.ts
@@ -375,6 +375,52 @@ const objectMetadataCapability = z
   })
   .strict();
 
+/** Canonical BAdI metadata (classic vit/wb or ENHO/XHH). */
+export const badiResponse = z
+  .object({
+    kind: z.enum(['definition', 'implementation', 'enhancement']),
+    name: z.string().trim().min(1).max(128),
+    type: z.string().trim().min(1).max(64),
+    description: z.string().max(1_024).optional(),
+    language: z.string().trim().min(1).max(16).optional(),
+    version: z.string().trim().min(1).max(64).optional(),
+    packageName: z.string().trim().min(1).max(128).optional(),
+    packageUri: z
+      .string()
+      .max(8 * 1024)
+      .optional(),
+    responsible: z.string().max(256).optional(),
+    masterLanguage: z.string().trim().min(1).max(16).optional(),
+    masterSystem: z.string().trim().min(1).max(32).optional(),
+    implementations: z
+      .array(
+        z
+          .object({
+            kind: z.literal('implementation'),
+            name: z.string().trim().min(1).max(128),
+            type: z.string().trim().min(1).max(64),
+            description: z.string().max(1_024).optional(),
+            language: z.string().trim().min(1).max(16).optional(),
+            version: z.string().trim().min(1).max(64).optional(),
+            packageName: z.string().trim().min(1).max(128).optional(),
+            packageUri: z
+              .string()
+              .max(8 * 1024)
+              .optional(),
+            responsible: z.string().max(256).optional(),
+            masterLanguage: z.string().trim().min(1).max(16).optional(),
+            masterSystem: z.string().trim().min(1).max(32).optional(),
+          })
+          .strict(),
+      )
+      .max(5_000)
+      .optional(),
+  })
+  .strict();
+
+/** @deprecated Use badiResponse */
+export const classicBadiResponse = badiResponse.omit({ kind: true });
+
 /** Safe metadata projection. Raw ADT links remain broker-local. */
 export const objectMetadataResponse = z
   .object({

--- a/packages/adt-server/src/server.ts
+++ b/packages/adt-server/src/server.ts
@@ -83,6 +83,12 @@ export interface AdtServerOperations {
     objectType: string,
     objectName: string,
   ): Promise<unknown>;
+  /** Unified BAdI read — classic SXSD/SXCI (vit/wb) or ENHO/XHH. */
+  getBadi?(
+    destination: string,
+    badiName: string,
+    options?: { includeImplementations?: boolean },
+  ): Promise<unknown>;
   /** Public metadata-only history; immutable source locators remain local. */
   getObjectSourceHistory?(
     destination: string,

--- a/packages/adt-server/tests/openapi.test.ts
+++ b/packages/adt-server/tests/openapi.test.ts
@@ -206,6 +206,14 @@ it('documents canonical object metadata without raw ADT links', () => {
   assert.ok(!JSON.stringify(metadata).includes('href'));
 });
 
+it('documents unified BAdI metadata endpoint', () => {
+  const badi =
+    openApiDocument.paths['/v1/destinations/{destination}/badi/{name}'].get;
+
+  assert.strictEqual(badi.operationId, 'getBadi');
+  assert.ok(badi.responses['200'].content?.['application/json'].schema);
+});
+
 it('documents canonical object source history without source locators', () => {
   const history =
     openApiDocument.paths[


### PR DESCRIPTION
## Summary

Stacked on #153 — adds classic BAdI (SXSD/XD definitions, SXCI/XI implementations) read support via `vit/wb`, unified under `adt get badi` + MCP + adt-server.

Builds on #153's ENHO `enhoxhb` metadata (`adt badi <name> --implementations`).

## What changed

- **Contract** — `adt/vit/wb/objectproperties` for SXSD/SXCI metadata
- **BadiService** — auto-detect kind (definition / implementation / enhancement); classic `--implementations` lists SXCI/XI via repository search heuristics
- **CLI** — `adt get badi <name>` (read-only); keeps #153's `adt badi` for ENHO CRUD + enhoxhb metadata
- **MCP** — `get_badi` uses unified `BadiService`
- **adt-server** — `GET /v1/destinations/{destination}/badi/{name}?implementations=true`
- **Fixtures + parity tests** for classic and ENHO flows

## Usage

```bash
# Classic definition (new)
adt get badi MOCK_CTS_REQUEST_CHECK --json
adt get badi MOCK_CTS_REQUEST_CHECK --implementations --json

# ENHO — from #153
adt badi ZE_MOCK_BADI --implementations
adt get badi ZE_MOCK_BADI --json
```

## Test plan

- [ ] `parity.badi.test.ts` passes (ENHO + classic)
- [ ] `vit-wb.test.ts` contract tests pass
- [ ] Live: `adt get badi CTS_REQUEST_CHECK --json` on a system with classic BAdIs