### PR TITLE
fix(codacy): resolve open code-scanning alerts

### DIFF
--- a/.agents/skills/add-endpoint/SKILL.md
+++ b/.agents/skills/add-endpoint/SKILL.md
@@ -54,10 +54,10 @@ If you have a running SAP system connection:
 If no system connection is available, research the endpoint:
 
 1. **Search SAP ADT documentation and community resources:**
-   - SAP Help Portal: https://help.sap.com/docs/abap-cloud/abap-development-tools-user-guide
-   - abapGit source (has XSD/schema reference implementations): https://github.com/abapGit/abapGit
+   - SAP Help Portal: <https://help.sap.com/docs/abap-cloud/abap-development-tools-user-guide>
+   - abapGit source (has XSD/schema reference implementations): <https://github.com/abapGit/abapGit>
    - SAP ADT API examples: search GitHub for `sap/bc/adt/{your-path}`
-   - Eclipse ADT plugin source: https://github.com/SAP/abap-adt-api
+   - Eclipse ADT plugin source: <https://github.com/SAP/abap-adt-api>
 
 2. **Search for XSD schema definitions:**
    - Look in the existing XSD files under `packages/adt-schemas/` for similar patterns

--- a/.agents/skills/add-object-type/SKILL.md
+++ b/.agents/skills/add-object-type/SKILL.md
@@ -57,12 +57,12 @@ Before writing code, gather details about the object type from live system or re
 ### Option B: No Live System — Web Research
 
 1. **ADT endpoint details:**
-   - SAP Help Portal: https://help.sap.com/docs/abap-cloud/abap-development-tools-user-guide
+   - SAP Help Portal: <https://help.sap.com/docs/abap-cloud/abap-development-tools-user-guide>
    - Search GitHub for `sap/bc/adt/{path}` to find client implementations
    - Look at `packages/adt-schemas/src/schemas/generated/schemas/sap/` for existing patterns
 
 2. **abapGit serializer and schema:**
-   - abapGit repository: https://github.com/abapGit/abapGit
+   - abapGit repository: <https://github.com/abapGit/abapGit>
    - Look in `src/objects/` for the relevant handler class (`ZCL_ABAPGIT_OBJECT_{TYPE}`)
    - Find `.abap` or `.xml` sample files in abapGit test fixtures
    - Search abapGit issues/PRs for the object type
@@ -446,7 +446,7 @@ The abapGit schema captures the structure of the XML file that abapGit writes fo
 
 Find out what fields the abapGit serializer writes. Resources:
 
-- **abapGit repository**: https://github.com/abapGit/abapGit — look in `src/objects/` for `ZCL_ABAPGIT_OBJECT_{TYPE}.clas.abap`
+- **abapGit repository**: <https://github.com/abapGit/abapGit> — look in `src/objects/` for `ZCL_ABAPGIT_OBJECT_{TYPE}.clas.abap`
 - Look for `CREATE_VSEO*`, `ZIF_ABAPGIT_OBJECT~DESERIALIZE`, or `SERIALIZE` methods
 - Look at `.xml` files in abapGit test repositories
 - Search for `{TYPE}` in abapGit's `docs/` directory

--- a/.agents/skills/adt-reverse-engineering/SKILL.md
+++ b/.agents/skills/adt-reverse-engineering/SKILL.md
@@ -280,11 +280,11 @@ grep -r 'xmlns.*sap.com/adt' packages/adt-fixtures/
 
 ### Official sources
 
-| Source               | URL                                                                    | Best For                         |
-| -------------------- | ---------------------------------------------------------------------- | -------------------------------- |
-| SAP Help - ADT API   | https://help.sap.com/docs/abap-cloud/abap-development-tools-user-guide | Official endpoint docs           |
-| SAP Community        | https://community.sap.com                                              | Blog posts with endpoint details |
-| SAP API Business Hub | https://api.sap.com                                                    | Some ADT-related APIs            |
+| Source               | URL                                                                      | Best For                         |
+| -------------------- | ------------------------------------------------------------------------ | -------------------------------- |
+| SAP Help - ADT API   | <https://help.sap.com/docs/abap-cloud/abap-development-tools-user-guide> | Official endpoint docs           |
+| SAP Community        | <https://community.sap.com>                                              | Blog posts with endpoint details |
+| SAP API Business Hub | <https://api.sap.com>                                                    | Some ADT-related APIs            |
 
 ### Web search patterns
 

--- a/.agents/skills/nx-import/SKILL.md
+++ b/.agents/skills/nx-import/SKILL.md
@@ -13,8 +13,8 @@ description: Import, merge, or combine repositories into an Nx workspace using n
 
 Primary docs:
 
-- https://nx.dev/docs/guides/adopting-nx/import-project
-- https://nx.dev/docs/guides/adopting-nx/preserving-git-histories
+- <https://nx.dev/docs/guides/adopting-nx/import-project>
+- <https://nx.dev/docs/guides/adopting-nx/preserving-git-histories>
 
 Read the nx docs if you have the tools for it.
 

--- a/.agents/skills/nx-import/references/GRADLE.md
+++ b/.agents/skills/nx-import/references/GRADLE.md
@@ -9,4 +9,4 @@
 
 Helpful docs:
 
-- https://nx.dev/docs/technologies/java/gradle/introduction
+- <https://nx.dev/docs/technologies/java/gradle/introduction>

--- a/.agents/skills/nx-import/references/TURBOREPO.md
+++ b/.agents/skills/nx-import/references/TURBOREPO.md
@@ -1,7 +1,7 @@
 ## Turborepo
 
 - Nx replaces Turborepo task orchestration, but a clean migration requires handling Turborepo's config packages.
-- Migration guide: https://nx.dev/docs/guides/adopting-nx/from-turborepo#easy-automated-migration-example
+- Migration guide: <https://nx.dev/docs/guides/adopting-nx/from-turborepo#easy-automated-migration-example>
 - Since Nx replaces Turborepo, all turbo config files and config packages become dead code and should be removed.
 
 ## The Config-as-Package Pattern
@@ -59,4 +59,4 @@ The config package centralizes ESLint plugin dependencies and exports composable
 
 Helpful docs:
 
-- https://nx.dev/docs/guides/adopting-nx/from-turborepo
+- <https://nx.dev/docs/guides/adopting-nx/from-turborepo>

--- a/.agents/skills/nx-import/references/TURBOREPO.md
+++ b/.agents/skills/nx-import/references/TURBOREPO.md
@@ -1,7 +1,7 @@
 ## Turborepo
 
 - Nx replaces Turborepo task orchestration, but a clean migration requires handling Turborepo's config packages.
-- Migration guide: <https://nx.dev/docs/guides/adopting-nx/from-turborepo#easy-automated-migration-example>
+- Migration guide: <https://nx.dev/docs/guides/adopting-nx/from-turborepo>
 - Since Nx replaces Turborepo, all turbo config files and config packages become dead code and should be removed.
 
 ## The Config-as-Package Pattern

--- a/.agents/workflows/lint.md
+++ b/.agents/workflows/lint.md
@@ -2,7 +2,10 @@
 name: lint
 description: Run Nx lint with fix and iterate until clean.
 category: workflow
-tags: [nx, lint, quality]
+tags:
+  - nx
+  - lint
+  - quality
 ---
 
 1. Run lint with fix (Nx `lint` target for affected packages).

--- a/.agents/workflows/opsx-apply.md
+++ b/.agents/workflows/opsx-apply.md
@@ -2,7 +2,10 @@
 name: opsx-apply
 description: Implement tasks from an OpenSpec change (experimental workflow).
 category: workflow
-tags: [openspec, experimental, implementation]
+tags:
+  - openspec
+  - experimental
+  - implementation
 ---
 
 Implement tasks from an OpenSpec change.

--- a/.agents/workflows/opsx-archive.md
+++ b/.agents/workflows/opsx-archive.md
@@ -2,7 +2,9 @@
 name: opsx-archive
 description: Archive a completed OpenSpec change (experimental workflow).
 category: workflow
-tags: [openspec, experimental]
+tags:
+  - openspec
+  - experimental
 ---
 
 Archive a completed change in the experimental workflow.

--- a/.agents/workflows/opsx-explore.md
+++ b/.agents/workflows/opsx-explore.md
@@ -2,7 +2,10 @@
 name: opsx-explore
 description: Enter explore mode — think through ideas, investigate problems, clarify requirements (no implementation).
 category: workflow
-tags: [openspec, experimental, discovery]
+tags:
+  - openspec
+  - experimental
+  - discovery
 ---
 
 Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.

--- a/.agents/workflows/opsx-propose.md
+++ b/.agents/workflows/opsx-propose.md
@@ -2,7 +2,10 @@
 name: opsx-propose
 description: Propose a new OpenSpec change and generate all artifacts in one step.
 category: workflow
-tags: [openspec, experimental, artifacts]
+tags:
+  - openspec
+  - experimental
+  - artifacts
 ---
 
 Propose a new change - create the change and generate all artifacts in one step.

--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -2,7 +2,10 @@
 name: 'OPSX: Apply'
 description: Implement tasks from an OpenSpec change (Experimental)
 category: Workflow
-tags: [workflow, artifacts, experimental]
+tags:
+  - workflow
+  - artifacts
+  - experimental
 ---
 
 **Canonical workflow:** `.agents/workflows/opsx-apply.md`

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -2,7 +2,10 @@
 name: 'OPSX: Archive'
 description: Archive a completed change in the experimental workflow
 category: Workflow
-tags: [workflow, archive, experimental]
+tags:
+  - workflow
+  - archive
+  - experimental
 ---
 
 **Canonical workflow:** `.agents/workflows/opsx-archive.md`

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -2,7 +2,11 @@
 name: 'OPSX: Explore'
 description: 'Enter explore mode - think through ideas, investigate problems, clarify requirements'
 category: Workflow
-tags: [workflow, explore, experimental, thinking]
+tags:
+  - workflow
+  - explore
+  - experimental
+  - thinking
 ---
 
 **Canonical workflow:** `.agents/workflows/opsx-explore.md`

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -2,7 +2,10 @@
 name: 'OPSX: Propose'
 description: Propose a new change - create it and generate all artifacts in one step
 category: Workflow
-tags: [workflow, artifacts, experimental]
+tags:
+  - workflow
+  - artifacts
+  - experimental
 ---
 
 **Canonical workflow:** `.agents/workflows/opsx-propose.md`

--- a/.claude/hooks/sonar-secrets/build-scripts/prompt-secrets.sh
+++ b/.claude/hooks/sonar-secrets/build-scripts/prompt-secrets.sh
@@ -17,7 +17,7 @@ fi
 
 # Create temporary file with prompt content (stdin is already occupied by hook input)
 temp_file=$(mktemp)
-trap "rm -f $temp_file" EXIT
+trap 'rm -f "$temp_file"' EXIT
 
 echo -n "$prompt" > "$temp_file"
 

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,14 @@
+---
+engines:
+  csslint:
+    exclude_paths:
+      # CSSLint does not support CSS custom properties used by Docusaurus/Infima
+      - 'website/src/css/custom.css'
+  remark-lint:
+    exclude_paths:
+      # Generated release notes contain markdown constructs (e.g. `[bot]`)
+      # that are not intended as reference links
+      - '**/CHANGELOG.md'
+      # Prompt frontmatter uses bracket placeholders that remark-lint treats
+      # as undefined references
+      - '.github/prompts/*.prompt.md'

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ Contents:
 - `examples/` — usage samples
 - `ci-cd-setup.md` — CI/CD configuration notes
 
-For end-user docs visit https://adt-cli.netlify.app (source: `website/docs/`).
+For end-user docs visit <https://adt-cli.netlify.app> (source: `website/docs/`).
 
 ## Specs → OpenSpec
 

--- a/docs/planning/abap-code-review.md
+++ b/docs/planning/abap-code-review.md
@@ -1,7 +1,7 @@
 # ABAP Code Review CI/CD Pipeline - Project Plan
 
 **Specification Reference**: `openspec/specs/cicd/abap-cicd-pipeline.md`  
-**GitHub Project**: https://github.com/orgs/abapify/projects/3  
+**GitHub Project**: <https://github.com/orgs/abapify/projects/3>  
 **Epic Issue**: [#2](https://github.com/abapify/js/issues/2)
 
 ## Project Overview
@@ -20,27 +20,27 @@ Implement a complete CI/CD pipeline for ABAP code review using transport request
 
 ### 🔄 Ready for Implementation
 
-- **[#3] Transport Import Stage** - Extract and serialize transport objects
+- **\[#3] Transport Import Stage** - Extract and serialize transport objects
   - Status: `status:ready`
   - Dependencies: ADT CLI auth, ADK adapters, abapGit format
   - Estimated effort: 2-3 days
-- **[#4] Quality Check Stage** - ATC integration with multi-platform output
+- **\[#4] Quality Check Stage** - ATC integration with multi-platform output
   - Status: `status:ready`
   - Dependencies: Transport import, ATC API integration
   - Estimated effort: 3-4 days
-- **[#5] Reporting Stage** - Comprehensive summary generation
+- **\[#5] Reporting Stage** - Comprehensive summary generation
   - Status: `status:ready`
   - Dependencies: Transport import, Quality check results
   - Estimated effort: 2-3 days
 
 ### 📋 Backlog
 
-- **[#7] CI/CD Platform Templates** - Integration templates for major platforms
+- **\[#7] CI/CD Platform Templates** - Integration templates for major platforms
   - Status: `status:backlog`
   - Dependencies: Core pipeline stages
   - Estimated effort: 1-2 days
 
-- **[#6] Delta Analysis Stage** - Change impact analysis (Future)
+- **\[#6] Delta Analysis Stage** - Change impact analysis (Future)
   - Status: `status:backlog`
   - Dependencies: Transport import, historical data
   - Estimated effort: 4-5 days

--- a/docs/planning/current-sprint.md
+++ b/docs/planning/current-sprint.md
@@ -42,7 +42,7 @@
 
 ### 🔄 In Progress
 
-- **[#5] Reporting Stage** - Comprehensive summary generation (ON HOLD)
+- **\[#5] Reporting Stage** - Comprehensive summary generation (ON HOLD)
   - Dependencies: Transport import (✅ completed), Quality check (✅ completed)
   - Next: Template engine implementation and markdown report generation
   - Status: Paused pending ADT CLI decoupling completion

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -110,7 +110,7 @@ mcp_call_tool(server="deepwiki", tool="devin_session_create",
                           "tags": ["sapcli-parity", "eXX"]})
 ```
 
-Otherwise: open https://app.devin.ai/ → New session → paste the **Devin prompt** block from the epic file.
+Otherwise: open <https://app.devin.ai/> → New session → paste the **Devin prompt** block from the epic file.
 
 ## Conventions enforced across all epics
 

--- a/docs/roadmap/epics/e06-gcts-format-plugin.md
+++ b/docs/roadmap/epics/e06-gcts-format-plugin.md
@@ -17,7 +17,7 @@ gCTS has its own on-disk layout (different from abapGit). Users on S/4HANA Cloud
 
 - gCTS file format docs: SAP Help → "git-enabled CTS file format". Capture relevant pages locally as references.
 - sapcli gCTS module (for shape, NOT for format — sapcli doesn't serialize, only commands): `tmp/sapcli-ref/sapcli/sap/cli/gcts.py`, `sap/adt/gcts.py`
-- Real gCTS-formatted repo example: see https://github.com/SAP-samples/abap-platform-sample-app or similar; clone to `tmp/gcts-sample/` for reference.
+- Real gCTS-formatted repo example: see <https://github.com/SAP-samples/abap-platform-sample-app> or similar; clone to `tmp/gcts-sample/` for reference.
 - Our abapGit plugin (template to mimic): `packages/adt-plugin-abapgit/src/lib/handlers/`
 
 ## Scope — files

--- a/docs/roadmap/epics/e09-acds-parser.md
+++ b/docs/roadmap/epics/e09-acds-parser.md
@@ -17,7 +17,7 @@ We have a starter parser at `packages/acds/`. RAP (E10/E11/E12) needs reliable A
 
 - Existing package: `packages/acds/` (read README/AGENTS.md)
 - ABAP CDS DDL specification: SAP help (download / pin reference grammar locally — `tmp/cds-grammar/`).
-- abaplint CDS support (TS implementation): https://github.com/abaplint/abaplint — for cross-comparison of grammar rules.
+- abaplint CDS support (TS implementation): <https://github.com/abaplint/abaplint> — for cross-comparison of grammar rules.
 
 ## Scope — files
 

--- a/docs/roadmap/epics/e13-startrfc.md
+++ b/docs/roadmap/epics/e13-startrfc.md
@@ -17,7 +17,7 @@ ADT is HTTP REST, but huge swathes of SAP automation still rely on RFC (BAPI cal
 
 - sapcli: `tmp/sapcli-ref/sapcli/sap/cli/startrfc.py` + `sap/rfc/`
 - Two implementation choices:
-  1. Use `node-rfc` (https://github.com/SAP/node-rfc) — official SAP NW RFC SDK binding for Node. Native module; requires SAP NW RFC SDK installed locally. Best fidelity.
+  1. Use `node-rfc` (<https://github.com/SAP/node-rfc>) — official SAP NW RFC SDK binding for Node. Native module; requires SAP NW RFC SDK installed locally. Best fidelity.
   2. Use SOAP-over-HTTP RFC (`/sap/bc/soap/rfc?...`) — REST/SOAP wrapper SAP exposes for some FMs. Doesn't require SDK but is limited.
 
 Recommend: ship Option 2 first (universal, no native deps), keep Option 1 as opt-in plugin (`@abapify/adt-plugin-rfc-native`).

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -1,3 +1,4 @@
+/* jshint esversion: 9 */
 const nxPreset = require('@nx/jest/preset').default;
 
 module.exports = { ...nxPreset };

--- a/openspec/changes/arc-1-feature-parity/design.md
+++ b/openspec/changes/arc-1-feature-parity/design.md
@@ -83,10 +83,10 @@ Not all systems are cloud ABAP; some users want to bypass the gate. Following AR
 
 ## Risks / Trade-offs
 
-- **`@abaplint/core` bundle size** — adds ~2–5 MB to `adt-lint`. [Risk] Tree-shaking may not be effective for the core parser. → Mitigation: lazy-load / dynamic import; measure bundle before shipping.
-- **AST stripping accuracy** — `@abaplint/core` may not parse all ABAP dialects (macros, include forms). [Risk] Stripping produces malformed output on edge cases. → Mitigation: strip operation falls back to returning full source if AST parse fails.
-- **Dump/trace endpoint availability** — `/sap/bc/adt/runtime/dumps` is available on NetWeaver 7.50+ but not on BTP. [Risk] Tool fails on BTP with 404. → Mitigation: graceful error message indicating BTP limitation.
-- **Method surgery cursor errors** — finding the method boundary in the AST requires the method to already exist. [Risk] Editing a non-existent method causes confusing errors. → Mitigation: explicit validation step; return `isError: true` with clear message.
+- **`@abaplint/core` bundle size** — adds ~2–5 MB to `adt-lint`. \[Risk] Tree-shaking may not be effective for the core parser. → Mitigation: lazy-load / dynamic import; measure bundle before shipping.
+- **AST stripping accuracy** — `@abaplint/core` may not parse all ABAP dialects (macros, include forms). \[Risk] Stripping produces malformed output on edge cases. → Mitigation: strip operation falls back to returning full source if AST parse fails.
+- **Dump/trace endpoint availability** — `/sap/bc/adt/runtime/dumps` is available on NetWeaver 7.50+ but not on BTP. \[Risk] Tool fails on BTP with 404. → Mitigation: graceful error message indicating BTP limitation.
+- **Method surgery cursor errors** — finding the method boundary in the AST requires the method to already exist. \[Risk] Editing a non-existent method causes confusing errors. → Mitigation: explicit validation step; return `isError: true` with clear message.
 
 ## Migration Plan
 

--- a/packages/adt-client/AGENTS.md
+++ b/packages/adt-client/AGENTS.md
@@ -459,7 +459,7 @@ npx adt fetch /sap/bc/adt/<endpoint> -H "Accept: application/vnd.sap.adt.feature
 - ❌ Real usernames (PPLENKOV)
 - ✅ Mock usernames (TESTUSER)
 - ❌ Real system URLs
-- ✅ Mock URLs (https://mock-system.example.com)
+- ✅ Mock URLs (<https://mock-system.example.com>)
 
 ```bash
 # Create fixture directory structure matching endpoint path

--- a/packages/ts-xsd/AGENTS.md
+++ b/packages/ts-xsd/AGENTS.md
@@ -186,7 +186,7 @@ type SchemaLike = {
 
 ### Adding a New XSD Type
 
-1. **Find in W3C spec**: https://www.w3.org/TR/xmlschema11-1/XMLSchema.xsd
+1. **Find in W3C spec**: <https://www.w3.org/TR/xmlschema11-1/XMLSchema.xsd>
 2. **Add interface** to `src/xsd/types.ts`:
    ```typescript
    export interface NewType extends Annotated {

--- a/website/docs/cli/import.md
+++ b/website/docs/cli/import.md
@@ -46,16 +46,16 @@ support.
 
 ### `transport`
 
-| Flag                          | Description                                                 |
-| ----------------------------- | ----------------------------------------------------------- |
-| `<transportNumber>`           | Transport request number to import.                         |
-| `[targetFolder]`              | Target folder for output.                                   |
-| `-o, --output <path>`         | Output directory (overrides `targetFolder`).                |
-| `-t, --object-types <types>`  | Comma-separated object types.                               |
-| `--format <format>`           | Output format. Default: `abapgit`.                          |
-| `--format-option <key=value>` | Repeatable format option.                                   |
-| `--folder-logic <logic>`      | **[DEPRECATED]** Use `--format-option folderLogic=<logic>`. |
-| `--debug`                     | Enable debug output.                                        |
+| Flag                          | Description                                               |
+| ----------------------------- | --------------------------------------------------------- |
+| `<transportNumber>`           | Transport request number to import.                       |
+| `[targetFolder]`              | Target folder for output.                                 |
+| `-o, --output <path>`         | Output directory (overrides `targetFolder`).              |
+| `-t, --object-types <types>`  | Comma-separated object types.                             |
+| `--format <format>`           | Output format. Default: `abapgit`.                        |
+| `--format-option <key=value>` | Repeatable format option.                                 |
+| `--folder-logic <logic>`      | **DEPRECATED** Use `--format-option folderLogic=<logic>`. |
+| `--debug`                     | Enable debug output.                                      |
 
 ## Examples
 


### PR DESCRIPTION
## **User description**
## Summary

Resolves the open [code-scanning alerts](https://github.com/abapify/adt-cli/security/code-scanning) reported by Codacy.

### Root causes

- `prompt-secrets.sh`: `trap` used double quotes, so `$temp_file` expanded at trap definition time instead of at signal time (shellcheck SC2064).
- `jest.preset.js`: JSHint defaulted to ES5 and flagged `const`/object spread; added an `esversion` directive.
- `website/src/css/custom.css`: CSSLint does not support CSS custom properties (`--ifm-*`), producing false-positive parse errors.
- Generated `CHANGELOG.md` files and `.github/prompts/*.prompt.md` contain bracket placeholders (`[bot]`, `[instructions]`, etc.) that remark-lint treats as undefined/shortcut references.
- Source docs/skills/AGENTS/openspec files used bare literal URLs or bracket labels (`[#N]`, `[Risk]`, `[DEPRECATED]`) that triggered remark-lint.

### Changes

- Fixed the `trap` command to use single quotes and deferred variable expansion.
- Added `/* jshint esversion: 9 */` to `jest.preset.js`.
- Added `.codacy.yml` to exclude generated `CHANGELOG.md` files, prompt frontmatter, and `website/src/css/custom.css` from the noisy Codacy checks.
- Escaped bracket placeholders and wrapped literal URLs in source markdown files.
- Converted workflow/command frontmatter `tags: [...]` arrays to YAML list syntax so remark-lint no longer sees them as shortcut reference links.


Link to Devin session: https://app.devin.ai/sessions/68e46e97ea5847d8a4c3f38062ef1f13
Requested by: @ThePlenkov

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes all open Codacy code-scanning alerts. Cleans up shell, JS, and Markdown issues to reduce false positives and keep scans green.

- **Bug Fixes**
  - Shell: fixed deferred variable expansion in `prompt-secrets.sh` trap.
  - JS lint: added `/* jshint esversion: 9 */` to `jest.preset.js`.
  - Codacy: added `.codacy.yml` to exclude `website/src/css/custom.css`, `**/CHANGELOG.md`, and `.github/prompts/*.prompt.md`.
  - Docs: escaped bracket placeholders, wrapped bare URLs in angle brackets, and removed a stale Turborepo migration anchor.
  - Frontmatter: converted `tags: [...]` arrays to YAML lists to avoid remark-lint shortcut link errors.

<sup>Written for commit 0de9d34b33a17ce899998d847540d4a6fa310a1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved Markdown formatting for links, references, and risk descriptions across guides and roadmap content.
  - Added spacing improvements to planning documentation.
  - Clarified the deprecated status of the `--folder-logic` CLI option without changing its behavior.

- **Maintenance**
  - Standardized workflow and command metadata formatting.
  - Added linting exclusions for generated or specialized documentation files.
  - Improved temporary-file cleanup reliability.
  - Added compatibility guidance for modern JavaScript syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Resolve code-scanning findings and keep project checks passing

### What Changed
- Prevents the secret-scanning hook from using an outdated temporary-file path during cleanup
- Keeps JavaScript linting compatible with the modern syntax used by the Jest configuration
- Updates Markdown links, placeholders, warnings, and metadata so documentation checks no longer treat them as broken references
- Excludes generated changelogs, prompt templates, and unsupported CSS syntax from noisy scans

### Impact
`✅ Reliable temporary-file cleanup in secret scanning`
`✅ Cleaner code-scanning results`
`✅ Fewer documentation lint failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
