### PR TITLE
fix(flow): ignore unsupported manifest diagnostics

### DIFF
--- a/openspec/changes/add-adt-flow-transport-checkout/specs/adt-flow-transport-checkout/spec.md
+++ b/openspec/changes/add-adt-flow-transport-checkout/specs/adt-flow-transport-checkout/spec.md
@@ -29,7 +29,7 @@ current source.
 
 #### Scenario: Object has no materializable source history
 
-- **GIVEN** a transport contains an otherwise relevant object whose manifest entry is `unsupported`, including one whose ADT metadata cannot be loaded
+- **GIVEN** a transport contains an otherwise relevant object whose manifest entry is `unsupported` or carries the `OBJECT_TYPE_UNSUPPORTED` diagnostic, including one whose ADT metadata cannot be loaded
 - **WHEN** checkout is requested
 - **THEN** checkout excludes that object without reading source or changing its repository paths
 - **THEN** checkout continues with the remaining exact source components

--- a/packages/adt-flow/src/service.ts
+++ b/packages/adt-flow/src/service.ts
@@ -148,6 +148,13 @@ function isApplicationComponentExcluded(
   );
 }
 
+function isUnsupportedEntry(entry: TransportSourceManifestEntry): boolean {
+  return (
+    entry.changeKind === 'unsupported' ||
+    entry.diagnostic?.code === 'OBJECT_TYPE_UNSUPPORTED'
+  );
+}
+
 function selectedVersion(
   entry: TransportSourceManifestEntry,
   mode: 'base' | 'head',
@@ -947,9 +954,7 @@ async function unsupportedEntries(
   limiter: Limiter,
   hasApplicationComponentFilter: boolean,
 ): Promise<FlowCheckoutResult['skipped']> {
-  const unsupported = entries.filter(
-    (entry) => entry.changeKind === 'unsupported',
-  );
+  const unsupported = entries.filter(isUnsupportedEntry);
 
   if (!hasApplicationComponentFilter) {
     return unsupported.map((entry) => ({
@@ -1038,9 +1043,7 @@ async function buildManifestAndGroups(
     metadataLimiter,
     hasApplicationComponentFilter,
   );
-  const entries = scopedEntries.filter(
-    (entry) => entry.changeKind !== 'unsupported',
-  );
+  const entries = scopedEntries.filter((entry) => !isUnsupportedEntry(entry));
   const sourceLimiter = new Limiter(
     ctx.config.concurrency?.sources ?? DEFAULT_SOURCE_CONCURRENCY,
   );

--- a/packages/adt-flow/tests/service.test.ts
+++ b/packages/adt-flow/tests/service.test.ts
@@ -625,8 +625,12 @@ describe('transport checkout', () => {
         diagnostic: 'OBJECT_TYPE_UNSUPPORTED',
       },
     ]);
-    expect(result.changed).toContain('src/feature/zcl_sample.clas.abap');
+    expect(result.changed).toEqual([
+      'src/feature/zcl_sample.clas.abap',
+      'src/feature/zcl_sample.clas.xml',
+    ]);
     expect(ports.loadObject).toHaveBeenCalledTimes(1);
+    expect(ports.readSource).toHaveBeenCalledTimes(1);
   });
 
   it('reconciles a package reassignment as old-path removal plus new-path writes', async () => {

--- a/packages/adt-flow/tests/service.test.ts
+++ b/packages/adt-flow/tests/service.test.ts
@@ -81,6 +81,19 @@ function unsupportedEntry(
   };
 }
 
+function unsupportedDiagnosticEntry(): TransportSourceManifest['entries'][number] {
+  return {
+    ...unsupportedEntry('ZCL_TR_LOAN_CUSTOM_ENTITY FETCH_DATA_LIST'),
+    object: {
+      pgmid: 'R3TR',
+      type: 'METH',
+      name: 'ZCL_TR_LOAN_CUSTOM_ENTITY FETCH_DATA_LIST',
+      packageName: 'ZROOT_FEATURE',
+    },
+    changeKind: 'ambiguous',
+  };
+}
+
 function metadataLoadFailedEntry(
   name = 'PAYHX01',
 ): TransportSourceManifest['entries'][number] {
@@ -580,6 +593,34 @@ describe('transport checkout', () => {
     expect(result.skipped).toEqual([
       {
         object: 'TABD/PAYHX01',
+        component: 'object',
+        diagnostic: 'OBJECT_TYPE_UNSUPPORTED',
+      },
+    ]);
+    expect(result.changed).toContain('src/feature/zcl_sample.clas.abap');
+    expect(ports.loadObject).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips an unsupported diagnostic even when its manifest change kind is ambiguous', async () => {
+    const workspace = await root();
+    const current = manifest('modified', version('before'), version('after'));
+    current.entries.push(unsupportedDiagnosticEntry());
+    const ports = dependencies(() => current);
+    ports.readSource.mockResolvedValue('stable source\n');
+    ports.loadObject.mockResolvedValue({
+      object: { name: 'ZCL_SAMPLE' },
+      packagePath: ['ZROOT', 'ZROOT_FEATURE'],
+    });
+
+    const result = await createAdtFlowService(ports).checkout({
+      root: workspace,
+      transports: ['DEVK900001'],
+      config,
+    });
+
+    expect(result.skipped).toEqual([
+      {
+        object: 'METH/ZCL_TR_LOAN_CUSTOM_ENTITY FETCH_DATA_LIST',
         component: 'object',
         diagnostic: 'OBJECT_TYPE_UNSUPPORTED',
       },


### PR DESCRIPTION
## Why

An unsupported transport object can carry OBJECT_TYPE_UNSUPPORTED while its manifest changeKind is ambiguous. The previous filter only skipped changeKind=unsupported, so the object reached exact-boundary validation and failed checkout.

## Change

Treat OBJECT_TYPE_UNSUPPORTED as authoritative for skipping independently of changeKind. Every other ambiguous or failed diagnostic remains fail-closed.

## Verification

- Regression test covers METH/ZCL_TR_LOAN_CUSTOM_ENTITY FETCH_DATA_LIST with changeKind=ambiguous.
- adt-flow: 29 tests passed; typecheck, build, and strict OpenSpec validation passed.
- Full-repository Prettier has existing failures outside this change; changed files pass Prettier and git diff --check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip unsupported transport objects when ADT reports OBJECT_TYPE_UNSUPPORTED, even if the manifest changeKind is ambiguous. Previously only changeKind=unsupported was skipped, which let some objects fail checkout; now they are excluded without reading source or changing paths.

- Adds a shared predicate to treat entries as unsupported when changeKind=unsupported or diagnostic=OBJECT_TYPE_UNSUPPORTED; used for manifest filtering, grouping, and skipped reporting.
- Updates OpenSpec to cover diagnostic-based skipping (including when ADT metadata cannot be loaded) and extends tests to assert no source-side effects; all `adt-flow` tests pass.
- Other ambiguous or failed diagnostics still fail closed; no migration required.

<sup>Written for commit 6737ba36c4b579534c102daba315a757d2649d17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Checkout now correctly skips unsupported objects identified by diagnostic information, including when metadata cannot be loaded.
  * Supported objects continue processing normally, without unnecessary source reads or repository changes.
  * Checkout diagnostics clearly identify skipped objects and the reason they were excluded.

* **Tests**
  * Added coverage for mixed supported and unsupported object checkout scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->