### PR TITLE
fix(adk): skip unmaterializable transport objects

### DIFF
--- a/openspec/changes/add-adt-flow-transport-checkout/design.md
+++ b/openspec/changes/add-adt-flow-transport-checkout/design.md
@@ -69,8 +69,9 @@ Alternatives rejected:
 `adt-flow` calls `buildTransportSourceManifest`. It rejects any relevant
 `ambiguous` or `failed` entry before reading source bodies or changing files.
 It records and excludes `unsupported` entries, so object types with no
-source-history implementation do not block exact components in the same
-transport. It lazily downloads only selected base or head bodies.
+source-history implementation and objects whose ADT metadata cannot be loaded
+do not block exact components in the same transport. It lazily downloads only
+selected base or head bodies.
 
 For an added component, base means absence. For a deleted component, base
 materializes the recoverable predecessor and head means absence. This produces

--- a/openspec/changes/add-adt-flow-transport-checkout/specs/adt-flow-transport-checkout/spec.md
+++ b/openspec/changes/add-adt-flow-transport-checkout/specs/adt-flow-transport-checkout/spec.md
@@ -27,9 +27,9 @@ current source.
 - **THEN** checkout fails with a typed bounded diagnostic
 - **THEN** no repository path is changed
 
-#### Scenario: Object type has no source-history implementation
+#### Scenario: Object has no materializable source history
 
-- **GIVEN** a transport contains an otherwise relevant object whose manifest entry is `unsupported`
+- **GIVEN** a transport contains an otherwise relevant object whose manifest entry is `unsupported`, including one whose ADT metadata cannot be loaded
 - **WHEN** checkout is requested
 - **THEN** checkout excludes that object without reading source or changing its repository paths
 - **THEN** checkout continues with the remaining exact source components

--- a/packages/adk/src/transport-source-manifest.ts
+++ b/packages/adk/src/transport-source-manifest.ts
@@ -674,7 +674,7 @@ async function buildObjectEntries( // NOSONAR - SAP object manifest construction
         failureIdentity,
         { id: 'object' },
         sourceTransport,
-        error.code === 'OBJECT_METADATA_LOAD_FAILED' ? 'failed' : 'unsupported',
+        'unsupported',
         {
           code: error.code,
           message: error.message,

--- a/packages/adk/tests/transport-source-manifest.test.ts
+++ b/packages/adk/tests/transport-source-manifest.test.ts
@@ -852,7 +852,7 @@ describe('buildTransportSourceManifest', () => {
     expect(manifest.entries[0]?.diagnostic?.message).not.toContain('sensitive');
   });
 
-  it('marks a concrete ADK metadata load rejection as failed', async () => {
+  it('marks a concrete ADK metadata load rejection unsupported', async () => {
     const object = transportObject({
       name: 'ZLOAD_FAILURE',
       metadata: rootSourceMetadata(),
@@ -868,7 +868,7 @@ describe('buildTransportSourceManifest', () => {
     );
 
     expect(manifest.entries[0]).toMatchObject({
-      changeKind: 'failed',
+      changeKind: 'unsupported',
       exact: false,
       diagnostic: { code: 'OBJECT_METADATA_LOAD_FAILED' },
     });

--- a/packages/adt-flow/src/service.ts
+++ b/packages/adt-flow/src/service.ts
@@ -974,20 +974,41 @@ async function unsupportedEntries(
   }
 
   const skipped: FlowCheckoutResult['skipped'] = [];
+  const pushSkipped = (identityEntries: TransportSourceManifestEntry[]) => {
+    for (const entry of identityEntries) {
+      skipped.push({
+        object: `${entry.object.type}/${entry.object.name}`,
+        component: entry.component.id,
+        diagnostic: entry.diagnostic?.code ?? 'UNSUPPORTED',
+      });
+    }
+  };
+
   await Promise.all(
     [...byIdentity.values()].map(
       async ({ identity, entries: identityEntries }) => {
-        const model = await limiter.run(() =>
-          ctx.dependencies.loadObject(identity),
-        );
-        ctx.calls.metadata += model.metadataCalls ?? 1;
-        if (isApplicationComponentExcluded(ctx.config, model)) return;
-        for (const entry of identityEntries) {
-          skipped.push({
-            object: `${entry.object.type}/${entry.object.name}`,
-            component: entry.component.id,
-            diagnostic: entry.diagnostic?.code ?? 'UNSUPPORTED',
-          });
+        if (
+          identityEntries.some(
+            (entry) => entry.diagnostic?.code === 'OBJECT_METADATA_LOAD_FAILED',
+          )
+        ) {
+          pushSkipped(identityEntries);
+          return;
+        }
+
+        try {
+          const model = await limiter.run(() =>
+            ctx.dependencies.loadObject(identity),
+          );
+          ctx.calls.metadata += model.metadataCalls ?? 1;
+          if (isApplicationComponentExcluded(ctx.config, model)) return;
+          pushSkipped(identityEntries);
+        } catch (error) {
+          if (error instanceof AdtFlowError) {
+            pushSkipped(identityEntries);
+            return;
+          }
+          throw error;
         }
       },
     ),

--- a/packages/adt-flow/tests/service.test.ts
+++ b/packages/adt-flow/tests/service.test.ts
@@ -5,7 +5,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { TransportSourceManifest } from '@abapify/adk';
 import type { SourceVersionRef } from '@abapify/adt-client';
 import type { FormatPlugin } from '@abapify/adt-plugin';
-import { createAdtFlowService, type FlowCheckoutDependencies } from '../src';
+import {
+  createAdtFlowService,
+  AdtFlowError,
+  type FlowCheckoutDependencies,
+} from '../src';
 
 const roots: string[] = [];
 
@@ -73,6 +77,18 @@ function unsupportedEntry(
     diagnostic: {
       code: 'OBJECT_TYPE_UNSUPPORTED',
       message: 'No source-history loader is registered for this object type.',
+    },
+  };
+}
+
+function metadataLoadFailedEntry(
+  name = 'PAYHX01',
+): TransportSourceManifest['entries'][number] {
+  return {
+    ...unsupportedEntry(name),
+    diagnostic: {
+      code: 'OBJECT_METADATA_LOAD_FAILED',
+      message: 'SAP ADT rejected repository object metadata retrieval.',
     },
   };
 }
@@ -726,6 +742,68 @@ describe('transport checkout', () => {
     });
 
     expect(result.skipped).toEqual([]);
+    expect(ports.loadObject).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips metadata-load-failed objects without re-loading metadata when an application component filter is configured', async () => {
+    const workspace = await root();
+    const current: TransportSourceManifest = {
+      requestedTransports: ['DEVK900001'],
+      scopeTransports: ['DEVK900001'],
+      entries: [metadataLoadFailedEntry()],
+    };
+    const ports = dependencies(() => current);
+    const result = await createAdtFlowService(ports).checkout({
+      root: workspace,
+      transports: ['DEVK900001'],
+      config: {
+        ...config,
+        include: { applicationComponents: ['ZAPP'] },
+      },
+    });
+
+    expect(result.skipped).toEqual([
+      {
+        object: 'TABD/PAYHX01',
+        component: 'object',
+        diagnostic: 'OBJECT_METADATA_LOAD_FAILED',
+      },
+    ]);
+    expect(ports.loadObject).not.toHaveBeenCalled();
+  });
+
+  it('records unsupported objects in skipped when loadObject fails during application component filtering', async () => {
+    const workspace = await root();
+    const current: TransportSourceManifest = {
+      requestedTransports: ['DEVK900001'],
+      scopeTransports: ['DEVK900001'],
+      entries: [unsupportedEntry()],
+    };
+    const ports = dependencies(() => current);
+    ports.loadObject.mockRejectedValue(
+      new AdtFlowError(
+        'object_metadata_unavailable',
+        'ADT returned an unsupported object metadata model.',
+        { object: 'R3TR/TABD/PAYHX01' },
+      ),
+    );
+
+    const result = await createAdtFlowService(ports).checkout({
+      root: workspace,
+      transports: ['DEVK900001'],
+      config: {
+        ...config,
+        include: { applicationComponents: ['ZAPP'] },
+      },
+    });
+
+    expect(result.skipped).toEqual([
+      {
+        object: 'TABD/PAYHX01',
+        component: 'object',
+        diagnostic: 'OBJECT_TYPE_UNSUPPORTED',
+      },
+    ]);
     expect(ports.loadObject).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

Classify OBJECT_METADATA_LOAD_FAILED as unsupported, so a transport can continue materializing exact source components when one object has no usable ADT metadata.

This directly fixes the failure shape in Booking ACR job 15849947781: PROG/ZI_FX_PST_CNTRL_CLS with OBJECT_METADATA_LOAD_FAILED.

## Verification

- ADK tests: 192 passed.
- adt-flow tests: 26 passed.
- ADK and adt-flow typechecks: passed.
- ADK build: passed.
- Targeted formatting and git diff checks: passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat ADT metadata-load failures as unsupported so checkout skips those objects and continues materializing exact components. Applies to `adk` manifest building and `adt-flow` application component filtering.

- **Bug Fixes**
  - `adk`: manifest now classifies object metadata load errors as `unsupported`, skipping unmaterializable objects without reading source or changing paths.
  - `adt-flow`: during application component filtering, skip objects with metadata-load failures without reloading metadata; if `loadObject` throws an `AdtFlowError`, record them as skipped instead of failing checkout.

<sup>Written for commit dabd37e1b133951607323086ad23c9dd8ca4b0c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Allow transport checkout to continue when an object's ADT metadata cannot be loaded

### What Changed
- Objects whose ADT metadata cannot be loaded are treated as unsupported instead of failed
- Checkout skips those objects without reading their source or changing repository paths
- Remaining exact source components in the same transport continue through checkout

### Impact
`✅ Fewer transport checkout failures`
`✅ Exact components continue despite unusable object metadata`
`✅ No repository changes for skipped objects`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
