### PR TITLE
quality: resolve open remark-lint code-scanning findings and fix codacy workflow formatting

### DIFF
--- a/.agents/workflows/lint.md
+++ b/.agents/workflows/lint.md
@@ -2,10 +2,7 @@
 name: lint
 description: Run Nx lint with fix and iterate until clean.
 category: workflow
-tags:
-  - nx
-  - lint
-  - quality
+tags: [nx, lint, quality]
 ---
 
 1. Run lint with fix (Nx `lint` target for affected packages).

--- a/.agents/workflows/opsx-apply.md
+++ b/.agents/workflows/opsx-apply.md
@@ -2,10 +2,7 @@
 name: opsx-apply
 description: Implement tasks from an OpenSpec change (experimental workflow).
 category: workflow
-tags:
-  - openspec
-  - experimental
-  - implementation
+tags: [openspec, experimental, implementation]
 ---
 
 Implement tasks from an OpenSpec change.

--- a/.agents/workflows/opsx-archive.md
+++ b/.agents/workflows/opsx-archive.md
@@ -2,9 +2,7 @@
 name: opsx-archive
 description: Archive a completed OpenSpec change (experimental workflow).
 category: workflow
-tags:
-  - openspec
-  - experimental
+tags: [openspec, experimental]
 ---
 
 Archive a completed change in the experimental workflow.

--- a/.agents/workflows/opsx-explore.md
+++ b/.agents/workflows/opsx-explore.md
@@ -2,10 +2,7 @@
 name: opsx-explore
 description: Enter explore mode — think through ideas, investigate problems, clarify requirements (no implementation).
 category: workflow
-tags:
-  - openspec
-  - experimental
-  - discovery
+tags: [openspec, experimental, discovery]
 ---
 
 Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.

--- a/.agents/workflows/opsx-propose.md
+++ b/.agents/workflows/opsx-propose.md
@@ -2,10 +2,7 @@
 name: opsx-propose
 description: Propose a new OpenSpec change and generate all artifacts in one step.
 category: workflow
-tags:
-  - openspec
-  - experimental
-  - artifacts
+tags: [openspec, experimental, artifacts]
 ---
 
 Propose a new change - create the change and generate all artifacts in one step.

--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -2,10 +2,7 @@
 name: 'OPSX: Apply'
 description: Implement tasks from an OpenSpec change (Experimental)
 category: Workflow
-tags:
-  - workflow
-  - artifacts
-  - experimental
+tags: [workflow, artifacts, experimental]
 ---
 
 **Canonical workflow:** `.agents/workflows/opsx-apply.md`

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -2,10 +2,7 @@
 name: 'OPSX: Archive'
 description: Archive a completed change in the experimental workflow
 category: Workflow
-tags:
-  - workflow
-  - archive
-  - experimental
+tags: [workflow, archive, experimental]
 ---
 
 **Canonical workflow:** `.agents/workflows/opsx-archive.md`

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -2,11 +2,7 @@
 name: 'OPSX: Explore'
 description: 'Enter explore mode - think through ideas, investigate problems, clarify requirements'
 category: Workflow
-tags:
-  - workflow
-  - explore
-  - experimental
-  - thinking
+tags: [workflow, explore, experimental, thinking]
 ---
 
 **Canonical workflow:** `.agents/workflows/opsx-explore.md`

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -2,10 +2,7 @@
 name: 'OPSX: Propose'
 description: Propose a new change - create it and generate all artifacts in one step
 category: Workflow
-tags:
-  - workflow
-  - artifacts
-  - experimental
+tags: [workflow, artifacts, experimental]
 ---
 
 **Canonical workflow:** `.agents/workflows/opsx-propose.md`

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -15,10 +15,10 @@ name: Codacy Security Scan
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ['main']
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: ['main']
   schedule:
     - cron: '21 3 * * 1'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,17 +34,17 @@
 - apply CodeRabbit auto-fixes ([68e47903](https://github.com/abapify/adt-cli/commit/68e47903))
 - address PR review — regex security, method detection, BTP 404, lint gate, specs ([bf634260](https://github.com/abapify/adt-cli/commit/bf634260))
 - reduce duplication, remove useless conditional, harden JSONC parser ([7181ab33](https://github.com/abapify/adt-cli/commit/7181ab33))
-- guard starts[0] with nullish coalescing for SonarCloud reliability ([77334cf7](https://github.com/abapify/adt-cli/commit/77334cf7))
+- guard starts\[0] with nullish coalescing for SonarCloud reliability ([77334cf7](https://github.com/abapify/adt-cli/commit/77334cf7))
 - use localeCompare in sort for SonarCloud S2871 reliability ([a40e9dec](https://github.com/abapify/adt-cli/commit/a40e9dec))
 - prefer-const lint error in cts tr objects command ([11da0c54](https://github.com/abapify/adt-cli/commit/11da0c54))
 - apply prettier formatting to service.ts ([52dfffae](https://github.com/abapify/adt-cli/commit/52dfffae))
 - optimize findObjectFiles index, restore transportNumber compat, dedup ImportContext ([4f08ee94](https://github.com/abapify/adt-cli/commit/4f08ee94))
 - resolve SonarCloud reliability and duplication findings ([ac951739](https://github.com/abapify/adt-cli/commit/ac951739))
-- use const variable for transportNumbers[0] to avoid non-null assertions ([12dbce6c](https://github.com/abapify/adt-cli/commit/12dbce6c))
+- use const variable for transportNumbers\[0] to avoid non-null assertions ([12dbce6c](https://github.com/abapify/adt-cli/commit/12dbce6c))
 - **aclass:** proper regex metacharacter escaping in `kw()` helper ([77908b41](https://github.com/abapify/adt-cli/commit/77908b41))
 - **aclass:** qualified method names + keyword method names ([cfe5839d](https://github.com/abapify/adt-cli/commit/cfe5839d))
 - **aclass+openai-codegen:** address PR #111 review findings ([#111](https://github.com/abapify/adt-cli/issues/111))
-- **adt-lint:** replace lazy '._?' with '[^']_' in token regex to fix S5852/polynomial-redos ([6238f973](https://github.com/abapify/adt-cli/commit/6238f973))
+- **adt-lint:** replace lazy '._?' with '\[^']_' in token regex to fix S5852/polynomial-redos ([6238f973](https://github.com/abapify/adt-cli/commit/6238f973))
 - **adt-pilot:** use https in test/example URLs to clear SonarCloud hotspots ([f7246654](https://github.com/abapify/adt-cli/commit/f7246654))
 - **adt-pilot:** use extensionless internal imports per bundler-imports rule ([d819a8de](https://github.com/abapify/adt-cli/commit/d819a8de))
 - **adt-pilot:** align declared deps with actual usage ([ffa6346f](https://github.com/abapify/adt-cli/commit/ffa6346f))
@@ -60,8 +60,8 @@
 
 - CodeRabbit
 - Cursor @cursoragent
-- Devin @devin-ai-integration[bot]
-- Devin AI @devin-ai-integration[bot]
+- Devin @devin-ai-integration\[bot]
+- Devin AI @devin-ai-integration\[bot]
 - Petr Plenkov
 - ThePlenkov @ThePlenkov
 
@@ -149,7 +149,7 @@
 
 ### ❤️ Thank You
 
-- Devin @devin-ai-integration[bot]
+- Devin @devin-ai-integration\[bot]
 - Petr Plenkov
 
 ## 0.3.0 (2026-04-20)
@@ -256,7 +256,7 @@
 
 - CodeRabbit
 - Codex @oai-codex
-- Devin @devin-ai-integration[bot]
+- Devin @devin-ai-integration\[bot]
 - Petr Plenkov
 - ThePlenkov @ThePlenkov
 
@@ -304,7 +304,7 @@
 - resolve SonarCloud quality gate failures ([e8cfed9](https://github.com/abapify/adt-cli/commit/e8cfed9))
 - address remaining SonarQube findings - complexity, duplication, and code quality ([11a3408](https://github.com/abapify/adt-cli/commit/11a3408))
 - update sonar-project.properties with exclusions and project key ([dc374f8](https://github.com/abapify/adt-cli/commit/dc374f8))
-- use [^<]+ in XML tag regexes to require non-empty content ([b459ea7](https://github.com/abapify/adt-cli/commit/b459ea7))
+- use \[^<]+ in XML tag regexes to require non-empty content ([b459ea7](https://github.com/abapify/adt-cli/commit/b459ea7))
 - simplify sonar exclusions to **/generated/** ([ecc42c5](https://github.com/abapify/adt-cli/commit/ecc42c5))
 - simplify sonar exclusions to **/generated/** ([2c2dad3](https://github.com/abapify/adt-cli/commit/2c2dad3))
 - remove trailing blank lines from sonar-project.properties ([56b8e5e](https://github.com/abapify/adt-cli/commit/56b8e5e))
@@ -325,7 +325,7 @@
 
 ### ❤️ Thank You
 
-- Devin @devin-ai-integration[bot]
+- Devin @devin-ai-integration\[bot]
 - Petr Plenkov
 - ThePlenkov @ThePlenkov
 


### PR DESCRIPTION
## Summary

Closes the 45 open `remark-lint` code-scanning alerts reported by Codacy:

- **list-item-bullet-indent (27 alerts):** Converted YAML `tags:` block lists in `.agents/workflows/*.md` and `.claude/commands/opsx/*.md` frontmatter to inline arrays so the indented bullets are no longer parsed as markdown list items.
- **no-undefined-references / no-shortcut-reference-link (18 alerts):** Escaped the opening brackets of non-link bracket sequences in `CHANGELOG.md` (e.g. `starts[0]`, `@devin-ai-integration[bot]`, `'\[^']_'`, `\[^<]+`) so `remark` no longer treats them as shortcut/reference links.
- Also applies `prettier` formatting to `.github/workflows/codacy.yml` to fix the current `main` CI `nx format:check` failure.

These are root-cause fixes; no suppression comments or global exclusions were added.

Link to Devin session: https://app.devin.ai/sessions/754774d02df644c5894ee8b773029700
Requested by: @ThePlenkov

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 45 Codacy `remark-lint` alerts and unblocks CI by formatting the Codacy workflow file. Converts agent frontmatter tags to inline arrays and escapes non-link brackets in the changelog.

- **Bug Fixes**
  - Converted YAML frontmatter `tags:` lists in `.agents/workflows/*.md` and `.claude/commands/opsx/*.md` to inline arrays to clear `list-item-bullet-indent`.
  - Escaped non-link bracket sequences in `CHANGELOG.md` to satisfy `no-undefined-references` and `no-shortcut-reference-link`.
  - Applied `prettier` to `.github/workflows/codacy.yml` to pass `nx format:check`.

<sup>Written for commit 452ab6256b8c6bf9ef53b904b74ecba3461862a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

