### PR TITLE
Potential fix for code scanning alert no. 48: Clear-text logging of sensitive information

### DIFF
--- a/packages/adt-client/src/adapter.ts
+++ b/packages/adt-client/src/adapter.ts
@@ -377,9 +377,7 @@ export function createAdtAdapter(config: AdtAdapterConfig): AdtHttpAdapter {
         const safeHeaders = {
           ...headers,
           // Mask sensitive headers for security
-          ...(headers.Authorization
-            ? { Authorization: headers.Authorization.substring(0, 10) + '***' }
-            : {}),
+          ...(headers.Authorization ? { Authorization: '***' } : {}),
           ...(headers.Cookie ? { Cookie: '***' } : {}),
           ...(headers['x-csrf-token'] ? { 'x-csrf-token': '***' } : {}),
         };


### PR DESCRIPTION
Potential fix for [https://github.com/abapify/adt-cli/security/code-scanning/48](https://github.com/abapify/adt-cli/security/code-scanning/48)

The safest fix is to **never log any part of authentication or session headers**. Keep request-header debugging, but replace sensitive header values with constant redacted markers instead of substringing real secrets.

Best minimal change in `packages/adt-client/src/adapter.ts` (around lines 376–388):
- In the `safeHeaders` construction, replace the current `Authorization` masking logic (`substring(0, 10) + '***'`) with a full redaction string (for example `'***'` or `'[REDACTED]'`).
- Keep existing redaction for `Cookie` and `x-csrf-token`.
- No behavior changes to request execution; only debug logging output changes.
- No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fully redact the Authorization header in debug logs to prevent clear-text exposure of secrets. Addresses code scanning alert 48; Cookie and x-csrf-token stay redacted, with no behavior or dependency changes.

<sup>Written for commit 01a74bdff9bb0805cc4cedae61604cef6a23ce57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security in debug logs by fully masking authorization header values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->