### PR TITLE
fix(aunit): preserve coverage measurement links

### DIFF
--- a/packages/adt-contracts/tests/contracts/aunit.test.ts
+++ b/packages/adt-contracts/tests/contracts/aunit.test.ts
@@ -9,11 +9,13 @@
  */
 
 import { fixtures } from '@abapify/adt-fixtures';
+import { expect, it } from 'vitest';
 import { aunitRun, aunitResult } from '../../src/schemas';
 import { ContractScenario, runScenario, type ContractOperation } from './base';
 
 // Import contracts
 import { aunitContract } from '../../src/adt/aunit';
+import { extractCoverageMeasurementId } from '../../src/adt/aunit/coverage-link';
 
 // =============================================================================
 // Contract Definition Tests
@@ -51,3 +53,12 @@ class AunitTestrunsScenario extends ContractScenario {
 // =============================================================================
 
 runScenario(new AunitTestrunsScenario());
+
+it('preserves the Atom coverage measurement link from an AUnit result', async () => {
+  const xml = await fixtures.aunit.runResultCoverageLink.load();
+  const parsed = aunitResult.parse(xml);
+
+  expect(extractCoverageMeasurementId(parsed)).toBe(
+    '6D664D9B46CB1FE1859107ADE8729541',
+  );
+});

--- a/packages/adt-contracts/tests/contracts/aunit.test.ts
+++ b/packages/adt-contracts/tests/contracts/aunit.test.ts
@@ -9,13 +9,11 @@
  */
 
 import { fixtures } from '@abapify/adt-fixtures';
-import { expect, it } from 'vitest';
 import { aunitRun, aunitResult } from '../../src/schemas';
 import { ContractScenario, runScenario, type ContractOperation } from './base';
 
 // Import contracts
 import { aunitContract } from '../../src/adt/aunit';
-import { extractCoverageMeasurementId } from '../../src/adt/aunit/coverage-link';
 
 // =============================================================================
 // Contract Definition Tests
@@ -53,12 +51,3 @@ class AunitTestrunsScenario extends ContractScenario {
 // =============================================================================
 
 runScenario(new AunitTestrunsScenario());
-
-it('preserves the Atom coverage measurement link from an AUnit result', async () => {
-  const xml = await fixtures.aunit.runResultCoverageLink.load();
-  const parsed = aunitResult.parse(xml);
-
-  expect(extractCoverageMeasurementId(parsed)).toBe(
-    '6D664D9B46CB1FE1859107ADE8729541',
-  );
-});

--- a/packages/adt-contracts/tests/contracts/coverage.test.ts
+++ b/packages/adt-contracts/tests/contracts/coverage.test.ts
@@ -12,11 +12,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { fixtures } from '@abapify/adt-fixtures';
-import {
-  acoverageResult,
-  acoverageStatements,
-  aunitResult,
-} from '../../src/schemas';
+import { acoverageResult, acoverageStatements } from '../../src/schemas';
 import {
   coverageContract,
   measurements,
@@ -24,7 +20,6 @@ import {
 } from '../../src/adt/runtime/traces/coverage';
 import { ContractScenario, runScenario, type ContractOperation } from './base';
 import { TypedContractScenario, runTypedScenario } from './base/typed-scenario';
-import { extractCoverageMeasurementId } from '../../src/adt/aunit/coverage-link';
 
 const SCOV_CONTENT_TYPE = 'application/xml+scov';
 
@@ -144,56 +139,3 @@ class StatementsTypedScenario extends TypedContractScenario<
 }
 
 runTypedScenario(new StatementsTypedScenario());
-
-// ─────────────────────────────────────────────────────────────
-// 4. Coverage link helper
-// ─────────────────────────────────────────────────────────────
-
-describe('extractCoverageMeasurementId', () => {
-  it('returns undefined when no coverage link is present', () => {
-    expect(extractCoverageMeasurementId({})).toBeUndefined();
-    expect(extractCoverageMeasurementId(null)).toBeUndefined();
-  });
-
-  it('finds the measurement id from a flat link array', () => {
-    // Atom link `rel` is an opaque relation-type URI per RFC 5988, not a
-    // network URL. Must match SAP wire format byte-for-byte.
-    const rel =
-      'http://www.sap.com/adt/relations/runtime/traces/coverage/measurements/coveredobjects'; // NOSONAR: link-relation identifier (not a URL)
-    const id = extractCoverageMeasurementId({
-      link: [
-        {
-          href: '/sap/bc/adt/runtime/traces/coverage/measurements/6D664D9B46CB1FE1859107ADE8729541/coveredobjects',
-          rel,
-        },
-      ],
-    });
-    expect(id).toBe('6D664D9B46CB1FE1859107ADE8729541');
-  });
-
-  it('finds the measurement id by walking nested nodes', () => {
-    const id = extractCoverageMeasurementId({
-      program: {
-        testClasses: {
-          testClass: {
-            link: [
-              {
-                href: '/sap/bc/adt/runtime/traces/coverage/measurements/ABCDEF012345/statements',
-              },
-            ],
-          },
-        },
-      },
-    });
-    expect(id).toBe('ABCDEF012345');
-  });
-
-  it('preserves the Atom coverage measurement link from an AUnit result', async () => {
-    const xml = await fixtures.aunit.runResultCoverageLink.load();
-    const parsed = aunitResult.parse(xml);
-
-    expect(extractCoverageMeasurementId(parsed)).toBe(
-      '6D664D9B46CB1FE1859107ADE8729541',
-    );
-  });
-});

--- a/packages/adt-contracts/tests/contracts/coverage.test.ts
+++ b/packages/adt-contracts/tests/contracts/coverage.test.ts
@@ -12,7 +12,11 @@
 
 import { describe, it, expect } from 'vitest';
 import { fixtures } from '@abapify/adt-fixtures';
-import { acoverageResult, acoverageStatements } from '../../src/schemas';
+import {
+  acoverageResult,
+  acoverageStatements,
+  aunitResult,
+} from '../../src/schemas';
 import {
   coverageContract,
   measurements,
@@ -182,5 +186,14 @@ describe('extractCoverageMeasurementId', () => {
       },
     });
     expect(id).toBe('ABCDEF012345');
+  });
+
+  it('preserves the Atom coverage measurement link from an AUnit result', async () => {
+    const xml = await fixtures.aunit.runResultCoverageLink.load();
+    const parsed = aunitResult.parse(xml);
+
+    expect(extractCoverageMeasurementId(parsed)).toBe(
+      '6D664D9B46CB1FE1859107ADE8729541',
+    );
   });
 });

--- a/packages/adt-contracts/tests/coverage-link.test.ts
+++ b/packages/adt-contracts/tests/coverage-link.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for the coverage-link helper.
+ *
+ * These are parser-only assertions (no HTTP contract), so they live
+ * outside tests/contracts/ which is reserved for ContractScenario /
+ * ContractOperation definitions.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { fixtures } from '@abapify/adt-fixtures';
+import { aunitResult } from '../src/schemas';
+import { extractCoverageMeasurementId } from '../src/adt/aunit/coverage-link';
+
+describe('extractCoverageMeasurementId', () => {
+  it('returns undefined when no coverage link is present', () => {
+    expect(extractCoverageMeasurementId({})).toBeUndefined();
+    expect(extractCoverageMeasurementId(null)).toBeUndefined();
+  });
+
+  it('finds the measurement id from a flat link array', () => {
+    // Atom link `rel` is an opaque relation-type URI per RFC 5988, not a
+    // network URL. Must match SAP wire format byte-for-byte.
+    const rel =
+      'http://www.sap.com/adt/relations/runtime/traces/coverage/measurements/coveredobjects'; // NOSONAR: link-relation identifier (not a URL)
+    const id = extractCoverageMeasurementId({
+      link: [
+        {
+          href: '/sap/bc/adt/runtime/traces/coverage/measurements/6D664D9B46CB1FE1859107ADE8729541/coveredobjects',
+          rel,
+        },
+      ],
+    });
+    expect(id).toBe('6D664D9B46CB1FE1859107ADE8729541');
+  });
+
+  it('finds the measurement id by walking nested nodes', () => {
+    const id = extractCoverageMeasurementId({
+      program: {
+        testClasses: {
+          testClass: {
+            link: [
+              {
+                href: '/sap/bc/adt/runtime/traces/coverage/measurements/ABCDEF012345/statements',
+              },
+            ],
+          },
+        },
+      },
+    });
+    expect(id).toBe('ABCDEF012345');
+  });
+
+  it('preserves the Atom coverage measurement link from an AUnit result', async () => {
+    const xml = await fixtures.aunit.runResultCoverageLink.load();
+    const parsed = aunitResult.parse(xml);
+
+    expect(extractCoverageMeasurementId(parsed)).toBe(
+      '6D664D9B46CB1FE1859107ADE8729541',
+    );
+  });
+});

--- a/packages/adt-fixtures/src/fixtures/aunit/run-result-coverage-link.xml
+++ b/packages/adt-fixtures/src/fixtures/aunit/run-result-coverage-link.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aunit:runResult xmlns:aunit="http://www.sap.com/adt/aunit" xmlns:atom="http://www.w3.org/2005/Atom">
+  <atom:link href="/sap/bc/adt/runtime/traces/coverage/measurements/6D664D9B46CB1FE1859107ADE8729541" rel="http://www.sap.com/adt/relations/runtime/traces/coverage/measurements"/>
+</aunit:runResult>

--- a/packages/adt-fixtures/src/fixtures/registry.ts
+++ b/packages/adt-fixtures/src/fixtures/registry.ts
@@ -26,6 +26,7 @@ export const registry = {
   aunit: {
     runRequest: 'aunit/run-request.xml',
     runResult: 'aunit/run-result.xml',
+    runResultCoverageLink: 'aunit/run-result-coverage-link.xml',
     // Sourced from jfilak/sapcli test fixtures (fixtures_adt_acoverage /
     // fixtures_adt_coverage). Real sanitized SAP responses for the
     // /runtime/traces/coverage endpoints.

--- a/packages/adt-schemas/.xsd/custom/aunitResult.xsd
+++ b/packages/adt-schemas/.xsd/custom/aunitResult.xsd
@@ -33,9 +33,12 @@
 -->
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
     xmlns:aunit="http://www.sap.com/adt/aunit"
+    xmlns:atom="http://www.w3.org/2005/Atom"
     targetNamespace="http://www.sap.com/adt/aunit"
     elementFormDefault="qualified"
     attributeFormDefault="unqualified">
+
+  <xsd:import namespace="http://www.w3.org/2005/Atom" schemaLocation="../sap/atom.xsd"/>
 
   <!-- Root element -->
   <xsd:element name="runResult" type="aunit:AunitRunResult"/>
@@ -43,6 +46,7 @@
   <!-- Run Result -->
   <xsd:complexType name="AunitRunResult">
     <xsd:sequence>
+      <xsd:element ref="atom:link" minOccurs="0" maxOccurs="unbounded"/>
       <xsd:element name="program" type="aunit:AunitProgram" minOccurs="0" maxOccurs="unbounded" form="unqualified"/>
     </xsd:sequence>
   </xsd:complexType>

--- a/packages/adt-schemas/src/schemas/generated/schemas/custom/aunitResult.ts
+++ b/packages/adt-schemas/src/schemas/generated/schemas/custom/aunitResult.ts
@@ -5,11 +5,17 @@
  * Source: xsd/custom/aunitResult.xsd
  */
 
+import atom from '../sap/atom';
+
 export default {
   $xmlns: {
     xsd: 'http://www.w3.org/2001/XMLSchema',
     aunit: 'http://www.sap.com/adt/aunit',
+    atom: 'http://www.w3.org/2005/Atom',
   },
+  $imports: [
+    atom,
+  ],
   targetNamespace: 'http://www.sap.com/adt/aunit',
   attributeFormDefault: 'unqualified',
   elementFormDefault: 'qualified',
@@ -24,6 +30,11 @@ export default {
       name: 'AunitRunResult',
       sequence: {
         element: [
+          {
+            ref: 'atom:link',
+            minOccurs: '0',
+            maxOccurs: 'unbounded',
+          },
           {
             name: 'program',
             type: 'aunit:AunitProgram',

--- a/packages/adt-schemas/src/schemas/generated/types/custom/aunitResult.types.ts
+++ b/packages/adt-schemas/src/schemas/generated/types/custom/aunitResult.types.ts
@@ -7,6 +7,16 @@
 
 export type AunitResultSchema = {
     runResult: {
+        link?: undefined | {
+            href: string;
+            rel?: string | undefined;
+            type?: string | undefined;
+            hreflang?: string | undefined;
+            title?: string | undefined;
+            length?: number | undefined;
+            etag?: string | undefined;
+            _text?: string | undefined;
+        }[];
         program?: undefined | {
             testClasses?: undefined | {
                 testClass?: undefined | {


### PR DESCRIPTION
## **User description**
----
## Summary by Gitar

- **Schemas:**
    - Added `atom:link` support to `aunitResult.xsd` to preserve coverage measurement links
- **Fixtures & Tests:**
    - Added test fixture and contract test verifying coverage measurement link extraction

<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves AUnit coverage measurement links by modeling `atom:link` on `runResult`. Previously these links were dropped during parse; now they are retained for navigation and ID extraction with no other behavior changes.

- Import Atom in `aunitResult.xsd` and allow `atom:link` on `runResult`; regenerate schemas/types in `packages/adt-schemas` to expose optional `runResult.link[]`.
- Add `aunit/run-result-coverage-link.xml` fixture and registry entry in `packages/adt-fixtures`.
- Move parser-only `extractCoverageMeasurementId` tests from `packages/adt-contracts/tests/contracts/coverage.test.ts` to `packages/adt-contracts/tests/coverage-link.test.ts`, adding a fixture-based parse assertion.
- No migration required; consumers may read `parsed.runResult.link` or call `extractCoverageMeasurementId(parsed)`.

<sup>Written for commit f7d4d8a79a7abcfee694b1be985244a4a4035302. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/abapify/adt-cli/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Preserve coverage measurement links in AUnit test results

### What Changed
- AUnit results now retain Atom links to coverage measurement data
- Coverage measurement IDs can be extracted from parsed AUnit responses
- Added a fixture and contract test covering results that include a coverage link

### Impact
`✅ Coverage results remain accessible after parsing`
`✅ Reliable coverage measurement lookup`
`✅ Regression protection for linked AUnit responses`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * AUnit run results can now include coverage-measurement links.
  * Coverage information is correctly recognized when provided through these links.

* **Tests**
  * Added coverage validation for AUnit results containing coverage-measurement links.
  * Added fixture data to verify parsing and measurement ID extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->