### PR TITLE
fix: CTS lifecycle follow-ups — lock correlation, release details, flow scope

### DIFF
--- a/packages/adk/src/objects/cts/transport/transport.ts
+++ b/packages/adk/src/objects/cts/transport/transport.ts
@@ -77,8 +77,8 @@ function releaseReportFailure(
     (entry) => entry.shortText,
   )?.shortText;
   return (
-    failed.statusText ||
     message ||
+    failed.statusText ||
     `SAP release report failed with status ${failed.status || 'unknown'}`
   );
 }

--- a/packages/adk/tests/transport-lifecycle.test.ts
+++ b/packages/adk/tests/transport-lifecycle.test.ts
@@ -10,6 +10,7 @@ interface TransportState {
 interface LifecycleFixtureOptions {
   releaseStatus?: string;
   releaseStatusText?: string;
+  releaseMessage?: string;
   applyReassign?: boolean;
   applyAddTask?: boolean;
   addTaskNumber?: string;
@@ -63,11 +64,19 @@ function taskResponse(
   };
 }
 
-function releaseResponse(status: string, statusText: string) {
+function releaseResponse(status: string, statusText: string, message?: string) {
   return {
     root: {
       releasereports: {
-        checkReport: [{ status, statusText }],
+        checkReport: [
+          {
+            status,
+            statusText,
+            ...(message
+              ? { checkMessageList: { checkMessage: [{ shortText: message }] } }
+              : {}),
+          },
+        ],
       },
     },
   };
@@ -105,6 +114,7 @@ function createLifecycleFixture(options: LifecycleFixtureOptions = {}) {
       status,
       options.releaseStatusText ??
         (status === 'released' ? 'Released' : 'Release failed'),
+      options.releaseMessage,
     );
   });
   const reassign = vi.fn(
@@ -202,7 +212,8 @@ describe('AdkTransportRequest CTS lifecycle', () => {
   it('surfaces a failed release report instead of reporting success', async () => {
     const fixture = createLifecycleFixture({
       releaseStatus: 'abortrelapifail',
-      releaseStatusText: 'Task is unclassified and cannot be released',
+      releaseStatusText: 'Release failed. See Problems view',
+      releaseMessage: 'Task is unclassified and cannot be released',
     });
     const transport = await AdkTransportRequest.get(fixture.rootNumber, {
       client: fixture.client,

--- a/packages/adt-cli/src/lib/commands/abap/run.ts
+++ b/packages/adt-cli/src/lib/commands/abap/run.ts
@@ -31,6 +31,7 @@ import { createProgressReporter } from '../../utils/progress-reporter';
 import { createCliLogger } from '../../utils/logger-config';
 import { AdkClass } from '@abapify/adk';
 import { resolveLockCorrelation } from '@abapify/adt-locks';
+import { deleteWithReleasedLock } from '../object/builder';
 
 function buildClassTemplate(className: string, body: string): string {
   const lower = className.toLowerCase();
@@ -163,9 +164,10 @@ export const abapRunCommand = new Command('run')
         // Step 6: Always delete the temp class
         progress.step(`🗑️  Cleaning up ${className}...`);
         try {
-          await AdkClass.delete(
-            className,
-            options.transport ? { transport: options.transport } : undefined,
+          await deleteWithReleasedLock(
+            cls,
+            (deleteOptions) => AdkClass.delete(className, deleteOptions),
+            options.transport,
           );
           progress.done();
         } catch {

--- a/packages/adt-cli/src/lib/commands/cts/tr/set.ts
+++ b/packages/adt-cli/src/lib/commands/cts/tr/set.ts
@@ -43,7 +43,7 @@ export const ctsSetCommand = new Command('set')
         process.exit(1);
       }
 
-      const client = await getAdtClientV2();
+      await getAdtClientV2();
 
       // Build update options
       let updateOptions: { description?: string; target?: string };
@@ -73,8 +73,9 @@ export const ctsSetCommand = new Command('set')
 
       // Get transport via ADK
       progress.step(`🔍 Getting transport ${transport}...`);
-      // ADK expects (number, ctx?) - ctx is AdkContext with client property
-      const tr = await AdkTransportRequest.get(transport, { client });
+      // getAdtClientV2() initializes the complete global ADK context,
+      // including the lock service required by update().
+      const tr = await AdkTransportRequest.get(transport);
       progress.done();
 
       // Update using ADK (handles lock/unlock automatically)

--- a/packages/adt-cli/src/lib/commands/object/builder.test.ts
+++ b/packages/adt-cli/src/lib/commands/object/builder.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   createWithReadbackRecovery,
+  deleteWithReleasedLock,
   persistSourceWithReleasedLock,
   resolveEffectiveTransport,
 } from './builder';
@@ -19,6 +20,52 @@ describe('resolveEffectiveTransport', () => {
     expect(resolveEffectiveTransport({ handle: 'lock-1' }, 'DEVK900002')).toBe(
       'DEVK900002',
     );
+  });
+});
+
+describe('deleteWithReleasedLock', () => {
+  it('deletes with the SAP lock handle and authoritative correlation', async () => {
+    const calls: string[] = [];
+    const object = {
+      lock: vi.fn(async () => {
+        calls.push('lock');
+        return {
+          handle: 'lock-1',
+          correlationNumber: 'DEVK900001',
+        };
+      }),
+      unlock: vi.fn(async () => {
+        calls.push('unlock');
+      }),
+    };
+    const deleteObject = vi.fn(async () => {
+      calls.push('delete');
+    });
+
+    await deleteWithReleasedLock(object, deleteObject, 'DEVK900002');
+
+    expect(calls).toEqual(['lock', 'delete', 'unlock']);
+    expect(deleteObject).toHaveBeenCalledWith({
+      lockHandle: 'lock-1',
+      transport: 'DEVK900001',
+    });
+  });
+
+  it('unlocks and preserves a failed delete', async () => {
+    const deleteError = new Error('delete failed');
+    const object = {
+      lock: vi.fn().mockResolvedValue({ handle: 'lock-1' }),
+      unlock: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await expect(
+      deleteWithReleasedLock(
+        object,
+        vi.fn().mockRejectedValue(deleteError),
+        'DEVK900002',
+      ),
+    ).rejects.toBe(deleteError);
+    expect(object.unlock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/adt-cli/src/lib/commands/object/builder.test.ts
+++ b/packages/adt-cli/src/lib/commands/object/builder.test.ts
@@ -49,6 +49,7 @@ describe('deleteWithReleasedLock', () => {
       lockHandle: 'lock-1',
       transport: 'DEVK900001',
     });
+    expect(object.unlock).toHaveBeenCalledWith('lock-1');
   });
 
   it('unlocks and preserves a failed delete', async () => {
@@ -66,6 +67,7 @@ describe('deleteWithReleasedLock', () => {
       ),
     ).rejects.toBe(deleteError);
     expect(object.unlock).toHaveBeenCalledTimes(1);
+    expect(object.unlock).toHaveBeenCalledWith('lock-1');
   });
 });
 

--- a/packages/adt-cli/src/lib/commands/object/builder.ts
+++ b/packages/adt-cli/src/lib/commands/object/builder.ts
@@ -153,7 +153,7 @@ interface PersistSourceOptions {
 
 interface DeleteLifecycleObject {
   lock(transport?: string): Promise<ObjectLockHandle>;
-  unlock(): Promise<void>;
+  unlock(lockHandle: string): Promise<void>;
 }
 
 /** Delete under an editor lock and release that lock on every outcome. */
@@ -177,7 +177,7 @@ export async function deleteWithReleasedLock(
   }
 
   try {
-    await object.unlock();
+    await object.unlock(lockHandle.handle);
   } catch (unlockError) {
     if (deleteError) {
       throw new AggregateError(

--- a/packages/adt-cli/src/lib/commands/object/builder.ts
+++ b/packages/adt-cli/src/lib/commands/object/builder.ts
@@ -151,6 +151,46 @@ interface PersistSourceOptions {
   beforeActivate?: () => void;
 }
 
+interface DeleteLifecycleObject {
+  lock(transport?: string): Promise<ObjectLockHandle>;
+  unlock(): Promise<void>;
+}
+
+/** Delete under an editor lock and release that lock on every outcome. */
+export async function deleteWithReleasedLock(
+  object: DeleteLifecycleObject,
+  deleteObject: (options: {
+    transport?: string;
+    lockHandle: string;
+  }) => Promise<void>,
+  requestedTransport?: string,
+): Promise<void> {
+  const lockHandle = await object.lock(requestedTransport);
+  let deleteError: unknown;
+  try {
+    await deleteObject({
+      lockHandle: lockHandle.handle,
+      transport: resolveEffectiveTransport(lockHandle, requestedTransport),
+    });
+  } catch (error) {
+    deleteError = error;
+  }
+
+  try {
+    await object.unlock();
+  } catch (unlockError) {
+    if (deleteError) {
+      throw new AggregateError(
+        [deleteError, unlockError],
+        'Object delete and lock release both failed',
+        { cause: unlockError },
+      );
+    }
+    throw unlockError;
+  }
+  if (deleteError) throw deleteError;
+}
+
 /** Save under the editor lock, release it, and only then activate. */
 export async function persistSourceWithReleasedLock<T>(
   object: SourceLifecycleObject<T>,
@@ -583,9 +623,11 @@ export function buildObjectCrudCommands<
           }
 
           progress.step(`🗑️  Deleting ${def.label} ${n}...`);
-          await def.delete(
-            n,
-            options.transport ? { transport: options.transport } : undefined,
+          const object = await def.get(n);
+          await deleteWithReleasedLock(
+            object,
+            (deleteOptions) => def.delete(n, deleteOptions),
+            options.transport,
           );
           progress.done();
 

--- a/packages/adt-cli/tests/e2e/parity.cts.test.ts
+++ b/packages/adt-cli/tests/e2e/parity.cts.test.ts
@@ -6,13 +6,9 @@
  * counts, etc.). All tests run against the shared in-process mock ADT
  * server wired by the harness. No real SAP calls.
  *
- * Several CTS CLI commands (get, create, release, reassign, set) build on
- * `@abapify/adk` (e.g. `AdkTransportRequest`). The e2e harness does NOT
- * call `initializeAdk(client)`, so those CLI paths cannot be exercised
- * end-to-end here. We still assert the MCP side (which uses the v2 client
- * services / raw contracts directly) and mark the CLI-parity assertions as
- * `it.todo` with the specific gap noted. MCP-only smoke tests keep the
- * tools covered until the harness gains ADK wiring.
+ * Several CTS CLI commands build on `@abapify/adk` (for example,
+ * `AdkTransportRequest`). The e2e harness initializes the complete ADK
+ * context so lock-dependent CLI paths are covered alongside MCP paths.
  */
 
 import { describe, it, beforeAll, beforeEach, afterAll, expect } from 'vitest';
@@ -402,22 +398,23 @@ describe('parity: cts', () => {
 
   // ──────────────────────────────────────────────────────────────────────────
   // 7. Update transport
-  //
-  // CLI `cts tr set` calls `AdkTransportRequest.get(transport, { client })`,
-  // building a *custom* AdkContext that contains only `client` (no
-  // `lockService`). `tr.update(...)` then tries to lock the request and
-  // fails with "Lock not available: no lockService in context".
-  // The global ADK context (populated by the harness via `initializeAdk`)
-  // has a lockService but is NOT consulted once a custom ctx is passed.
-  //
-  // Fixing this properly requires editing `cts/tr/set.ts` (or the
-  // equivalent in `release`, `reassign`, `delete`) to either drop the
-  // custom ctx or merge in the global context's lockService — both of
-  // which are out of scope for this task.
   // ──────────────────────────────────────────────────────────────────────────
-  it.todo(
-    'update transport: CLI parity blocked — `cts tr set` passes a custom ADK context without lockService, bypassing the global context set up by the harness',
-  );
+  it('update transport: CLI `cts tr set` uses the initialized lock service', async () => {
+    const cli = await runCliCommand(harness, [
+      'cts',
+      'tr',
+      'set',
+      'DEVK900001',
+      '--description',
+      'Updated text',
+      '--json',
+    ]);
+    expect(cli.exitCode, cli.stderr || cli.stdout).toBe(0);
+    expect(extractJson(cli)).toMatchObject({
+      status: 'updated',
+      transport: 'DEVK900001',
+    });
+  });
 
   it('update transport (MCP only): `cts_update_transport`', async () => {
     const mcp = await callMcpTool<{

--- a/packages/adt-fixtures/src/mock-server/routes.ts
+++ b/packages/adt-fixtures/src/mock-server/routes.ts
@@ -736,7 +736,11 @@ export function matchRoute(
       contentType: 'application/vnd.sap.adt.domains.v2+xml',
     };
   }
-  if (m === 'POST' && url.startsWith('/sap/bc/adt/ddic/domains')) {
+  if (
+    m === 'POST' &&
+    url.startsWith('/sap/bc/adt/ddic/domains') &&
+    !url.includes('_action=')
+  ) {
     return { status: 200, body: '', contentType: 'text/plain' };
   }
   if (m === 'DELETE' && url.startsWith('/sap/bc/adt/ddic/domains/')) {
@@ -757,7 +761,11 @@ export function matchRoute(
       contentType: 'application/vnd.sap.adt.dataelements.v2+xml',
     };
   }
-  if (m === 'POST' && url.startsWith('/sap/bc/adt/ddic/dataelements')) {
+  if (
+    m === 'POST' &&
+    url.startsWith('/sap/bc/adt/ddic/dataelements') &&
+    !url.includes('_action=')
+  ) {
     return { status: 200, body: '', contentType: 'text/plain' };
   }
   if (m === 'DELETE' && url.startsWith('/sap/bc/adt/ddic/dataelements/')) {
@@ -784,7 +792,11 @@ export function matchRoute(
       contentType: 'application/xml',
     };
   }
-  if (m === 'POST' && url.startsWith('/sap/bc/adt/ddic/structures')) {
+  if (
+    m === 'POST' &&
+    url.startsWith('/sap/bc/adt/ddic/structures') &&
+    !url.includes('_action=')
+  ) {
     return { status: 200, body: '', contentType: 'text/plain' };
   }
   if (m === 'DELETE' && url.startsWith('/sap/bc/adt/ddic/structures/')) {
@@ -794,7 +806,11 @@ export function matchRoute(
     return { status: 200, body: '', contentType: 'text/plain' };
   }
   // DDIC tables POST/DELETE/PUT
-  if (m === 'POST' && url.startsWith('/sap/bc/adt/ddic/tables')) {
+  if (
+    m === 'POST' &&
+    url.startsWith('/sap/bc/adt/ddic/tables') &&
+    !url.includes('_action=')
+  ) {
     return { status: 200, body: '', contentType: 'text/plain' };
   }
   if (m === 'DELETE' && url.startsWith('/sap/bc/adt/ddic/tables/')) {
@@ -818,7 +834,11 @@ export function matchRoute(
       contentType: 'application/vnd.sap.adt.ddl.source.v2+xml',
     };
   }
-  if (m === 'POST' && url.startsWith('/sap/bc/adt/ddic/ddl/sources')) {
+  if (
+    m === 'POST' &&
+    url.startsWith('/sap/bc/adt/ddic/ddl/sources') &&
+    !url.includes('_action=')
+  ) {
     return { status: 200, body: '', contentType: 'text/plain' };
   }
   if (m === 'DELETE' && url.startsWith('/sap/bc/adt/ddic/ddl/sources/')) {
@@ -845,7 +865,11 @@ export function matchRoute(
       contentType: 'application/vnd.sap.adt.acm.dcl.source.v1+xml',
     };
   }
-  if (m === 'POST' && url.startsWith('/sap/bc/adt/acm/dcl/sources')) {
+  if (
+    m === 'POST' &&
+    url.startsWith('/sap/bc/adt/acm/dcl/sources') &&
+    !url.includes('_action=')
+  ) {
     return { status: 200, body: '', contentType: 'text/plain' };
   }
   if (m === 'DELETE' && url.startsWith('/sap/bc/adt/acm/dcl/sources/')) {

--- a/packages/adt-flow/src/service.ts
+++ b/packages/adt-flow/src/service.ts
@@ -1129,7 +1129,8 @@ async function addTransportDescriptors(
     }
     if (
       existing &&
-      stableJson(existing.requestedTransports) === stableJson(ctx.requested)
+      existing.requestedTransports.includes(transport) &&
+      existing.scopeTransports.includes(transport)
     ) {
       ownedPaths.add(path);
       ownedOwners.set(path, 'flow-index');

--- a/packages/adt-flow/tests/service.test.ts
+++ b/packages/adt-flow/tests/service.test.ts
@@ -205,6 +205,68 @@ describe('transport checkout', () => {
     expect(ports.loadObject).not.toHaveBeenCalled();
   });
 
+  it('expands a managed transport descriptor for a cumulative task scope', async () => {
+    const workspace = await root();
+    let current = manifest(
+      'added',
+      undefined,
+      version('task-one'),
+      'DEVK900001',
+    );
+    const ports = dependencies(() => current);
+    const flow = createAdtFlowService(ports);
+    await flow.checkout({
+      root: workspace,
+      transports: ['DEVK900001'],
+      config,
+    });
+
+    current = {
+      ...manifest('added', undefined, version('task-two'), 'DEVK900002'),
+      requestedTransports: ['DEVK900001', 'DEVK900002'],
+      scopeTransports: ['DEVK900001', 'DEVK900002'],
+    };
+
+    await expect(
+      flow.checkout({
+        root: workspace,
+        transports: ['DEVK900001', 'DEVK900002'],
+        config,
+      }),
+    ).resolves.toMatchObject({
+      requestedTransports: ['DEVK900001', 'DEVK900002'],
+    });
+    for (const transport of ['DEVK900001', 'DEVK900002']) {
+      expect(
+        JSON.parse(
+          await readFile(join(workspace, `.adt/tr/${transport}.json`), 'utf8'),
+        ).requestedTransports,
+      ).toEqual(['DEVK900001', 'DEVK900002']);
+    }
+  });
+
+  it('does not overwrite an unrecognized file at a transport descriptor path', async () => {
+    const workspace = await root();
+    await mkdir(join(workspace, '.adt/tr'), { recursive: true });
+    const descriptorPath = join(workspace, '.adt/tr/DEVK900001.json');
+    await writeFile(descriptorPath, 'user content\n');
+    const flow = createAdtFlowService(
+      dependencies(() => manifest('added', undefined, version('task-one'))),
+    );
+
+    await expect(
+      flow.checkout({
+        root: workspace,
+        transports: ['DEVK900001'],
+        config,
+      }),
+    ).rejects.toMatchObject({
+      code: 'configuration_invalid',
+      details: { path: '.adt/tr/DEVK900001.json' },
+    });
+    expect(await readFile(descriptorPath, 'utf8')).toBe('user content\n');
+  });
+
   it('reuses an indexed component as the base of the next transport', async () => {
     const workspace = await root();
     let current = manifest(


### PR DESCRIPTION
## Summary

Follow-up to #151 — CTS/CLI lifecycle and incremental-flow corrections:

- Surface release problem details from CTS responses
- Delete objects under an editor lock (honor authoritative lock correlation on source-write/delete paths)
- Expand managed transport scope metadata in `adt-flow`
- Retain ADK lock context for `cts tr set`

## Context

Builds on the CTS lifecycle fix merged in #151. GitLab shadow review: booking-com/finsys-devops/adt-cli!33.

## Validation

- [x] CTS CLI/MCP parity: 16/16 passed
- [x] Incremental flow regression suite: 23/23 passed
- [x] Object lifecycle regression suite: 68 tests passed
- [x] `adt-cli`, `adt-flow`, and `adt-mcp` builds passed
- [x] Exact-SHA ACR live proofs: cumulative scope expansion, one-file modification, new object, idempotent replay

## Test plan

- [ ] `nx run adt-cli:test` (parity.cts)
- [ ] `nx run adt-flow:test`
- [ ] `adt cts tr release` on a transport with known problems — verify problem details surface
- [ ] `adt flow checkout` with cumulative transport scope expansion


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CTS release messaging, lock-safe deletes, and flow transport scope. Ensures updates use the ADK lock service and that lock handles are honored end-to-end.

- **Bug Fixes**
  - CTS release: show problem details from check reports first, then status text (`@abapify/adk`).
  - Object delete: use editor lock + authoritative correlation; always unlock with the lock handle; applied in `adt-cli` CRUD and `abap run`; mock server routing aligned for lock/unlock.
  - `cts tr set`: drop custom client context and rely on the initialized ADK lock service for updates.
  - `adt-flow`: persist cumulative `requestedTransports` and `scopeTransports`; treat descriptors as owned when they already include the transport; do not overwrite unrecognized files.

<sup>Written for commit 05980a297cdef604b0e50e665ea2b92f334ebf2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

