### PR TITLE
fix(adk): exclude SUSK CTS entries from source manifests

### DIFF
--- a/openspec/changes/add-adt-flow-transport-checkout/specs/adt-flow-transport-checkout/spec.md
+++ b/openspec/changes/add-adt-flow-transport-checkout/specs/adt-flow-transport-checkout/spec.md
@@ -155,6 +155,13 @@ from the root `adt.config.ts` and SHALL persist only relevant identities.
 - **THEN** an object is relevant only when it satisfies every configured dimension
 - **THEN** type filtering occurs before source-history retrieval
 
+#### Scenario: A CTS configuration entry has no source representation
+
+- **GIVEN** a transport contains an `R3TR SUSK` authorization-maintenance assignment
+- **WHEN** checkout evaluates the transport
+- **THEN** that non-source entry is excluded before source-history retrieval
+- **THEN** all remaining relevant repository source components retain exact-boundary validation
+
 #### Scenario: Configuration expands scope
 
 - **GIVEN** a previously excluded object type or package becomes enabled

--- a/openspec/changes/add-adt-flow-transport-checkout/tasks.md
+++ b/openspec/changes/add-adt-flow-transport-checkout/tasks.md
@@ -21,6 +21,7 @@
 - [x] 3.5 Implement the exact-repeat head zero-SAP-call fast path and the base/head per-component no-body-read fast path, with tests that assert call counts and zero writes.
 - [x] 3.6 Prove transport descriptors first appear on successful head checkout, while base writes only present predecessor object descriptors and does not pre-create new-object identities.
 - [x] 3.7 Add tests proving deletion of `.adt` changes call counts but not the materialized source result.
+- [x] 3.8 Exclude the non-source `R3TR SUSK` CTS authorization-maintenance entry before source-history retrieval, with a manifest regression test.
 
 ## 4. Safe repository reconciliation
 

--- a/packages/adk/src/transport-source-manifest.ts
+++ b/packages/adk/src/transport-source-manifest.ts
@@ -135,6 +135,7 @@ const VERSIONS_RELATION = 'http://www.sap.com/adt/relations/versions';
 const DEFAULT_CONCURRENCY = 4;
 const MAX_CONCURRENCY = 32;
 const RELATIVE_URI_TRAVERSAL = /(?:^|\/)(?:\.{1,2}|%2e(?:%2e)?)(?:\/|$)/i;
+const NON_SOURCE_CTS_OBJECT_KEYS = new Set(['R3TR/SUSK']);
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value !== null && typeof value === 'object'
@@ -167,6 +168,20 @@ function compareText(left: string, right: string): number {
   if (left < right) return -1;
   if (left > right) return 1;
   return 0;
+}
+
+/**
+ * Some CTS entries represent SAP-maintained configuration rather than
+ * repository source. They have neither an ADK source model nor an abapGit
+ * representation, so they must not participate in a source-boundary manifest.
+ */
+function isNonSourceCtsObject(reference: {
+  pgmid: string;
+  type: string;
+}): boolean {
+  return NON_SOURCE_CTS_OBJECT_KEYS.has(
+    `${reference.pgmid.trim().toUpperCase()}/${reference.type.trim().toUpperCase()}`,
+  );
 }
 
 function isUnsafeRelativeHref(href: string): boolean {
@@ -839,12 +854,14 @@ export async function buildTransportSourceManifest(
     ...requested,
     ...resolved.scopeTransportNumbers,
   ]);
-  const objects = [...resolved.objects].sort(
-    (left, right) =>
-      compareText(left.pgmid, right.pgmid) ||
-      compareText(left.type, right.type) ||
-      compareText(left.name, right.name),
-  );
+  const objects = resolved.objects
+    .filter((reference) => !isNonSourceCtsObject(reference))
+    .sort(
+      (left, right) =>
+        compareText(left.pgmid, right.pgmid) ||
+        compareText(left.type, right.type) ||
+        compareText(left.name, right.name),
+    );
 
   const perObjectEntries = await mapOrdered(
     objects,

--- a/packages/adk/src/transport-source-manifest.ts
+++ b/packages/adk/src/transport-source-manifest.ts
@@ -10,12 +10,7 @@ import {
 } from './objects/cts';
 
 export type TransportSourceChangeKind =
-  | 'added'
-  | 'modified'
-  | 'deleted'
-  | 'ambiguous'
-  | 'unsupported'
-  | 'failed';
+  'added' | 'modified' | 'deleted' | 'ambiguous' | 'unsupported' | 'failed';
 
 export type SourceHistoryDiagnosticCode =
   | 'DELETED_SOURCE_BASE_UNAVAILABLE'

--- a/packages/adk/tests/transport-source-manifest.test.ts
+++ b/packages/adk/tests/transport-source-manifest.test.ts
@@ -665,6 +665,42 @@ describe('buildTransportSourceManifest', () => {
     ]);
   });
 
+  it('ignores R3TR SUSK authorization-maintenance assignments as non-source entries', async () => {
+    const authorizationAssignment = transportObject({
+      name: 'Z_CONCUR_RECON',
+      type: 'SUSK',
+    });
+    const program = transportObject({
+      name: 'ZREVIEWED_PROGRAM',
+      metadata: rootSourceMetadata(),
+    });
+    mockResolution(
+      [authorizationAssignment, program],
+      ['DEVK900002', 'DEVK900002'],
+    );
+    const head = version('00001', 0, ['DEVK900002']);
+    const { ctx } = contextWithVersions(vi.fn().mockResolvedValue([head]));
+
+    const manifest = await buildTransportSourceManifest(
+      ['DEVK900001'],
+      {},
+      ctx,
+    );
+
+    expect(manifest.entries).toEqual([
+      expect.objectContaining({
+        object: expect.objectContaining({
+          pgmid: 'R3TR',
+          type: 'PROG',
+          name: 'ZREVIEWED_PROGRAM',
+        }),
+        exact: true,
+        head,
+      }),
+    ]);
+    expect(factoryGet).not.toHaveBeenCalledWith('Z_CONCUR_RECON', 'SUSK');
+  });
+
   it('discovers and selects composite components independently', async () => {
     const object = transportObject({
       name: 'ZCL_SAMPLE',


### PR DESCRIPTION
## **User description**
## Summary

- Exclude `R3TR/SUSK` authorization-maintenance assignments from source-history manifests — these CTS entries represent SAP-maintained configuration, not repository source.
- Preserve exact-boundary validation for every remaining repository-source object.
- Add an ADK manifest regression test and an OpenSpec scenario.

## Test plan

- [ ] `bunx nx test adk`
- [ ] `bunx nx typecheck adk`
- [ ] `bunx nx build adk`
- [ ] `bunx nx lint adk`
- [ ] `bunx openspec validate add-adt-flow-transport-checkout --strict`
- [ ] `bunx nx format:check --all`


Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
Exclude non-source authorization entries from transport source manifests

### What Changed
- Transport checkout now ignores `R3TR/SUSK` authorization-maintenance entries because they have no repository source representation
- Remaining source objects continue through source-history retrieval and exact-boundary validation
- Added regression coverage and documented the expected checkout behavior

### Impact
`✅ Fewer invalid source-manifest entries`
`✅ Fewer checkout failures for SAP-maintained authorization entries`
`✅ Preserved validation for repository source components`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude `R3TR/SUSK` CTS authorization-maintenance entries from `adk` transport source manifests so non-source config never enters source-history; keep exact-boundary validation for other repository-source objects, with a regression test and an OpenSpec scenario.

<sup>Written for commit 861ce48fe91321faf2a6f0838a327f2e66c2006e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excluded CTS authorization-maintenance assignments from source-history retrieval.
  * Preserved exact-boundary validation for relevant repository source components.
  * Ensured regular program entries continue to appear with their source version.

* **Tests**
  * Added regression coverage confirming non-source authorization entries are excluded and not loaded during manifest generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->