### PR TITLE
fix(cli): expose safe fetch failure diagnostics

### DIFF
--- a/packages/adt-cli/src/lib/commands/fetch.test.ts
+++ b/packages/adt-cli/src/lib/commands/fetch.test.ts
@@ -37,4 +37,63 @@ describe('formatFetchFailure', () => {
       'Transport cause: socket hang up (ECONNRESET)',
     );
   });
+
+  it('redacts API-key headers, Digest auth parameters, and sensitive statusText', () => {
+    const error = Object.assign(
+      new Error(
+        'Authorization: Digest username="u", realm="r", nonce="n"\nX-Api-Key: leaked-key',
+      ),
+      {
+        status: 401,
+        statusText: 'Unauthorized?access_token=status-secret',
+        rawBody:
+          'Authorization: Digest username="u", response="resp"\nX-Api-Key: body-key',
+      },
+    );
+
+    const diagnostic = formatFetchFailure(error).join('\n');
+
+    expect(diagnostic).not.toContain('leaked-key');
+    expect(diagnostic).not.toContain('body-key');
+    expect(diagnostic).not.toContain('status-secret');
+    expect(diagnostic).not.toContain('response="resp"');
+    expect(diagnostic).not.toContain('nonce="n"');
+    expect(diagnostic).toContain('[REDACTED]');
+  });
+
+  it('redacts authorization/cookie JSON keys and ADT XML entry attributes', () => {
+    const error = Object.assign(new Error('upstream error'), {
+      status: 500,
+      rawBody:
+        '{"authorization":"Bearer abc","cookie":"sid=123","set-cookie":"x=1"}\n' +
+        '<entry key="access_token">plain-secret</entry>',
+    });
+
+    const diagnostic = formatFetchFailure(error).join('\n');
+
+    expect(diagnostic).not.toContain('Bearer abc');
+    expect(diagnostic).not.toContain('sid=123');
+    expect(diagnostic).not.toContain('plain-secret');
+    expect(diagnostic).toContain('[REDACTED]');
+  });
+
+  it('truncates the response body at a code-point boundary (no split surrogates)', () => {
+    // Build a body where the 4000th code point is a surrogate pair ('😀').
+    // 3999 'a's + '😀' (1 code point, 2 UTF-16 units) + 'b' = 4001 code points.
+    // Code-point slicing keeps 3999 'a's + '😀' (valid); naive unit slicing
+    // would cut inside the surrogate pair and emit a lone high surrogate.
+    const rawBody = 'a'.repeat(3999) + '😀b';
+    const error = Object.assign(new Error('err'), {
+      status: 500,
+      rawBody,
+    });
+
+    const diagnostic = formatFetchFailure(error).join('\n');
+
+    expect(diagnostic).toContain('… [truncated]');
+    // The truncated body must not contain a lone high surrogate (U+D800–U+DBFF
+    // alone renders as U+FFFD). '😀' is preserved intact.
+    expect(diagnostic).toContain('😀');
+    expect(diagnostic).not.toContain('\uFFFD');
+  });
 });

--- a/packages/adt-cli/src/lib/commands/fetch.test.ts
+++ b/packages/adt-cli/src/lib/commands/fetch.test.ts
@@ -58,6 +58,7 @@ describe('formatFetchFailure', () => {
     expect(diagnostic).not.toContain('status-secret');
     expect(diagnostic).not.toContain('response="resp"');
     expect(diagnostic).not.toContain('nonce="n"');
+    expect(diagnostic).not.toContain('username="u"');
     expect(diagnostic).toContain('[REDACTED]');
   });
 
@@ -73,7 +74,23 @@ describe('formatFetchFailure', () => {
 
     expect(diagnostic).not.toContain('Bearer abc');
     expect(diagnostic).not.toContain('sid=123');
+    expect(diagnostic).not.toContain('x=1');
     expect(diagnostic).not.toContain('plain-secret');
+    expect(diagnostic).toContain('[REDACTED]');
+  });
+
+  it('redacts JSON string values containing escaped quotes', () => {
+    const error = Object.assign(new Error('err'), {
+      status: 500,
+      rawBody: '{"password":"abc\\"def","token":"xyz\\"wuv"}',
+    });
+
+    const diagnostic = formatFetchFailure(error).join('\n');
+
+    // The old pattern [^"']* stopped at the escaped quote, leaking `def"`
+    // and `wuv"`. The escape-aware pattern consumes the full value.
+    expect(diagnostic).not.toContain('def');
+    expect(diagnostic).not.toContain('wuv');
     expect(diagnostic).toContain('[REDACTED]');
   });
 

--- a/packages/adt-cli/src/lib/commands/fetch.test.ts
+++ b/packages/adt-cli/src/lib/commands/fetch.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { formatFetchFailure } from './fetch';
+
+describe('formatFetchFailure', () => {
+  it('reports HTTP status and a bounded, redacted response body', () => {
+    const error = Object.assign(
+      new Error('HTTP 502: Bad Gateway?access_token=message-secret'),
+      {
+        status: 502,
+        statusText: 'Bad Gateway',
+        rawBody:
+          '{"message":"upstream unavailable","requestId":"req-123","access_token":"secret-token","password":"secret-password"}',
+      },
+    );
+
+    const diagnostic = formatFetchFailure(error).join('\n');
+
+    expect(diagnostic).toContain('HTTP status: 502 Bad Gateway');
+    expect(diagnostic).toContain('Response body (sanitized');
+    expect(diagnostic).toContain('requestId');
+    expect(diagnostic).toContain('[REDACTED]');
+    expect(diagnostic).not.toContain('secret-token');
+    expect(diagnostic).not.toContain('secret-password');
+    expect(diagnostic).not.toContain('message-secret');
+  });
+
+  it('distinguishes a transport failure from an HTTP response', () => {
+    const cause = Object.assign(new Error('socket hang up'), {
+      code: 'ECONNRESET',
+    });
+    const error = new TypeError('fetch failed', { cause });
+
+    const diagnostic = formatFetchFailure(error).join('\n');
+
+    expect(diagnostic).toContain('HTTP response: none received');
+    expect(diagnostic).toContain(
+      'Transport cause: socket hang up (ECONNRESET)',
+    );
+  });
+});

--- a/packages/adt-cli/src/lib/commands/fetch.ts
+++ b/packages/adt-cli/src/lib/commands/fetch.ts
@@ -12,9 +12,9 @@ type FetchFailure = Error & {
   cause?: unknown;
 };
 
-// Sensitive JSON/XML/query key fragments shared across redaction patterns.
-const SENSITIVE_KEY_FRAGMENT =
-  'token|password|passwd|secret|api[_-]?key|access[_-]?key|samlrequest|relaystate|authorization|cookie|set-cookie';
+// Sensitive key fragments are inlined into each regex literal below (rather
+// than interpolated via new RegExp) to satisfy Codacy's non-literal-RegExp
+// rule. Keep the lists in sync when adding new sensitive key names.
 
 function redactDiagnostic(value: string): string {
   return value
@@ -24,31 +24,19 @@ function redactDiagnostic(value: string): string {
     )
     .replace(/(?:set-)?cookie:\s*[^\r\n]*/gi, 'Cookie: [REDACTED]')
     .replace(
-      new RegExp(
-        String.raw`(["'](?:[a-z0-9_-]*?(?:${SENSITIVE_KEY_FRAGMENT})[a-z0-9_-]*)["']\s*:\s*["'])(?:[^"'\\]|\\.)*`,
-        'gi',
-      ),
+      /(["'](?:[a-z0-9_-]*?(?:token|password|passwd|secret|api[_-]?key|access[_-]?key|samlrequest|relaystate|authorization|cookie|set-cookie)[a-z0-9_-]*)["']\s*:\s*["'])(?:[^"'\\]|\\.)*/gi,
       '$1[REDACTED]',
     )
     .replace(
-      new RegExp(
-        String.raw`(<(?:${SENSITIVE_KEY_FRAGMENT})\b[^>]*>)[\s\S]*?(<\/[^>]+>)`,
-        'gi',
-      ),
+      /(<(?:token|password|passwd|secret|api[_-]?key|access[_-]?key|samlrequest|relaystate|authorization|cookie|set-cookie)\b[^>]*>)[\s\S]*?(<\/[^>]+>)/gi,
       '$1[REDACTED]$2',
     )
     .replace(
-      new RegExp(
-        String.raw`(<\w+\b[^>]*\bkey=["'](?:[a-z0-9_-]*?(?:${SENSITIVE_KEY_FRAGMENT})[a-z0-9_-]*)["'][^>]*>)[\s\S]*?(<\/[^>]+>)`,
-        'gi',
-      ),
+      /(<\w+\b[^>]*\bkey=["'](?:[a-z0-9_-]*?(?:token|password|passwd|secret|api[_-]?key|access[_-]?key|samlrequest|relaystate|authorization|cookie|set-cookie)[a-z0-9_-]*)["'][^>]*>)[\s\S]*?(<\/[^>]+>)/gi,
       '$1[REDACTED]$2',
     )
     .replace(
-      new RegExp(
-        String.raw`([?&](?:[a-z0-9_-]*?(?:${SENSITIVE_KEY_FRAGMENT})[a-z0-9_-]*)=)[^&\s]*`,
-        'gi',
-      ),
+      /([?&](?:[a-z0-9_-]*?(?:token|password|passwd|secret|api[_-]?key|access[_-]?key|samlrequest|relaystate|authorization|cookie|set-cookie)[a-z0-9_-]*)=)[^&\s]*/gi,
       '$1[REDACTED]',
     );
 }

--- a/packages/adt-cli/src/lib/commands/fetch.ts
+++ b/packages/adt-cli/src/lib/commands/fetch.ts
@@ -25,28 +25,28 @@ function redactDiagnostic(value: string): string {
     .replace(/(?:set-)?cookie:\s*[^\r\n]*/gi, 'Cookie: [REDACTED]')
     .replace(
       new RegExp(
-        `(["'](?:[a-z0-9_-]*?(?:${SENSITIVE_KEY_FRAGMENT})[a-z0-9_-]*)["']\\s*:\\s*["'])[^"']*`,
+        String.raw`(["'](?:[a-z0-9_-]*?(?:${SENSITIVE_KEY_FRAGMENT})[a-z0-9_-]*)["']\s*:\s*["'])(?:[^"'\\]|\\.)*`,
         'gi',
       ),
       '$1[REDACTED]',
     )
     .replace(
       new RegExp(
-        `(<(?:${SENSITIVE_KEY_FRAGMENT})\\b[^>]*>)[\\s\\S]*?(<\\/[^>]+>)`,
+        String.raw`(<(?:${SENSITIVE_KEY_FRAGMENT})\b[^>]*>)[\s\S]*?(<\/[^>]+>)`,
         'gi',
       ),
       '$1[REDACTED]$2',
     )
     .replace(
       new RegExp(
-        `(<\\w+\\b[^>]*\\bkey=["'](?:[a-z0-9_-]*?(?:${SENSITIVE_KEY_FRAGMENT})[a-z0-9_-]*)["'][^>]*>)[\\s\\S]*?(<\\/[^>]+>)`,
+        String.raw`(<\w+\b[^>]*\bkey=["'](?:[a-z0-9_-]*?(?:${SENSITIVE_KEY_FRAGMENT})[a-z0-9_-]*)["'][^>]*>)[\s\S]*?(<\/[^>]+>)`,
         'gi',
       ),
       '$1[REDACTED]$2',
     )
     .replace(
       new RegExp(
-        `([?&](?:[a-z0-9_-]*?(?:${SENSITIVE_KEY_FRAGMENT})[a-z0-9_-]*)=)[^&\\s]*`,
+        String.raw`([?&](?:[a-z0-9_-]*?(?:${SENSITIVE_KEY_FRAGMENT})[a-z0-9_-]*)=)[^&\s]*`,
         'gi',
       ),
       '$1[REDACTED]',

--- a/packages/adt-cli/src/lib/commands/fetch.ts
+++ b/packages/adt-cli/src/lib/commands/fetch.ts
@@ -2,6 +2,84 @@ import { Command } from 'commander';
 import { writeFileSync } from 'node:fs';
 import { getAdtClientV2 } from '../utils/adt-client-v2';
 
+const MAX_RESPONSE_DIAGNOSTIC_CHARS = 4_000;
+
+type FetchFailure = Error & {
+  code?: unknown;
+  status?: unknown;
+  statusText?: unknown;
+  rawBody?: unknown;
+  cause?: unknown;
+};
+
+function redactDiagnostic(value: string): string {
+  return value
+    .replace(
+      /((?:proxy-)?authorization:\s*(?:bearer|basic)?\s*)\S+/gi,
+      '$1[REDACTED]',
+    )
+    .replace(/(?:set-)?cookie:\s*[^\r\n]*/gi, 'Cookie: [REDACTED]')
+    .replace(
+      /(["'](?:[a-z0-9_-]*?(?:token|password|passwd|secret|api[_-]?key|access[_-]?key|samlrequest|relaystate)[a-z0-9_-]*)["']\s*:\s*["'])[^"']*/gi,
+      '$1[REDACTED]',
+    )
+    .replace(
+      /(<(?:token|password|passwd|secret|api[_-]?key|access[_-]?key|samlrequest|relaystate)\b[^>]*>)[\s\S]*?(<\/[^>]+>)/gi,
+      '$1[REDACTED]$2',
+    )
+    .replace(
+      /([?&](?:[a-z0-9_-]*?(?:token|password|passwd|secret|api[_-]?key|access[_-]?key|samlrequest|relaystate)[a-z0-9_-]*)=[^&\s]*)/gi,
+      (match) => `${match.slice(0, match.indexOf('=') + 1)}[REDACTED]`,
+    );
+}
+
+function describeCause(cause: unknown): string | undefined {
+  if (!(cause instanceof Error)) return undefined;
+  const code = 'code' in cause ? (cause as { code?: unknown }).code : undefined;
+  const message = redactDiagnostic(cause.message);
+  return code ? `${message} (${String(code)})` : message;
+}
+
+/**
+ * Formats a fetch failure without exposing credentials or unbounded response data.
+ * A missing HTTP response is meaningful: it distinguishes a network/proxy/TLS
+ * failure from a server-side HTTP failure.
+ */
+export function formatFetchFailure(error: unknown): string[] {
+  const failure = error instanceof Error ? (error as FetchFailure) : undefined;
+  const message = redactDiagnostic(failure?.message ?? String(error));
+  const lines = [`❌ Request failed: ${message}`];
+
+  if (typeof failure?.status === 'number') {
+    const statusText =
+      typeof failure.statusText === 'string' ? ` ${failure.statusText}` : '';
+    lines.push(`   HTTP status: ${failure.status}${statusText}`);
+  } else {
+    lines.push(
+      '   HTTP response: none received (connection failed before a server response)',
+    );
+  }
+
+  if (typeof failure?.rawBody === 'string' && failure.rawBody.length > 0) {
+    const body = redactDiagnostic(failure.rawBody).slice(
+      0,
+      MAX_RESPONSE_DIAGNOSTIC_CHARS,
+    );
+    const suffix =
+      failure.rawBody.length > MAX_RESPONSE_DIAGNOSTIC_CHARS
+        ? '… [truncated]'
+        : '';
+    lines.push(
+      `   Response body (sanitized, max ${MAX_RESPONSE_DIAGNOSTIC_CHARS} chars): ${body}${suffix}`,
+    );
+  }
+
+  const cause = describeCause(failure?.cause);
+  if (cause) lines.push(`   Transport cause: ${cause}`);
+
+  return lines;
+}
+
 export const fetchCommand = new Command('fetch')
   .description('Fetch a URL with authentication (like curl but authenticated)')
   .argument('<url>', 'URL path to fetch (e.g., /sap/bc/adt/core/http/sessions)')
@@ -40,11 +118,7 @@ export const fetchCommand = new Command('fetch')
       }
 
       const method = options.method.toUpperCase() as
-        | 'GET'
-        | 'POST'
-        | 'PUT'
-        | 'PATCH'
-        | 'DELETE';
+        'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
       console.log(`🔄 ${method} ${url}...\n`);
 
@@ -74,10 +148,7 @@ export const fetchCommand = new Command('fetch')
 
       console.log('\n✅ Done!');
     } catch (error) {
-      console.error(
-        '❌ Request failed:',
-        error instanceof Error ? error.message : String(error),
-      );
+      for (const line of formatFetchFailure(error)) console.error(line);
       if (error instanceof Error && error.stack) {
         console.error('\nStack trace:', error.stack);
       }

--- a/packages/adt-cli/src/lib/commands/fetch.ts
+++ b/packages/adt-cli/src/lib/commands/fetch.ts
@@ -12,31 +12,51 @@ type FetchFailure = Error & {
   cause?: unknown;
 };
 
+// Sensitive JSON/XML/query key fragments shared across redaction patterns.
+const SENSITIVE_KEY_FRAGMENT =
+  'token|password|passwd|secret|api[_-]?key|access[_-]?key|samlrequest|relaystate|authorization|cookie|set-cookie';
+
 function redactDiagnostic(value: string): string {
   return value
     .replace(
-      /((?:proxy-)?authorization:\s*(?:bearer|basic)?\s*)\S+/gi,
+      /((?:(?:proxy-)?authorization|x-api-key|x-apikey|api-key|x-auth-token):\s*)[^\r\n]*/gi,
       '$1[REDACTED]',
     )
     .replace(/(?:set-)?cookie:\s*[^\r\n]*/gi, 'Cookie: [REDACTED]')
     .replace(
-      /(["'](?:[a-z0-9_-]*?(?:token|password|passwd|secret|api[_-]?key|access[_-]?key|samlrequest|relaystate)[a-z0-9_-]*)["']\s*:\s*["'])[^"']*/gi,
+      new RegExp(
+        `(["'](?:[a-z0-9_-]*?(?:${SENSITIVE_KEY_FRAGMENT})[a-z0-9_-]*)["']\\s*:\\s*["'])[^"']*`,
+        'gi',
+      ),
       '$1[REDACTED]',
     )
     .replace(
-      /(<(?:token|password|passwd|secret|api[_-]?key|access[_-]?key|samlrequest|relaystate)\b[^>]*>)[\s\S]*?(<\/[^>]+>)/gi,
+      new RegExp(
+        `(<(?:${SENSITIVE_KEY_FRAGMENT})\\b[^>]*>)[\\s\\S]*?(<\\/[^>]+>)`,
+        'gi',
+      ),
       '$1[REDACTED]$2',
     )
     .replace(
-      /([?&](?:[a-z0-9_-]*?(?:token|password|passwd|secret|api[_-]?key|access[_-]?key|samlrequest|relaystate)[a-z0-9_-]*)=[^&\s]*)/gi,
-      (match) => `${match.slice(0, match.indexOf('=') + 1)}[REDACTED]`,
+      new RegExp(
+        `(<\\w+\\b[^>]*\\bkey=["'](?:[a-z0-9_-]*?(?:${SENSITIVE_KEY_FRAGMENT})[a-z0-9_-]*)["'][^>]*>)[\\s\\S]*?(<\\/[^>]+>)`,
+        'gi',
+      ),
+      '$1[REDACTED]$2',
+    )
+    .replace(
+      new RegExp(
+        `([?&](?:[a-z0-9_-]*?(?:${SENSITIVE_KEY_FRAGMENT})[a-z0-9_-]*)=)[^&\\s]*`,
+        'gi',
+      ),
+      '$1[REDACTED]',
     );
 }
 
 function describeCause(cause: unknown): string | undefined {
   if (!(cause instanceof Error)) return undefined;
   const code = 'code' in cause ? (cause as { code?: unknown }).code : undefined;
-  const message = redactDiagnostic(cause.message);
+  const message = redactDiagnostic(cause.message ?? '');
   return code ? `${message} (${String(code)})` : message;
 }
 
@@ -52,7 +72,9 @@ export function formatFetchFailure(error: unknown): string[] {
 
   if (typeof failure?.status === 'number') {
     const statusText =
-      typeof failure.statusText === 'string' ? ` ${failure.statusText}` : '';
+      typeof failure.statusText === 'string'
+        ? ` ${redactDiagnostic(failure.statusText)}`
+        : '';
     lines.push(`   HTTP status: ${failure.status}${statusText}`);
   } else {
     lines.push(
@@ -61,14 +83,12 @@ export function formatFetchFailure(error: unknown): string[] {
   }
 
   if (typeof failure?.rawBody === 'string' && failure.rawBody.length > 0) {
-    const body = redactDiagnostic(failure.rawBody).slice(
-      0,
-      MAX_RESPONSE_DIAGNOSTIC_CHARS,
-    );
+    const sanitized = redactDiagnostic(failure.rawBody);
+    // Slice by code points to avoid splitting surrogate pairs (invalid UTF-8).
+    const codePoints = Array.from(sanitized);
+    const body = codePoints.slice(0, MAX_RESPONSE_DIAGNOSTIC_CHARS).join('');
     const suffix =
-      failure.rawBody.length > MAX_RESPONSE_DIAGNOSTIC_CHARS
-        ? '… [truncated]'
-        : '';
+      codePoints.length > MAX_RESPONSE_DIAGNOSTIC_CHARS ? '… [truncated]' : '';
     lines.push(
       `   Response body (sanitized, max ${MAX_RESPONSE_DIAGNOSTIC_CHARS} chars): ${body}${suffix}`,
     );
@@ -150,7 +170,7 @@ export const fetchCommand = new Command('fetch')
     } catch (error) {
       for (const line of formatFetchFailure(error)) console.error(line);
       if (error instanceof Error && error.stack) {
-        console.error('\nStack trace:', error.stack);
+        console.error('\nStack trace:', redactDiagnostic(error.stack));
       }
       process.exit(1);
     }


### PR DESCRIPTION
## **User description**
## What changed

The adt fetch command now prints safe, actionable diagnostics to stderr when a request fails:

- HTTP status and a response-body excerpt (maximum 4 KiB) when a server replied.
- HTTP response: none received plus the nested Node transport cause, such as ECONNRESET, when a connection failed before HTTP.
- Sensitive values in headers, cookies, JSON/XML fields, query strings and error messages are redacted.

## Why

Consumers previously saw only TypeError: fetch failed, which cannot distinguish firewall, proxy, or TLS resets from an HTTP response.

## Verification

- Targeted fetch diagnostics unit test passed.
- adt-cli build passed.
- adt-cli lint passed.
- Prettier check and git diff --check passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes safe, actionable diagnostics for failed `adt-cli` fetches so users can distinguish HTTP errors from transport issues without leaking secrets. Previously: a generic “TypeError: fetch failed.” Now: structured, redacted error output with bounded response excerpts and sanitized stacks.

- Prints HTTP status and sanitized statusText; if no response, reports “HTTP response: none received” and includes the redacted transport cause and code.
- Shows a sanitized response-body excerpt up to 4,000 characters, truncated on code‑point boundaries to avoid broken surrogates.
- Redacts credentials in headers (all `Authorization` schemes incl. Digest params, `Proxy-Authorization`, `X-Api-Key`, `X-Auth-Token`), cookies; sensitive JSON keys with escape‑aware value matching; ADT XML contents and `<entry key="...">`; query strings; statusText; error messages and stack traces.
- Centralizes formatting in `formatFetchFailure`; adds tests for HTTP vs transport cases, redaction (incl. escaped‑quote JSON and Digest params), and safe truncation. Switches to regex literals to satisfy Codacy’s non‑literal‑RegExp rule (no behavior change). Successful requests are unchanged.

<sup>Written for commit 5d5018b41c502b493345e54f25bb54a7ad8f01b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Expose safe, actionable diagnostics when `adt fetch` requests fail

### What Changed
- Failed requests now show whether a server returned an HTTP response or the connection failed before a response.
- HTTP failures include the status, status text, and a response-body excerpt capped at 4,000 characters.
- Network failures include the underlying transport message and error code when available.
- Credentials and other sensitive values are removed from error messages, response bodies, URLs, headers, and cookies.
- Added coverage for sanitized HTTP errors and connection failures.

### Impact
`✅ Clearer firewall, proxy, and TLS failure diagnosis`
`✅ Safer request error output`
`✅ Bounded error details`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fetch error messages with clearer HTTP status and connection failure details.
  * Sanitized sensitive information and limited response content shown in diagnostics.
  * Preserved stack traces and existing command exit behavior for troubleshooting.
  * Ensured truncated response text safely handles Unicode characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->