### PR TITLE
fix(cli): keep payload stdout pipe-safe

### DIFF
--- a/.agents/rules/development/coding-conventions.md
+++ b/.agents/rules/development/coding-conventions.md
@@ -18,3 +18,8 @@ description: Core coding conventions for the abapify monorepo. TypeScript strict
 - Cross-package imports: `@abapify/<package-name>`
 - Internal file imports: extensionless relative paths — see [bundler-imports](bundler-imports.md) for details
 - `workspace:*` protocol for local workspace deps — see `$link-workspace-packages` skill for setup
+- **CLI stream contract** — stdout contains only the command payload (source,
+  JSON, XML, or other data intended for piping); progress, diagnostics, and
+  errors go to stderr. Source-producing commands must be safe to use as the
+  input of a corresponding write command. Enforce this via a regression test
+  at the shared output/progress abstraction, not in an individual command.

--- a/packages/adt-cli/src/lib/shared/adt-client.ts
+++ b/packages/adt-cli/src/lib/shared/adt-client.ts
@@ -70,10 +70,10 @@ export const silentLogger: Logger = {
  * Console logger - outputs to console (used when enableLogging is true)
  */
 export const consoleLogger: Logger = {
-  trace: (msg: string) => console.debug(msg),
-  debug: (msg: string) => console.debug(msg),
-  info: (msg: string) => console.log(msg),
-  warn: (msg: string) => console.warn(msg),
+  trace: (msg: string) => console.error(msg),
+  debug: (msg: string) => console.error(msg),
+  info: (msg: string) => console.error(msg),
+  warn: (msg: string) => console.error(msg),
   error: (msg: string) => console.error(msg),
   fatal: (msg: string) => console.error(msg),
   child: () => consoleLogger,

--- a/packages/adt-cli/src/lib/utils/logger-config.ts
+++ b/packages/adt-cli/src/lib/utils/logger-config.ts
@@ -45,6 +45,7 @@ export function createCliLogger(options: LoggerOptions = {}): Logger {
               ignore: 'pid,hostname,time',
               messageFormat: '[{component}] {msg}',
               hideObject: true,
+              destination: 2,
             },
           }
         : undefined,

--- a/packages/adt-cli/src/lib/utils/progress-reporter.test.ts
+++ b/packages/adt-cli/src/lib/utils/progress-reporter.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createProgressReporter } from './progress-reporter';
+
+describe('createProgressReporter', () => {
+  const stdout = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation(() => true);
+  const stderr = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation(() => true);
+
+  afterEach(() => {
+    stdout.mockClear();
+    stderr.mockClear();
+  });
+
+  it('keeps stdout clean when reporting compact progress', () => {
+    const reporter = createProgressReporter({ compact: true });
+
+    reporter.step('Reading source...');
+    reporter.done();
+
+    expect(stdout).not.toHaveBeenCalled();
+    expect(stderr).toHaveBeenCalled();
+  });
+});

--- a/packages/adt-cli/src/lib/utils/progress-reporter.test.ts
+++ b/packages/adt-cli/src/lib/utils/progress-reporter.test.ts
@@ -14,13 +14,42 @@ describe('createProgressReporter', () => {
     stderr.mockClear();
   });
 
-  it('keeps stdout clean when reporting compact progress', () => {
+  it('keeps stdout clean and writes compact step/done to stderr', () => {
     const reporter = createProgressReporter({ compact: true });
 
     reporter.step('Reading source...');
     reporter.done();
 
     expect(stdout).not.toHaveBeenCalled();
-    expect(stderr).toHaveBeenCalled();
+    expect(stderr).toHaveBeenCalledTimes(3);
+    expect(stderr).toHaveBeenNthCalledWith(1, 'Reading source...');
+    expect(stderr).toHaveBeenNthCalledWith(2, '\r\x1b[K');
+    expect(stderr).toHaveBeenNthCalledWith(3, 'Reading source...\n');
+  });
+
+  it('writes compact persist messages to stderr without touching stdout', () => {
+    const reporter = createProgressReporter({ compact: true });
+
+    reporter.step('Reading source...');
+    reporter.persist('Persisted source');
+
+    expect(stdout).not.toHaveBeenCalled();
+    expect(stderr).toHaveBeenCalledTimes(3);
+    expect(stderr).toHaveBeenNthCalledWith(1, 'Reading source...');
+    expect(stderr).toHaveBeenNthCalledWith(2, '\r\x1b[K');
+    expect(stderr).toHaveBeenNthCalledWith(3, 'Persisted source\n');
+  });
+
+  it('writes compact done(finalMessage) to stderr without touching stdout', () => {
+    const reporter = createProgressReporter({ compact: true });
+
+    reporter.step('Reading source...');
+    reporter.done('Finished');
+
+    expect(stdout).not.toHaveBeenCalled();
+    expect(stderr).toHaveBeenCalledTimes(3);
+    expect(stderr).toHaveBeenNthCalledWith(1, 'Reading source...');
+    expect(stderr).toHaveBeenNthCalledWith(2, '\r\x1b[K');
+    expect(stderr).toHaveBeenNthCalledWith(3, 'Finished\n');
   });
 });

--- a/packages/adt-cli/src/lib/utils/progress-reporter.ts
+++ b/packages/adt-cli/src/lib/utils/progress-reporter.ts
@@ -2,6 +2,8 @@
  * Lightweight progress reporter for CLI output.
  * - Compact mode keeps updates on a single line (overwriting previous text).
  * - Non-compact mode logs through the provided logger (or console).
+ * - Progress is written to stderr so stdout stays safe for piping source,
+ *   JSON, XML, and other command payloads.
  *
  * When a logger is provided, progress messages are tagged with { progress: true }.
  */
@@ -54,7 +56,7 @@ export function createProgressReporter(
 
   const clearLine = () => {
     if (open) {
-      process.stdout.write('\r\x1b[K');
+      process.stderr.write('\r\x1b[K');
     }
   };
 
@@ -65,7 +67,7 @@ export function createProgressReporter(
       return;
     }
     clearLine();
-    process.stdout.write(clean);
+    process.stderr.write(clean);
     lastMessage = clean;
     open = true;
     logWithFlag(clean, { transient: true });
@@ -75,7 +77,7 @@ export function createProgressReporter(
     const clean = sanitize(message);
     clearLine();
     if (compact || !logger) {
-      process.stdout.write(`${clean}\n`);
+      process.stderr.write(`${clean}\n`);
     }
     logWithFlag(clean);
     open = false;
@@ -91,10 +93,10 @@ export function createProgressReporter(
     if (compact) {
       if (finalMessage) {
         const clean = sanitize(finalMessage);
-        process.stdout.write(`${clean}\n`);
+        process.stderr.write(`${clean}\n`);
         logWithFlag(clean);
       } else if (open && lastMessage) {
-        process.stdout.write(`${lastMessage}\n`);
+        process.stderr.write(`${lastMessage}\n`);
         logWithFlag(lastMessage);
       }
     } else {

--- a/packages/adt-cli/src/lib/utils/progress-reporter.ts
+++ b/packages/adt-cli/src/lib/utils/progress-reporter.ts
@@ -1,7 +1,7 @@
 /**
  * Lightweight progress reporter for CLI output.
  * - Compact mode keeps updates on a single line (overwriting previous text).
- * - Non-compact mode logs through the provided logger (or console).
+ * - Non-compact mode logs through the provided logger (CLI loggers target stderr).
  * - Progress is written to stderr so stdout stays safe for piping source,
  *   JSON, XML, and other command payloads.
  *


### PR DESCRIPTION
## **User description**
## Summary
- send shared CLI progress to stderr
- preserve stdout for pipeable source and structured payloads
- add a regression test and agentic stream contract

## Verification
- `bunx nx test adt-cli --args="--run src/lib/utils/progress-reporter.test.ts"`
- S0D read-only smoke test: ABAP source on stdout, progress on stderr

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route all CLI progress and diagnostics to stderr and keep stdout strictly for command payloads (source, JSON, XML) to make `adt-cli` outputs pipe-safe.

- **Bug Fixes**
  - Write compact and non-compact progress to stderr in `createProgressReporter`, including `persist` and `done(finalMessage)`.
  - Route diagnostics to stderr (`consoleLogger` uses `console.error`; pretty logger sets `destination: 2`).
  - Add regression tests to keep stdout clean and document the CLI stream contract.

<sup>Written for commit fa4a32ddf3fdaefd8fc09e0d1eacda5bcd5c7d2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Keep CLI payload output safe for piping

### What Changed
- CLI progress updates and completion messages now go to stderr instead of stdout
- stdout remains reserved for source, JSON, XML, and other command payloads
- Added a regression test to ensure compact progress never writes to stdout
- Documented the stream contract for source-producing and write commands

### Impact
`✅ Safe piping of CLI payloads`
`✅ Clean machine-readable stdout`
`✅ Progress remains visible without corrupting output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line output so progress updates, diagnostics, and errors no longer interfere with command results.
  * Source-producing commands can now be reliably piped into corresponding write commands.
  * Updated logging behavior to keep formatted logs and diagnostic messages on the diagnostic stream.

* **Tests**
  * Added coverage confirming progress reports are sent to the diagnostic stream while command output remains available for piping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->