### PR TITLE
fix(flow): skip unsupported transport objects

### DIFF
--- a/openspec/changes/add-adt-flow-transport-checkout/design.md
+++ b/openspec/changes/add-adt-flow-transport-checkout/design.md
@@ -67,8 +67,10 @@ Alternatives rejected:
 ### 2. Compose exact-source-history; never reimplement it
 
 `adt-flow` calls `buildTransportSourceManifest`. It rejects any relevant
-`ambiguous`, `unsupported`, or `failed` entry before reading source bodies or
-changing files. It lazily downloads only selected base or head bodies.
+`ambiguous` or `failed` entry before reading source bodies or changing files.
+It records and excludes `unsupported` entries, so object types with no
+source-history implementation do not block exact components in the same
+transport. It lazily downloads only selected base or head bodies.
 
 For an added component, base means absence. For a deleted component, base
 materializes the recoverable predecessor and head means absence. This produces
@@ -214,7 +216,9 @@ functions require a separate design.
   reconstruction; indexed successive checkouts can still reconcile observed
   path changes.
 - **Deleted object metadata may no longer load** → Reuse source-history typed
-  diagnostics and fail closed unless the base is recoverable.
+  diagnostics and fail closed unless the base is recoverable. Object types
+  explicitly classified as unsupported are skipped with their diagnostic rather
+  than being misrepresented as an exact boundary.
 - **Large transports can overload SAP** → Filter types early, bound both
   metadata and source reads, deduplicate component URIs, and fetch bodies only
   after complete manifest validation.

--- a/openspec/changes/add-adt-flow-transport-checkout/proposal.md
+++ b/openspec/changes/add-adt-flow-transport-checkout/proposal.md
@@ -29,7 +29,9 @@ the source immediately before it and the source introduced by it.
 - Add a typed `flow` section to root `adt.config.ts` for relevant object types,
   packages, application components, format, and bounded concurrency.
 - Fail closed before filesystem mutation when the source boundary is
-  ambiguous, unsupported, colliding, or locally divergent from indexed state.
+  ambiguous or failed, or when paths collide or diverge from indexed state;
+  record and skip unsupported object types so exact source components in the
+  same transport remain reviewable.
 - Explicitly limit MVP exactness to versioned source components. Full history
   replication and reconstruction of historical object metadata are deferred.
 

--- a/openspec/changes/add-adt-flow-transport-checkout/specs/adt-flow-transport-checkout/spec.md
+++ b/openspec/changes/add-adt-flow-transport-checkout/specs/adt-flow-transport-checkout/spec.md
@@ -20,12 +20,20 @@ current source.
 - **THEN** each component materializes the version immediately older than its earliest in-scope version
 - **THEN** input array order is not used as source chronology
 
-#### Scenario: Source boundary is ambiguous
+#### Scenario: Source boundary is ambiguous or failed
 
-- **GIVEN** a relevant component has ambiguous, unsupported, or failed source history
+- **GIVEN** a relevant component has ambiguous or failed source history
 - **WHEN** checkout is requested
 - **THEN** checkout fails with a typed bounded diagnostic
 - **THEN** no repository path is changed
+
+#### Scenario: Object type has no source-history implementation
+
+- **GIVEN** a transport contains an otherwise relevant object whose manifest entry is `unsupported`
+- **WHEN** checkout is requested
+- **THEN** checkout excludes that object without reading source or changing its repository paths
+- **THEN** checkout continues with the remaining exact source components
+- **THEN** the structured result and CLI diagnostics identify the skipped object and its diagnostic code
 
 ### Requirement: Creation and deletion produce reviewable trees
 

--- a/packages/adt-flow/src/commands/flow.ts
+++ b/packages/adt-flow/src/commands/flow.ts
@@ -94,6 +94,11 @@ function checkoutTrCommand(
           `${result.changed.length} changed, ${result.moved.length} moved, ` +
           `${result.removed.length} removed, ${result.unchanged.length} unchanged.`,
       );
+      for (const skipped of result.skipped) {
+        ctx.logger.warn(
+          `Skipped unsupported object ${skipped.object} (${skipped.component}; ${skipped.diagnostic}).`,
+        );
+      }
       ctx.logger.info(
         `SAP calls: manifest=${result.sapCalls.manifest}, metadata=${result.sapCalls.metadata}, ` +
           `source=${result.sapCalls.source}; fast-path=${result.fastPath}.`,

--- a/packages/adt-flow/src/service.ts
+++ b/packages/adt-flow/src/service.ts
@@ -139,12 +139,12 @@ function applicationComponentMatches(
 }
 
 function isApplicationComponentExcluded(
-  ctx: ProcessGroupContext,
+  config: FlowConfig,
   model: FlowObjectModel,
 ): boolean {
   return !applicationComponentMatches(
     model.applicationComponent,
-    ctx.config.include?.applicationComponents,
+    config.include?.applicationComponents,
   );
 }
 
@@ -707,7 +707,7 @@ async function maybeSkipByAppComponent(
     dependencies.loadObject(group.identity),
   );
   calls.metadata += model.metadataCalls ?? 1;
-  if (isApplicationComponentExcluded(ctx, model)) {
+  if (isApplicationComponentExcluded(ctx.config, model)) {
     return {
       desired: [],
       descriptorPaths: [],
@@ -802,7 +802,7 @@ async function processGroup(ctx: ProcessGroupContext): Promise<GroupResult> {
   );
   calls.metadata += model.metadataCalls ?? 1;
 
-  if (isApplicationComponentExcluded(ctx, model)) {
+  if (isApplicationComponentExcluded(ctx.config, model)) {
     return emptyGroupResult();
   }
 
@@ -941,16 +941,58 @@ function prepareGroups(
   return groups;
 }
 
-function unsupportedEntries(
+async function unsupportedEntries(
   entries: readonly TransportSourceManifestEntry[],
-): FlowCheckoutResult['skipped'] {
-  return entries
-    .filter((entry) => entry.changeKind === 'unsupported')
-    .map((entry) => ({
+  ctx: CheckoutContext,
+  limiter: Limiter,
+  hasApplicationComponentFilter: boolean,
+): Promise<FlowCheckoutResult['skipped']> {
+  const unsupported = entries.filter(
+    (entry) => entry.changeKind === 'unsupported',
+  );
+
+  if (!hasApplicationComponentFilter) {
+    return unsupported.map((entry) => ({
       object: `${entry.object.type}/${entry.object.name}`,
       component: entry.component.id,
       diagnostic: entry.diagnostic?.code ?? 'UNSUPPORTED',
     }));
+  }
+
+  const byIdentity = new Map<
+    string,
+    { identity: FlowObjectIdentity; entries: TransportSourceManifestEntry[] }
+  >();
+  for (const entry of unsupported) {
+    const identity = objectIdentity(entry.object);
+    const existing = byIdentity.get(identity.canonical);
+    if (existing) {
+      existing.entries.push(entry);
+    } else {
+      byIdentity.set(identity.canonical, { identity, entries: [entry] });
+    }
+  }
+
+  const skipped: FlowCheckoutResult['skipped'] = [];
+  await Promise.all(
+    [...byIdentity.values()].map(
+      async ({ identity, entries: identityEntries }) => {
+        const model = await limiter.run(() =>
+          ctx.dependencies.loadObject(identity),
+        );
+        ctx.calls.metadata += model.metadataCalls ?? 1;
+        if (isApplicationComponentExcluded(ctx.config, model)) return;
+        for (const entry of identityEntries) {
+          skipped.push({
+            object: `${entry.object.type}/${entry.object.name}`,
+            component: entry.component.id,
+            diagnostic: entry.diagnostic?.code ?? 'UNSUPPORTED',
+          });
+        }
+      },
+    ),
+  );
+  return skipped;
 }
 
 async function buildManifestAndGroups(
@@ -964,19 +1006,24 @@ async function buildManifestAndGroups(
   const scopedEntries = manifest.entries.filter((entry) =>
     packageMatches(entry.object.packageName, ctx.config.include?.packages),
   );
-  const skipped = unsupportedEntries(scopedEntries);
-  const entries = scopedEntries.filter(
-    (entry) => entry.changeKind !== 'unsupported',
-  );
   const metadataLimiter = new Limiter(
     ctx.config.concurrency?.metadata ?? DEFAULT_METADATA_CONCURRENCY,
+  );
+  const hasApplicationComponentFilter =
+    (ctx.config.include?.applicationComponents?.length ?? 0) > 0;
+  const skipped = await unsupportedEntries(
+    scopedEntries,
+    ctx,
+    metadataLimiter,
+    hasApplicationComponentFilter,
+  );
+  const entries = scopedEntries.filter(
+    (entry) => entry.changeKind !== 'unsupported',
   );
   const sourceLimiter = new Limiter(
     ctx.config.concurrency?.sources ?? DEFAULT_SOURCE_CONCURRENCY,
   );
   const maxSourceBytes = ctx.config.maxSourceBytes ?? DEFAULT_MAX_SOURCE_BYTES;
-  const hasApplicationComponentFilter =
-    (ctx.config.include?.applicationComponents?.length ?? 0) > 0;
 
   const allSrcFiles = await walkFiles(ctx.root, 'src');
   const srcFilesByObject = buildObjectFileIndex(

--- a/packages/adt-flow/src/service.ts
+++ b/packages/adt-flow/src/service.ts
@@ -898,6 +898,7 @@ async function tryExactHeadFastPath(
     removed: [],
     unchanged: fast.ownedPaths,
     descriptors: fast.descriptorPaths,
+    skipped: [],
     sapCalls: ctx.calls,
     fastPath: 'exact-head',
   };
@@ -906,6 +907,7 @@ async function tryExactHeadFastPath(
 interface ManifestContext {
   manifest: TransportSourceManifest;
   entries: TransportSourceManifestEntry[];
+  skipped: FlowCheckoutResult['skipped'];
   metadataLimiter: Limiter;
   sourceLimiter: Limiter;
   maxSourceBytes: number;
@@ -939,6 +941,18 @@ function prepareGroups(
   return groups;
 }
 
+function unsupportedEntries(
+  entries: readonly TransportSourceManifestEntry[],
+): FlowCheckoutResult['skipped'] {
+  return entries
+    .filter((entry) => entry.changeKind === 'unsupported')
+    .map((entry) => ({
+      object: `${entry.object.type}/${entry.object.name}`,
+      component: entry.component.id,
+      diagnostic: entry.diagnostic?.code ?? 'UNSUPPORTED',
+    }));
+}
+
 async function buildManifestAndGroups(
   ctx: CheckoutContext,
 ): Promise<ManifestContext> {
@@ -947,8 +961,12 @@ async function buildManifestAndGroups(
     ctx.requested,
     buildManifestRequestOptions(ctx.config),
   );
-  const entries = manifest.entries.filter((entry) =>
+  const scopedEntries = manifest.entries.filter((entry) =>
     packageMatches(entry.object.packageName, ctx.config.include?.packages),
+  );
+  const skipped = unsupportedEntries(scopedEntries);
+  const entries = scopedEntries.filter(
+    (entry) => entry.changeKind !== 'unsupported',
   );
   const metadataLimiter = new Limiter(
     ctx.config.concurrency?.metadata ?? DEFAULT_METADATA_CONCURRENCY,
@@ -970,6 +988,7 @@ async function buildManifestAndGroups(
   return {
     manifest,
     entries,
+    skipped,
     metadataLimiter,
     sourceLimiter,
     maxSourceBytes,
@@ -1158,6 +1177,7 @@ async function addTransportDescriptors(
 function buildCheckoutResult(
   ctx: CheckoutContext,
   manifest: TransportSourceManifest,
+  skipped: FlowCheckoutResult['skipped'],
   plan: RepositoryPlan,
   processed: ProcessedGroups,
 ): FlowCheckoutResult {
@@ -1181,6 +1201,7 @@ function buildCheckoutResult(
       .sort(),
     unchanged: plan.unchanged.filter((path) => !descriptorSet.has(path)),
     descriptors: [...descriptorSet].sort(),
+    skipped,
     sapCalls: ctx.calls,
     fastPath: reusedIndexedComponent ? 'indexed-components' : 'none',
   };
@@ -1216,7 +1237,13 @@ async function checkoutFlow(
     processed.ownedOwners,
   );
   await applyRepositoryPlan(ctx.root, plan);
-  return buildCheckoutResult(ctx, manifestContext.manifest, plan, processed);
+  return buildCheckoutResult(
+    ctx,
+    manifestContext.manifest,
+    manifestContext.skipped,
+    plan,
+    processed,
+  );
 }
 
 export function createAdtFlowService(

--- a/packages/adt-flow/src/types.ts
+++ b/packages/adt-flow/src/types.ts
@@ -72,6 +72,11 @@ export interface FlowCheckoutResult {
   removed: string[];
   unchanged: string[];
   descriptors: string[];
+  skipped: Array<{
+    object: string;
+    component: string;
+    diagnostic: string;
+  }>;
   sapCalls: { manifest: number; metadata: number; source: number };
   fastPath: 'exact-head' | 'indexed-components' | 'none';
 }

--- a/packages/adt-flow/tests/flow-command.test.ts
+++ b/packages/adt-flow/tests/flow-command.test.ts
@@ -29,6 +29,13 @@ describe('flow CLI command', () => {
       removed: [],
       unchanged: [],
       descriptors: [],
+      skipped: [
+        {
+          object: 'TABD/PAYHX01',
+          component: 'object',
+          diagnostic: 'OBJECT_TYPE_UNSUPPORTED',
+        },
+      ],
       sapCalls: { manifest: 1, metadata: 1, source: 1 },
       fastPath: 'none' as const,
     }));
@@ -37,6 +44,7 @@ describe('flow CLI command', () => {
       createService: vi.fn(() => ({ checkout })),
     });
     const info = vi.fn();
+    const warn = vi.fn();
     const ctx = {
       cwd: '/workspace',
       config: {
@@ -45,7 +53,7 @@ describe('flow CLI command', () => {
           include: { objectTypes: ['CLAS'] },
         },
       },
-      logger: { debug: vi.fn(), info, warn: vi.fn(), error: vi.fn() },
+      logger: { debug: vi.fn(), info, warn, error: vi.fn() },
       getAdtClient: vi.fn(async () => ({}) as AdtClient),
     } satisfies CliContext;
 
@@ -65,6 +73,9 @@ describe('flow CLI command', () => {
     });
     expect(info).toHaveBeenCalledWith(
       expect.stringContaining('1 changed, 0 moved, 0 removed'),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      'Skipped unsupported object TABD/PAYHX01 (object; OBJECT_TYPE_UNSUPPORTED).',
     );
   });
 

--- a/packages/adt-flow/tests/flow-command.test.ts
+++ b/packages/adt-flow/tests/flow-command.test.ts
@@ -77,6 +77,7 @@ describe('flow CLI command', () => {
     expect(warn).toHaveBeenCalledWith(
       'Skipped unsupported object TABD/PAYHX01 (object; OBJECT_TYPE_UNSUPPORTED).',
     );
+    expect(warn).toHaveBeenCalledTimes(1);
   });
 
   it('rejects a missing flow config before requesting an ADT client', async () => {

--- a/packages/adt-flow/tests/service.test.ts
+++ b/packages/adt-flow/tests/service.test.ts
@@ -701,4 +701,31 @@ describe('transport checkout', () => {
     expect(filtered.changed).toEqual([]);
     expect(filtered.sapCalls.metadata).toBeGreaterThanOrEqual(1);
   });
+
+  it('does not record unsupported objects excluded by application component', async () => {
+    const workspace = await root();
+    const current: TransportSourceManifest = {
+      requestedTransports: ['DEVK900001'],
+      scopeTransports: ['DEVK900001'],
+      entries: [unsupportedEntry()],
+    };
+    const ports = dependencies(() => current);
+    ports.loadObject.mockResolvedValue({
+      object: { name: 'PAYHX01' },
+      packagePath: ['ZROOT', 'ZROOT_FEATURE'],
+      applicationComponent: 'ZOTHER',
+    });
+
+    const result = await createAdtFlowService(ports).checkout({
+      root: workspace,
+      transports: ['DEVK900001'],
+      config: {
+        ...config,
+        include: { applicationComponents: ['ZAPP'] },
+      },
+    });
+
+    expect(result.skipped).toEqual([]);
+    expect(ports.loadObject).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/adt-flow/tests/service.test.ts
+++ b/packages/adt-flow/tests/service.test.ts
@@ -56,6 +56,27 @@ function manifest(
   };
 }
 
+function unsupportedEntry(
+  name = 'PAYHX01',
+): TransportSourceManifest['entries'][number] {
+  return {
+    object: {
+      pgmid: 'R3TR',
+      type: 'TABD',
+      name,
+      packageName: 'ZROOT_FEATURE',
+    },
+    component: { id: 'object' },
+    sourceTransport: 'DEVK900001',
+    changeKind: 'unsupported',
+    exact: false,
+    diagnostic: {
+      code: 'OBJECT_TYPE_UNSUPPORTED',
+      message: 'No source-history loader is registered for this object type.',
+    },
+  };
+}
+
 const format: FormatPlugin = {
   id: 'abapgit',
   description: 'fixture',
@@ -521,6 +542,34 @@ describe('transport checkout', () => {
     ).rejects.toMatchObject({ code: 'manifest_inexact' });
     expect(ports.readSource).not.toHaveBeenCalled();
     expect(ports.loadObject).not.toHaveBeenCalled();
+  });
+
+  it('skips unsupported objects while materializing supported objects from the same transport', async () => {
+    const workspace = await root();
+    const current = manifest('modified', version('before'), version('after'));
+    current.entries.push(unsupportedEntry());
+    const ports = dependencies(() => current);
+    ports.readSource.mockResolvedValue('stable source\n');
+    ports.loadObject.mockResolvedValue({
+      object: { name: 'ZCL_SAMPLE' },
+      packagePath: ['ZROOT', 'ZROOT_FEATURE'],
+    });
+
+    const result = await createAdtFlowService(ports).checkout({
+      root: workspace,
+      transports: ['DEVK900001'],
+      config,
+    });
+
+    expect(result.skipped).toEqual([
+      {
+        object: 'TABD/PAYHX01',
+        component: 'object',
+        diagnostic: 'OBJECT_TYPE_UNSUPPORTED',
+      },
+    ]);
+    expect(result.changed).toContain('src/feature/zcl_sample.clas.abap');
+    expect(ports.loadObject).toHaveBeenCalledTimes(1);
   });
 
   it('reconciles a package reassignment as old-path removal plus new-path writes', async () => {

--- a/packages/adt-mcp/tests/flow-checkout-tr.test.ts
+++ b/packages/adt-mcp/tests/flow-checkout-tr.test.ts
@@ -63,6 +63,7 @@ test('flow_checkout_tr delegates to the shared service inside an allowed root', 
           removed: [],
           unchanged: [],
           descriptors: ['.adt/objects/CLAS/zcl_sample.clas.adt.json'],
+          skipped: [],
           sapCalls: { manifest: 1, metadata: 1, source: 1 },
           fastPath: 'none',
         };
@@ -88,6 +89,7 @@ test('flow_checkout_tr delegates to the shared service inside an allowed root', 
     config: ctx.flowConfig,
   });
   assert.equal(result.structuredContent?.mode, 'base');
+  assert.deepEqual(result.structuredContent?.skipped, []);
   assert.deepEqual(target.annotations, {
     readOnlyHint: false,
     destructiveHint: true,


### PR DESCRIPTION
## **User description**
## Summary
- Skip OBJECT_TYPE_UNSUPPORTED manifest entries while continuing checkout for exact source components in the same transport.
- Retain fail-closed behaviour for ambiguous and failed source boundaries.
- Surface each skipped object and diagnostic through the structured result and CLI warning.

## Verification
- adt-flow unit tests: 25 passed.
- adt-flow typecheck: passed.
- adt-flow build: passed.
- Targeted formatting and git diff checks: passed.

## Known baseline
Repository-wide formatting reports unrelated existing files. Package lint reports existing Nx dependency-boundary violations across the package, including untouched files.


___

## **CodeAnt-AI Description**
Skip unsupported transport objects without blocking valid checkout results

### What Changed
- Unsupported objects are excluded from checkout while supported source components in the same transport continue to be materialized.
- Checkout results identify each skipped object, component, and diagnostic code.
- The CLI warns users about every skipped unsupported object.
- Ambiguous and failed source boundaries still stop checkout without changing repository files.

### Impact
`✅ Fewer blocked transport checkouts`
`✅ Clearer skipped-object diagnostics`
`✅ Supported components remain reviewable`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Checkout now skips unsupported transport objects while continuing with supported components.
  * Skipped objects are reported with their component names and diagnostic details.
  * CLI warnings identify each unsupported object that was skipped.

* **Bug Fixes**
  * Ambiguous or failed source history continues to block checkout before any repository changes occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->