### PR TITLE
quality: convert agent frontmatter tags to YAML block sequences to fix remark-lint reference rules

### DIFF
--- a/.agents/workflows/lint.md
+++ b/.agents/workflows/lint.md
@@ -2,7 +2,10 @@
 name: lint
 description: Run Nx lint with fix and iterate until clean.
 category: workflow
-tags: [nx, lint, quality]
+tags:
+- nx
+- lint
+- quality
 ---
 
 1. Run lint with fix (Nx `lint` target for affected packages).

--- a/.agents/workflows/opsx-apply.md
+++ b/.agents/workflows/opsx-apply.md
@@ -2,7 +2,10 @@
 name: opsx-apply
 description: Implement tasks from an OpenSpec change (experimental workflow).
 category: workflow
-tags: [openspec, experimental, implementation]
+tags:
+- openspec
+- experimental
+- implementation
 ---
 
 Implement tasks from an OpenSpec change.

--- a/.agents/workflows/opsx-archive.md
+++ b/.agents/workflows/opsx-archive.md
@@ -2,7 +2,9 @@
 name: opsx-archive
 description: Archive a completed OpenSpec change (experimental workflow).
 category: workflow
-tags: [openspec, experimental]
+tags:
+- openspec
+- experimental
 ---
 
 Archive a completed change in the experimental workflow.

--- a/.agents/workflows/opsx-explore.md
+++ b/.agents/workflows/opsx-explore.md
@@ -2,7 +2,10 @@
 name: opsx-explore
 description: Enter explore mode — think through ideas, investigate problems, clarify requirements (no implementation).
 category: workflow
-tags: [openspec, experimental, discovery]
+tags:
+- openspec
+- experimental
+- discovery
 ---
 
 Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.

--- a/.agents/workflows/opsx-propose.md
+++ b/.agents/workflows/opsx-propose.md
@@ -2,7 +2,10 @@
 name: opsx-propose
 description: Propose a new OpenSpec change and generate all artifacts in one step.
 category: workflow
-tags: [openspec, experimental, artifacts]
+tags:
+- openspec
+- experimental
+- artifacts
 ---
 
 Propose a new change - create the change and generate all artifacts in one step.

--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -2,7 +2,10 @@
 name: 'OPSX: Apply'
 description: Implement tasks from an OpenSpec change (Experimental)
 category: Workflow
-tags: [workflow, artifacts, experimental]
+tags:
+- workflow
+- artifacts
+- experimental
 ---
 
 **Canonical workflow:** `.agents/workflows/opsx-apply.md`

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -2,7 +2,10 @@
 name: 'OPSX: Archive'
 description: Archive a completed change in the experimental workflow
 category: Workflow
-tags: [workflow, archive, experimental]
+tags:
+- workflow
+- archive
+- experimental
 ---
 
 **Canonical workflow:** `.agents/workflows/opsx-archive.md`

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -2,7 +2,11 @@
 name: 'OPSX: Explore'
 description: 'Enter explore mode - think through ideas, investigate problems, clarify requirements'
 category: Workflow
-tags: [workflow, explore, experimental, thinking]
+tags:
+- workflow
+- explore
+- experimental
+- thinking
 ---
 
 **Canonical workflow:** `.agents/workflows/opsx-explore.md`

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -2,7 +2,10 @@
 name: 'OPSX: Propose'
 description: Propose a new change - create it and generate all artifacts in one step
 category: Workflow
-tags: [workflow, artifacts, experimental]
+tags:
+- workflow
+- artifacts
+- experimental
 ---
 
 **Canonical workflow:** `.agents/workflows/opsx-propose.md`

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,12 @@
 /git_modules
 **/schemas/generated
 .nx/self-healing
+.agents/workflows/lint.md
+.agents/workflows/opsx-archive.md
+.agents/workflows/opsx-apply.md
+.agents/workflows/opsx-propose.md
+.agents/workflows/opsx-explore.md
+.claude/commands/opsx/archive.md
+.claude/commands/opsx/apply.md
+.claude/commands/opsx/explore.md
+.claude/commands/opsx/propose.md


### PR DESCRIPTION
## Summary

`codacy-remark-lint` treats the inline YAML arrays in workflow/command frontmatter as markdown shortcut-reference links, producing `remark-lint-no-undefined-references` and `remark-lint-no-shortcut-reference-link` alerts.

- Convert `tags: [...]` to unindented YAML block sequences in the 9 agent/claude frontmatter files. This keeps the parsed `tags` value as a list while avoiding `[`/`]` link syntax for `remark`.
- Add those files to `.prettierignore` so Prettier does not re-indent the list items and reintroduce `list-item-bullet-indent` findings.

Verified locally with `remark-cli` (no-undefined-references, no-shortcut-reference-link, list-item-bullet-indent), Prettier `--check`, and `nx format:check`.

Link to Devin session: https://app.devin.ai/sessions/754774d02df644c5894ee8b773029700
Requested by: @ThePlenkov

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes remark-lint reference rule violations by converting frontmatter `tags` from inline arrays to YAML block sequences in agent and Claude docs. Adds the edited files to `.prettierignore` so `Prettier` won’t re-indent the lists.

- **Bug Fixes**
  - Replaced `tags: [a, b]` with block sequences to satisfy `remark-lint-no-undefined-references` and `remark-lint-no-shortcut-reference-link`.
  - Added the affected files to `.prettierignore` to prevent reintroducing `list-item-bullet-indent` findings.

<sup>Written for commit a4f9f214e26962aa5810477b8afd6135b9f7953b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized workflow and command metadata formatting for improved readability.
  * Updated formatting exclusions to prevent automated formatting from altering workflow and command definitions.
  * Preserved all existing tags, instructions, and workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->