### PR TITLE
fix(adt-flow): ignore CTS release metadata during checkout

### DIFF
--- a/packages/adk/tests/transport-import.test.ts
+++ b/packages/adk/tests/transport-import.test.ts
@@ -517,6 +517,39 @@ describe('AdkTransport.getObjectsBySelector()', () => {
   });
 });
 
+describe('matchesSelector()', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('excludes CORR/RELE metadata while matching R3TR and LIMU repository pgmids', async () => {
+    const { matchesSelector, AdkTransportObjectRef } =
+      await import('../src/index');
+
+    const r3tr = new AdkTransportObjectRef({} as any, {
+      pgmid: 'R3TR',
+      type: 'CLAS',
+      name: 'ZCL_TEST',
+    });
+    const limu = new AdkTransportObjectRef({} as any, {
+      pgmid: 'LIMU',
+      type: 'REPS',
+      name: 'ZREPS',
+    });
+    const corrRele = new AdkTransportObjectRef({} as any, {
+      pgmid: 'CORR',
+      type: 'RELE',
+      name: 'S0DK954871',
+    });
+
+    const selector = { pgmid: ['R3TR', 'LIMU'] };
+
+    expect(matchesSelector(r3tr, selector)).toBe(true);
+    expect(matchesSelector(limu, selector)).toBe(true);
+    expect(matchesSelector(corrRele, selector)).toBe(false);
+  });
+});
+
 describe('MergedTransportView', () => {
   beforeEach(() => {
     vi.resetModules();

--- a/packages/adt-flow/src/adt-client-adapter.ts
+++ b/packages/adt-flow/src/adt-client-adapter.ts
@@ -2,6 +2,7 @@ import {
   buildTransportSourceManifest,
   createAdk,
   type AdkFactory,
+  type TransportObjectSelector,
   type TransportSourceManifest,
 } from '@abapify/adk';
 import type { AdtClient, SourceVersionRef } from '@abapify/adt-client';
@@ -21,7 +22,7 @@ interface PackageModel extends LoadableModel {
 export interface AdtFlowAdapterOperations {
   buildManifest(
     transports: string[],
-    options: { selector?: { type?: string[] }; concurrency: number },
+    options: { selector?: TransportObjectSelector; concurrency: number },
     context: { client: AdtClient },
   ): Promise<TransportSourceManifest>;
   createFactory(client: AdtClient): AdkFactory;
@@ -144,9 +145,12 @@ export function createAdtFlowDependencies(
         return await operations.buildManifest(
           transports,
           {
-            ...(options.objectTypes?.length
-              ? { selector: { type: options.objectTypes } }
-              : {}),
+            selector: {
+              pgmid: ['R3TR', 'LIMU'],
+              ...(options.objectTypes?.length
+                ? { type: options.objectTypes }
+                : {}),
+            },
             concurrency: options.concurrency,
           },
           { client },

--- a/packages/adt-flow/tests/adt-client-adapter.test.ts
+++ b/packages/adt-flow/tests/adt-client-adapter.test.ts
@@ -60,10 +60,35 @@ describe('ADT client adapter', () => {
 
     expect(buildManifest).toHaveBeenCalledWith(
       ['DEVK900001'],
-      { selector: { type: ['CLAS'] }, concurrency: 3 },
+      {
+        selector: { pgmid: ['R3TR', 'LIMU'], type: ['CLAS'] },
+        concurrency: 3,
+      },
       { client: adtClient },
     );
     expect(read).toHaveBeenCalledWith('/sap/bc/adt/source/v1', 1024);
+  });
+
+  it('excludes CORR/RELE metadata from source manifests', async () => {
+    const buildManifest = vi.fn(async () => manifest);
+    const adtClient = client();
+    const dependencies = createAdtFlowDependencies(adtClient, format, {
+      buildManifest,
+      createFactory: vi.fn(() => ({ get: vi.fn() }) as unknown as AdkFactory),
+    });
+
+    await expect(
+      dependencies.buildManifest(['DEVK900001'], { concurrency: 3 }),
+    ).resolves.toBe(manifest);
+
+    expect(buildManifest).toHaveBeenCalledWith(
+      ['DEVK900001'],
+      {
+        selector: { pgmid: ['R3TR', 'LIMU'] },
+        concurrency: 3,
+      },
+      { client: adtClient },
+    );
   });
 
   it('loads the object and resolves its package path and application component', async () => {

--- a/packages/adt-flow/tests/adt-client-adapter.test.ts
+++ b/packages/adt-flow/tests/adt-client-adapter.test.ts
@@ -69,7 +69,7 @@ describe('ADT client adapter', () => {
     expect(read).toHaveBeenCalledWith('/sap/bc/adt/source/v1', 1024);
   });
 
-  it('excludes CORR/RELE metadata from source manifests', async () => {
+  it('defaults the manifest selector to repository pgmids R3TR and LIMU', async () => {
     const buildManifest = vi.fn(async () => manifest);
     const adtClient = client();
     const dependencies = createAdtFlowDependencies(adtClient, format, {


### PR DESCRIPTION
## Summary

- Restrict `adt-flow` source-manifest discovery to repository object program IDs `R3TR` and `LIMU`
- Exclude technical CTS entries such as `CORR/RELE` before ADK metadata and source-history resolution
- Preserve configured object-type filtering and fail-closed exactness for relevant repository objects

## Root cause

`adt flow checkout` treated `RELE/S0DK954871 20260804 063030 TE_RFC` as a source object. ADK correctly reported `OBJECT_TYPE_UNSUPPORTED`, causing `manifest_inexact`. `RELE` is CTS release metadata, not a repository source component.

## Test plan

- [x] `packages/adt-flow/tests/adt-client-adapter.test.ts` — includes new `CORR/RELE` exclusion test
- [x] `nx run adt-flow:test`
- [x] `nx run adt-flow:build`
- [x] `nx run adt-flow:lint`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore CTS release metadata during `adt-flow` checkout so only real repository sources are included. Manifest discovery now always filters by `pgmid` R3TR/LIMU to avoid inexact manifests caused by `RELE` entries.

- **Bug Fixes**
  - Always pass selector `{ pgmid: ['R3TR', 'LIMU'] }` and merge `type` filters when provided.
  - Exclude CTS technical entries (e.g., `CORR/RELE`) before metadata/source-history resolution to prevent `OBJECT_TYPE_UNSUPPORTED` and `manifest_inexact`.
  - Use `TransportObjectSelector` from `@abapify/adk`; add tests for default `pgmid` filtering and `CORR/RELE` exclusion, including `adk` `matchesSelector` coverage.

<sup>Written for commit 1df6c9f9c08165aa7c85e6959f3421de39050f01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transport manifest filtering for more accurate object selection.
  * Manifests now consistently include the required transport object categories.
  * Metadata is excluded when no object-type filter is specified, while concurrency and client settings remain preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->